### PR TITLE
fix(db): migrate system DB schema from filename to path column

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,8 @@
     "sql:allow-close",
     "fs:default",
     "fs:allow-remove",
+    "fs:allow-rename",
+    "fs:allow-exists",
     "fs:allow-write-text-file",
     {
       "identifier": "fs:scope",

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -381,50 +381,55 @@ async function migrateSystemDbFilenameToPath(db: Database): Promise<void> {
   for (const tree of trees) {
     if (tree.path.startsWith(treesDir + '/')) continue;
 
-    // Determine the slug from the old value
-    let slug: string;
-    if (tree.path.endsWith('.db')) {
-      // Bare filename: "harry-potter-demo.db" → "harry-potter-demo"
-      slug = tree.path.replace(/\.db$/, '');
-    } else {
-      // Bad path from previous migration: extract last segment
-      slug = tree.path.split('/').pop() ?? tree.path;
-    }
-
-    const newPath = await getTreePathForSlug(slug);
-    const oldFilename = `${slug}.db`;
-    const newFile = `${newPath}/${oldFilename}`;
-
-    // The real .db file may live in one of two places depending on the bug:
-    //  - ${treesDir}/${slug}.db         : bare-filename case (very old schema)
-    //  - ${tree.path}/${slug}.db        : macOS bad-separator case, where
-    //                                     tree.path is a malformed directory
-    //                                     like "...vatatrees/${slug}"
-    const candidateSources = [
-      `${treesDir}/${oldFilename}`,
-      tree.path.endsWith('.db') ? null : `${tree.path}/${oldFilename}`,
-    ].filter((p): p is string => p !== null && p !== newFile);
-
-    // Create the subdirectory. If this fails (permissions, disk full), skip
-    // this tree — don't update the DB path to point to a nonexistent dir.
-    await mkdir(newPath, { recursive: true });
-
-    // Move the .db file from whichever old location still contains it.
-    for (const sourceFile of candidateSources) {
-      if (await exists(sourceFile)) {
-        await rename(sourceFile, newFile);
-        // WAL/SHM sidecar files may not exist — only move when present.
-        if (await exists(`${sourceFile}-wal`)) {
-          await rename(`${sourceFile}-wal`, `${newFile}-wal`);
-        }
-        if (await exists(`${sourceFile}-shm`)) {
-          await rename(`${sourceFile}-shm`, `${newFile}-shm`);
-        }
-        break;
+    try {
+      // Determine the slug from the old value
+      let slug: string;
+      if (tree.path.endsWith('.db')) {
+        // Bare filename: "harry-potter-demo.db" → "harry-potter-demo"
+        slug = tree.path.replace(/\.db$/, '');
+      } else {
+        // Bad path from previous migration: extract last segment
+        slug = tree.path.split('/').pop() ?? tree.path;
       }
-    }
 
-    await db.execute('UPDATE trees SET path = $1 WHERE id = $2', [newPath, tree.id]);
+      const newPath = await getTreePathForSlug(slug);
+      const oldFilename = `${slug}.db`;
+      const newFile = `${newPath}/${oldFilename}`;
+
+      // The real .db file may live in one of two places depending on the bug:
+      //  - ${treesDir}/${slug}.db         : bare-filename case (very old schema)
+      //  - ${tree.path}/${slug}.db        : macOS bad-separator case, where
+      //                                     tree.path is a malformed directory
+      //                                     like "...vatatrees/${slug}"
+      const candidateSources = [
+        `${treesDir}/${oldFilename}`,
+        tree.path.endsWith('.db') ? null : `${tree.path}/${oldFilename}`,
+      ].filter((p): p is string => p !== null && p !== newFile);
+
+      // Create the subdirectory. If this fails (permissions, disk full), skip
+      // this tree — don't update the DB path to point to a nonexistent dir.
+      await mkdir(newPath, { recursive: true });
+
+      // Move the .db file from whichever old location still contains it.
+      for (const sourceFile of candidateSources) {
+        if (await exists(sourceFile)) {
+          await rename(sourceFile, newFile);
+          // WAL/SHM sidecar files may not exist — only move when present.
+          if (await exists(`${sourceFile}-wal`)) {
+            await rename(`${sourceFile}-wal`, `${newFile}-wal`);
+          }
+          if (await exists(`${sourceFile}-shm`)) {
+            await rename(`${sourceFile}-shm`, `${newFile}-shm`);
+          }
+          break;
+        }
+      }
+
+      await db.execute('UPDATE trees SET path = $1 WHERE id = $2', [newPath, tree.id]);
+    } catch (err) {
+      console.error(`Failed to migrate tree id=${tree.id} path="${tree.path}":`, err);
+      continue;
+    }
   }
 }
 

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -5,6 +5,7 @@ import { getTreePathForSlug } from '$lib/tree-paths';
 import { seedHarryPotterDemo } from './seed/harry-potter-demo';
 
 let systemDb: Database | null = null;
+let systemDbInitPromise: Promise<Database> | null = null;
 let treeDb: Database | null = null;
 let currentTreePath: string | null = null;
 
@@ -392,22 +393,34 @@ async function migrateSystemDbFilenameToPath(db: Database): Promise<void> {
 
     const newPath = await getTreePathForSlug(slug);
     const oldFilename = `${slug}.db`;
-    const flatFile = `${treesDir}/${oldFilename}`;
     const newFile = `${newPath}/${oldFilename}`;
+
+    // The real .db file may live in one of two places depending on the bug:
+    //  - ${treesDir}/${slug}.db         : bare-filename case (very old schema)
+    //  - ${tree.path}/${slug}.db        : macOS bad-separator case, where
+    //                                     tree.path is a malformed directory
+    //                                     like "...vatatrees/${slug}"
+    const candidateSources = [
+      `${treesDir}/${oldFilename}`,
+      tree.path.endsWith('.db') ? null : `${tree.path}/${oldFilename}`,
+    ].filter((p): p is string => p !== null && p !== newFile);
 
     // Create the subdirectory. If this fails (permissions, disk full), skip
     // this tree — don't update the DB path to point to a nonexistent dir.
     await mkdir(newPath, { recursive: true });
 
-    // Move the flat .db file into the subdirectory if it still exists.
-    if (await exists(flatFile)) {
-      await rename(flatFile, newFile);
-      // WAL/SHM sidecar files may not exist — only move when present.
-      if (await exists(`${flatFile}-wal`)) {
-        await rename(`${flatFile}-wal`, `${newFile}-wal`);
-      }
-      if (await exists(`${flatFile}-shm`)) {
-        await rename(`${flatFile}-shm`, `${newFile}-shm`);
+    // Move the .db file from whichever old location still contains it.
+    for (const sourceFile of candidateSources) {
+      if (await exists(sourceFile)) {
+        await rename(sourceFile, newFile);
+        // WAL/SHM sidecar files may not exist — only move when present.
+        if (await exists(`${sourceFile}-wal`)) {
+          await rename(`${sourceFile}-wal`, `${newFile}-wal`);
+        }
+        if (await exists(`${sourceFile}-shm`)) {
+          await rename(`${sourceFile}-shm`, `${newFile}-shm`);
+        }
+        break;
       }
     }
 
@@ -444,14 +457,25 @@ async function initializeSystemDb(db: Database): Promise<void> {
 }
 
 export async function getSystemDb(): Promise<Database> {
-  if (!systemDb) {
-    systemDb = await Database.load('sqlite:system.db');
-    await applyConnectionPragmas(systemDb);
-    await initializeSystemDb(systemDb);
-    await migrateSystemDbFilenameToPath(systemDb);
-    await seedHarryPotterDemo(systemDb);
+  if (systemDb) return systemDb;
+
+  // Memoize the in-flight init promise so concurrent first-time callers all
+  // await the same load/migrate/seed sequence instead of racing it.
+  if (!systemDbInitPromise) {
+    systemDbInitPromise = (async () => {
+      const db = await Database.load('sqlite:system.db');
+      await applyConnectionPragmas(db);
+      await initializeSystemDb(db);
+      await migrateSystemDbFilenameToPath(db);
+      await seedHarryPotterDemo(db);
+      systemDb = db;
+      return db;
+    })().finally(() => {
+      systemDbInitPromise = null;
+    });
   }
-  return systemDb;
+
+  return systemDbInitPromise;
 }
 
 export async function openTreeDb(treePath: string): Promise<Database> {

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -472,8 +472,15 @@ export async function getSystemDb(): Promise<Database> {
       await applyConnectionPragmas(db);
       await initializeSystemDb(db);
       await migrateSystemDbFilenameToPath(db);
-      await seedHarryPotterDemo(db);
+      // Publish early so seedHarryPotterDemo → createTree → getSystemDb()
+      // returns the DB directly instead of re-entering systemDbInitPromise.
       systemDb = db;
+      try {
+        await seedHarryPotterDemo(db);
+      } catch (err) {
+        systemDb = null;
+        throw err;
+      }
       return db;
     })().finally(() => {
       systemDbInitPromise = null;

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -472,15 +472,8 @@ export async function getSystemDb(): Promise<Database> {
       await applyConnectionPragmas(db);
       await initializeSystemDb(db);
       await migrateSystemDbFilenameToPath(db);
-      // Publish early so seedHarryPotterDemo → createTree → getSystemDb()
-      // returns the DB directly instead of re-entering systemDbInitPromise.
+      await seedHarryPotterDemo(db);
       systemDb = db;
-      try {
-        await seedHarryPotterDemo(db);
-      } catch (err) {
-        systemDb = null;
-        throw err;
-      }
       return db;
     })().finally(() => {
       systemDbInitPromise = null;

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,6 +1,7 @@
 import Database from '@tauri-apps/plugin-sql';
 import { mkdir, rename, exists } from '@tauri-apps/plugin-fs';
 import { appDataDir } from '@tauri-apps/api/path';
+import { getTreePathForSlug } from '$lib/tree-paths';
 import { seedHarryPotterDemo } from './seed/harry-potter-demo';
 
 let systemDb: Database | null = null;
@@ -389,28 +390,25 @@ async function migrateSystemDbFilenameToPath(db: Database): Promise<void> {
       slug = tree.path.split('/').pop() ?? tree.path;
     }
 
-    const newPath = `${treesDir}/${slug}`;
+    const newPath = await getTreePathForSlug(slug);
     const oldFilename = `${slug}.db`;
     const flatFile = `${treesDir}/${oldFilename}`;
     const newFile = `${newPath}/${oldFilename}`;
 
-    try {
-      await mkdir(newPath, { recursive: true });
-      if (await exists(flatFile)) {
-        await rename(flatFile, newFile);
-        try {
-          await rename(`${flatFile}-wal`, `${newFile}-wal`);
-        } catch {
-          /* may not exist */
-        }
-        try {
-          await rename(`${flatFile}-shm`, `${newFile}-shm`);
-        } catch {
-          /* may not exist */
-        }
+    // Create the subdirectory. If this fails (permissions, disk full), skip
+    // this tree — don't update the DB path to point to a nonexistent dir.
+    await mkdir(newPath, { recursive: true });
+
+    // Move the flat .db file into the subdirectory if it still exists.
+    if (await exists(flatFile)) {
+      await rename(flatFile, newFile);
+      // WAL/SHM sidecar files may not exist — only move when present.
+      if (await exists(`${flatFile}-wal`)) {
+        await rename(`${flatFile}-wal`, `${newFile}-wal`);
       }
-    } catch {
-      /* directory/file already migrated */
+      if (await exists(`${flatFile}-shm`)) {
+        await rename(`${flatFile}-shm`, `${newFile}-shm`);
+      }
     }
 
     await db.execute('UPDATE trees SET path = $1 WHERE id = $2', [newPath, tree.id]);

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,5 +1,6 @@
 import Database from '@tauri-apps/plugin-sql';
-import { mkdir } from '@tauri-apps/plugin-fs';
+import { mkdir, rename, exists } from '@tauri-apps/plugin-fs';
+import { appDataDir } from '@tauri-apps/api/path';
 import { seedHarryPotterDemo } from './seed/harry-potter-demo';
 
 let systemDb: Database | null = null;
@@ -358,6 +359,64 @@ async function initializeTreeDb(db: Database): Promise<void> {
   await db.execute(`CREATE INDEX IF NOT EXISTS idx_source_files_file ON source_files(file_id)`);
 }
 
+async function migrateSystemDbFilenameToPath(db: Database): Promise<void> {
+  // Step 1: Rename column if still named 'filename'
+  const cols = await db.select<{ name: string }[]>(
+    "SELECT name FROM pragma_table_info('trees') WHERE name = 'filename'"
+  );
+  if (cols.length > 0) {
+    await db.execute('ALTER TABLE trees RENAME COLUMN filename TO path');
+  }
+
+  // Step 2: Migrate any paths that are bare filenames (e.g. "tree.db") or
+  // contain the wrong separator (e.g. "...genealogytrees/...")
+  const baseDir = await appDataDir();
+  const treesDir = `${baseDir}/trees`;
+  const trees = await db.select<{ id: number; path: string }[]>(
+    'SELECT id, path FROM trees'
+  );
+
+  for (const tree of trees) {
+    if (tree.path.startsWith(treesDir + '/')) continue;
+
+    // Determine the slug from the old value
+    let slug: string;
+    if (tree.path.endsWith('.db')) {
+      // Bare filename: "harry-potter-demo.db" → "harry-potter-demo"
+      slug = tree.path.replace(/\.db$/, '');
+    } else {
+      // Bad path from previous migration: extract last segment
+      slug = tree.path.split('/').pop() ?? tree.path;
+    }
+
+    const newPath = `${treesDir}/${slug}`;
+    const oldFilename = `${slug}.db`;
+    const flatFile = `${treesDir}/${oldFilename}`;
+    const newFile = `${newPath}/${oldFilename}`;
+
+    try {
+      await mkdir(newPath, { recursive: true });
+      if (await exists(flatFile)) {
+        await rename(flatFile, newFile);
+        try {
+          await rename(`${flatFile}-wal`, `${newFile}-wal`);
+        } catch {
+          /* may not exist */
+        }
+        try {
+          await rename(`${flatFile}-shm`, `${newFile}-shm`);
+        } catch {
+          /* may not exist */
+        }
+      }
+    } catch {
+      /* directory/file already migrated */
+    }
+
+    await db.execute('UPDATE trees SET path = $1 WHERE id = $2', [newPath, tree.id]);
+  }
+}
+
 async function initializeSystemDb(db: Database): Promise<void> {
   await db.execute(`
     CREATE TABLE IF NOT EXISTS trees (
@@ -391,6 +450,7 @@ export async function getSystemDb(): Promise<Database> {
     systemDb = await Database.load('sqlite:system.db');
     await applyConnectionPragmas(systemDb);
     await initializeSystemDb(systemDb);
+    await migrateSystemDbFilenameToPath(systemDb);
     await seedHarryPotterDemo(systemDb);
   }
   return systemDb;

--- a/src/db/seed/harry-potter-demo.test.ts
+++ b/src/db/seed/harry-potter-demo.test.ts
@@ -12,7 +12,8 @@ vi.mock('../connection', () => ({
 }));
 
 vi.mock('@tauri-apps/api/path', () => ({
-  appDataDir: vi.fn().mockResolvedValue('/mock/app-data/'),
+  // appDataDir returns no trailing slash on macOS
+  appDataDir: vi.fn().mockResolvedValue('/mock/app-data'),
 }));
 
 // Lazily resolve the mock after the module is loaded

--- a/src/db/seed/harry-potter-demo.ts
+++ b/src/db/seed/harry-potter-demo.ts
@@ -7,7 +7,7 @@ import { createFamily, addFamilyMember } from '../trees/families';
 import { createPlace } from '../trees/places';
 import { createEvent, addEventParticipant, getEventTypeByTag } from '../trees/events';
 
-import { appDataDir } from '@tauri-apps/api/path';
+import { getTreePathForSlug } from '$lib/tree-paths';
 
 const DEMO_SLUG = 'harry-potter-family';
 
@@ -20,8 +20,7 @@ export async function seedHarryPotterDemo(systemDb: Database): Promise<void> {
   if (rows.length > 0 && rows[0].value === 'true') return;
 
   // Create tree entry in system DB
-  const baseDir = await appDataDir();
-  const treePath = `${baseDir}/trees/${DEMO_SLUG}`;
+  const treePath = await getTreePathForSlug(DEMO_SLUG);
 
   const treeId = await createTree({
     name: 'Harry Potter Family',

--- a/src/db/seed/harry-potter-demo.ts
+++ b/src/db/seed/harry-potter-demo.ts
@@ -22,11 +22,14 @@ export async function seedHarryPotterDemo(systemDb: Database): Promise<void> {
   // Create tree entry in system DB
   const treePath = await getTreePathForSlug(DEMO_SLUG);
 
-  const treeId = await createTree({
-    name: 'Harry Potter Family',
-    path: treePath,
-    description: 'A demo family tree featuring the extended Potter-Weasley family',
-  });
+  const treeId = await createTree(
+    {
+      name: 'Harry Potter Family',
+      path: treePath,
+      description: 'A demo family tree featuring the extended Potter-Weasley family',
+    },
+    systemDb
+  );
 
   // Open tree DB
   await openTreeDb(treePath);
@@ -407,7 +410,7 @@ export async function seedHarryPotterDemo(systemDb: Database): Promise<void> {
   // Update tree stats & close
   // =========================================================================
 
-  await updateTreeStats(treeId, { individualCount: 35, familyCount: 10 });
+  await updateTreeStats(treeId, { individualCount: 35, familyCount: 10 }, systemDb);
   await closeTreeDb();
 
   // Mark as seeded

--- a/src/db/seed/harry-potter-demo.ts
+++ b/src/db/seed/harry-potter-demo.ts
@@ -21,7 +21,7 @@ export async function seedHarryPotterDemo(systemDb: Database): Promise<void> {
 
   // Create tree entry in system DB
   const baseDir = await appDataDir();
-  const treePath = `${baseDir}trees/${DEMO_SLUG}`;
+  const treePath = `${baseDir}/trees/${DEMO_SLUG}`;
 
   const treeId = await createTree({
     name: 'Harry Potter Family',

--- a/src/db/system/debug.ts
+++ b/src/db/system/debug.ts
@@ -49,7 +49,7 @@ export async function listTreeDatabaseFiles(): Promise<string[]> {
   try {
     const entries = await readDir('trees', { baseDir: BaseDirectory.AppData });
     return entries
-      .filter((entry) => entry.isFile && entry.name.endsWith('.db'))
+      .filter((entry) => entry.isDirectory || (entry.isFile && entry.name.endsWith('.db')))
       .map((entry) => entry.name);
   } catch {
     // Directory may not exist yet

--- a/src/db/system/trees.ts
+++ b/src/db/system/trees.ts
@@ -1,3 +1,4 @@
+import type Database from '@tauri-apps/plugin-sql';
 import { getSystemDb } from '../connection';
 import type { Tree } from '$/types/database';
 
@@ -46,12 +47,11 @@ export async function getTreeById(id: string): Promise<Tree | null> {
   return rows[0] ? mapToTree(rows[0]) : null;
 }
 
-export async function createTree(data: {
-  name: string;
-  path: string;
-  description?: string;
-}): Promise<string> {
-  const db = await getSystemDb();
+export async function createTree(
+  data: { name: string; path: string; description?: string },
+  dbOverride?: Database
+): Promise<string> {
+  const db = dbOverride ?? (await getSystemDb());
   const result = await db.execute(
     `INSERT INTO trees (name, path, description) VALUES ($1, $2, $3)`,
     [data.name, data.path, data.description ?? null]
@@ -90,9 +90,10 @@ export async function deleteTree(id: string): Promise<void> {
 
 export async function updateTreeStats(
   id: string,
-  stats: { individualCount?: number; familyCount?: number }
+  stats: { individualCount?: number; familyCount?: number },
+  dbOverride?: Database
 ): Promise<void> {
-  const db = await getSystemDb();
+  const db = dbOverride ?? (await getSystemDb());
   const sets: string[] = [];
   const params: number[] = [];
   let paramIndex = 1;

--- a/src/lib/tree-paths.ts
+++ b/src/lib/tree-paths.ts
@@ -1,0 +1,22 @@
+import { appDataDir } from '@tauri-apps/api/path';
+
+/**
+ * Convert a tree name to a URL-safe slug.
+ * Returns empty string if the name contains no alphanumeric characters.
+ */
+export function slugifyTreeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Build the absolute path to a tree's directory inside the app data dir.
+ * The path does NOT include the .db file — callers should append `/<slug>.db`
+ * when loading the database.
+ */
+export async function getTreePathForSlug(slug: string): Promise<string> {
+  const baseDir = await appDataDir();
+  return `${baseDir}/trees/${slug}`;
+}

--- a/src/managers/GedcomManager.ts
+++ b/src/managers/GedcomManager.ts
@@ -63,7 +63,7 @@ export class GedcomManager {
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-+|-+$/g, '') || crypto.randomUUID();
-    const treePath = `${baseDir}trees/${slug}`;
+    const treePath = `${baseDir}/trees/${slug}`;
 
     // Create new tree in system database
     const treeId = await createTree({
@@ -106,7 +106,7 @@ export class GedcomManager {
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-+|-+$/g, '') || crypto.randomUUID();
-    const treePath = `${baseDir}trees/${slug}`;
+    const treePath = `${baseDir}/trees/${slug}`;
 
     const treeId = await createTree({
       name: treeName,

--- a/src/managers/GedcomManager.ts
+++ b/src/managers/GedcomManager.ts
@@ -12,7 +12,7 @@ import { createTree, updateTreeStats, markTreeOpened } from '$/db/system/trees';
 import { openTreeDb, getTreeDb } from '$/db/connection';
 import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
 import { open, save } from '@tauri-apps/plugin-dialog';
-import { appDataDir } from '@tauri-apps/api/path';
+import { getTreePathForSlug, slugifyTreeName } from '$lib/tree-paths';
 
 export interface ImportResult {
   treeId: string;
@@ -57,13 +57,8 @@ export class GedcomManager {
     const treeName = filename.replace(/\.[^.]+$/, '');
 
     // Create tree folder in app data directory
-    const baseDir = await appDataDir();
-    const slug =
-      treeName
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '') || crypto.randomUUID();
-    const treePath = `${baseDir}/trees/${slug}`;
+    const slug = slugifyTreeName(treeName) || crypto.randomUUID();
+    const treePath = await getTreePathForSlug(slug);
 
     // Create new tree in system database
     const treeId = await createTree({
@@ -100,13 +95,8 @@ export class GedcomManager {
    * @returns Import result with tree ID and stats
    */
   static async importFromContent(content: string, treeName: string): Promise<ImportResult> {
-    const baseDir = await appDataDir();
-    const slug =
-      treeName
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '') || crypto.randomUUID();
-    const treePath = `${baseDir}/trees/${slug}`;
+    const slug = slugifyTreeName(treeName) || crypto.randomUUID();
+    const treePath = await getTreePathForSlug(slug);
 
     const treeId = await createTree({
       name: treeName,

--- a/src/managers/TreeManager.ts
+++ b/src/managers/TreeManager.ts
@@ -26,7 +26,7 @@ export class TreeManager {
   static async create(data: CreateTreeData): Promise<string> {
     const baseDir = await appDataDir();
     const slug = slugify(data.name) || crypto.randomUUID();
-    const treePath = `${baseDir}trees/${slug}`;
+    const treePath = `${baseDir}/trees/${slug}`;
 
     const treeId = await createTree({
       name: data.name,

--- a/src/managers/TreeManager.ts
+++ b/src/managers/TreeManager.ts
@@ -3,18 +3,11 @@ import { createTree, getTreeById, updateTreeStats, markTreeOpened } from '$/db/s
 import { countIndividuals } from '$db-tree/individuals';
 import { countFamilies } from '$db-tree/families';
 import { useAppStore } from '$/store/app-store';
-import { appDataDir } from '@tauri-apps/api/path';
+import { getTreePathForSlug, slugifyTreeName } from '$lib/tree-paths';
 
 interface CreateTreeData {
   name: string;
   description?: string;
-}
-
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
 }
 
 export class TreeManager {
@@ -24,9 +17,8 @@ export class TreeManager {
    * @returns The ID of the created tree
    */
   static async create(data: CreateTreeData): Promise<string> {
-    const baseDir = await appDataDir();
-    const slug = slugify(data.name) || crypto.randomUUID();
-    const treePath = `${baseDir}/trees/${slug}`;
+    const slug = slugifyTreeName(data.name) || crypto.randomUUID();
+    const treePath = await getTreePathForSlug(slug);
 
     const treeId = await createTree({
       name: data.name,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -55,7 +55,7 @@ export function HomePage() {
           .toLowerCase()
           .replace(/[^a-z0-9]+/g, '-')
           .replace(/^-+|-+$/g, '') || crypto.randomUUID();
-      const treePath = `${baseDir}trees/${slug}`;
+      const treePath = `${baseDir}/trees/${slug}`;
       return createTree({ name: data.name, path: treePath, description: data.description });
     },
     onSuccess: () => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,7 +10,7 @@ import { queryKeys } from '$lib/query-keys';
 import { ConfirmDialog } from '$components/ConfirmDialog';
 import { ImportGedcomModal } from '$components/ImportGedcomModal';
 import { ExportGedcomModal } from '$components/ExportGedcomModal';
-import { appDataDir } from '@tauri-apps/api/path';
+import { getTreePathForSlug, slugifyTreeName } from '$lib/tree-paths';
 
 export function HomePage() {
   const queryClient = useQueryClient();
@@ -49,13 +49,8 @@ export function HomePage() {
 
   const createMutation = useMutation({
     mutationFn: async (data: { name: string; description?: string }) => {
-      const baseDir = await appDataDir();
-      const slug =
-        data.name
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-')
-          .replace(/^-+|-+$/g, '') || crypto.randomUUID();
-      const treePath = `${baseDir}/trees/${slug}`;
+      const slug = slugifyTreeName(data.name) || crypto.randomUUID();
+      const treePath = await getTreePathForSlug(slug);
       return createTree({ name: data.name, path: treePath, description: data.description });
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary

- The `trees` table had a `filename` column but the code referenced `path`, causing all tree queries to fail silently (tree list showed "No trees yet" even when data existed).
- Root cause: column was renamed in code, but `CREATE TABLE IF NOT EXISTS` doesn't alter existing tables, so the old schema persisted.
- Adds an idempotent migration in `getSystemDb()` that renames the column, moves flat `.db` files into proper subdirectories, and updates paths to absolute format.
- Also fixes a missing `/` separator — `appDataDir()` returns without trailing slash on macOS, so `\${baseDir}trees/...` was producing `...genealogytrees/...`.

## Test plan

- [ ] Launch app with pre-existing DB (old `filename` schema) → trees appear in list
- [ ] Create a new tree from the UI → appears in list
- [ ] Click Open on the new tree → navigates to tree view
- [ ] Verify migrated trees still open correctly (old Harry Potter demo, imported GEDCOMs)
- [ ] Fresh install (no existing DB) → seed runs, demo tree appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic migration that reorganizes existing tree database files into a standardized directory layout on first startup.
  * Consistent tree storage path generation used across imports, creation, and seed data.

* **Bug Fixes**
  * Prevents race conditions during initial system database setup for more reliable first-run behavior.
  * Directory-aware listing of tree database entries for more accurate debug results.

* **Tests**
  * Aligned test path mock formatting with platform behavior.

* **Chores**
  * Added filesystem permissions to enable safe file moves and existence checks during migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->