### PR TITLE
feat(mvp4): Phase 3 source workspace

### DIFF
--- a/docs/mvps/mvp-4-sources-media/README.md
+++ b/docs/mvps/mvp-4-sources-media/README.md
@@ -57,17 +57,17 @@ UI is HTML-only with minimal CSS (shadcn/ui comes in MVP6).
 
 ### Phase 3: Source Workspace
 
-- [ ] Route: `/tree/$treeId/sources/$sourceId`
-- [ ] Workspace layout: side-by-side (image left, linking panel right)
-- [ ] Image viewer: zoom, pan, multi-file navigation
-- [ ] Event type selector with template loading
-- [ ] Template slots: Marriage, Baptism, Birth, Death, Burial, Census
-- [ ] Slot interaction: search existing entities
-- [ ] Slot interaction: create inline (adaptive detail by role)
-- [ ] Free-form entity addition ("+ Add person")
-- [ ] Event suggestion: "Create [event type] event?"
-- [ ] Auto-citation: automatic citation + citation_link creation
-- [ ] SourceWorkspaceManager: orchestrate multi-entity operations
+- [x] Route: `/tree/$treeId/source/$sourceId/edit`
+- [x] Workspace layout: side-by-side (citations/image left, linking panel right)
+- [x] Image viewer: zoom, pan, multi-file navigation
+- [x] File attachment via Tauri file dialog (from workspace)
+- [x] Event type selector with template loading (7 templates: Marriage, Baptism, Birth, Death, Burial, Census, Generic)
+- [x] Slot interaction: search existing entities (autocomplete with 300ms debounce)
+- [x] Slot interaction: create inline (name + gender; "More..." modal deferred post-Phase 3)
+- [x] Free-form entity addition ("+ Add person")
+- [x] Auto-citation: automatic citation + citation_link creation
+- [x] SourceWorkspaceManager: orchestrate multi-entity operations
+- [x] Citations summary on workspace left panel (joined query with event + individuals)
 
 ### Phase 4: Entity Timeline Integration
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,6 @@ export default [
     },
   },
   {
-    ignores: ['src/routeTree.gen.ts', 'dist/', 'src-tauri/'],
+    ignores: ['src/routeTree.gen.ts', 'dist/', 'src-tauri/', '.worktrees/'],
   },
 ];

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -18,8 +18,7 @@
       "allow": [
         { "path": "$APPDATA/**" },
         { "path": "$DOCUMENT/**" },
-        { "path": "$DOWNLOAD/**" },
-        { "path": "$HOME/**" }
+        { "path": "$DOWNLOAD/**" }
       ]
     },
     "dialog:default",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "fs:default",
     "fs:allow-remove",
     "fs:allow-write-text-file",
+    "fs:allow-stat",
     {
       "identifier": "fs:scope",
       "allow": [

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,7 +17,8 @@
       "allow": [
         { "path": "$APPDATA/**" },
         { "path": "$DOCUMENT/**" },
-        { "path": "$DOWNLOAD/**" }
+        { "path": "$DOWNLOAD/**" },
+        { "path": "$HOME/**" }
       ]
     },
     "dialog:default",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: data:"
     }
   },
   "plugins": {

--- a/src/components/workspace/CitationsSummary.tsx
+++ b/src/components/workspace/CitationsSummary.tsx
@@ -7,11 +7,19 @@ interface CitationsSummaryProps {
 }
 
 export function CitationsSummary({ treeId, sourceId }: CitationsSummaryProps): JSX.Element {
-  const { data: citations, isLoading } = useCitationsWithDetails(sourceId);
+  const { data: citations, isLoading, isError } = useCitationsWithDetails(sourceId);
 
   if (isLoading) {
     return (
       <p style={{ padding: '0.75rem', color: '#888', fontSize: '0.85rem' }}>Loading citations...</p>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p style={{ padding: '0.75rem', color: '#c00', fontSize: '0.85rem' }}>
+        Failed to load citations.
+      </p>
     );
   }
 

--- a/src/components/workspace/CitationsSummary.tsx
+++ b/src/components/workspace/CitationsSummary.tsx
@@ -1,0 +1,76 @@
+import { Link } from '@tanstack/react-router';
+import { useCitationsWithDetails } from '$hooks/useCitationsWithDetails';
+
+interface CitationsSummaryProps {
+  treeId: string;
+  sourceId: string;
+}
+
+export function CitationsSummary({ treeId, sourceId }: CitationsSummaryProps): JSX.Element {
+  const { data: citations, isLoading } = useCitationsWithDetails(sourceId);
+
+  if (isLoading) {
+    return (
+      <p style={{ padding: '0.75rem', color: '#888', fontSize: '0.85rem' }}>
+        Loading citations...
+      </p>
+    );
+  }
+
+  if (!citations || citations.length === 0) {
+    return (
+      <p style={{ padding: '0.75rem', color: '#888', fontSize: '0.85rem' }}>
+        No citations yet — use the panel on the right to start extracting data from this source.
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          padding: '0.5rem 0.75rem',
+          fontSize: '0.75rem',
+          color: '#888',
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+          borderBottom: '1px solid #e0e0e0',
+        }}
+      >
+        Citations ({citations.length})
+      </div>
+      {citations.map((citation) => (
+        <div
+          key={citation.citationId}
+          style={{ padding: '0.6rem 0.75rem', borderBottom: '1px solid #f0f0f0' }}
+        >
+          <div style={{ fontWeight: 600, fontSize: '0.85rem' }}>
+            {citation.eventTypeName ?? 'No event'}
+            {citation.eventDate && (
+              <span style={{ fontWeight: 400, color: '#666' }}> — {citation.eventDate}</span>
+            )}
+          </div>
+          {citation.page && (
+            <div style={{ fontSize: '0.75rem', color: '#888', marginTop: '0.15rem' }}>
+              {citation.page}
+            </div>
+          )}
+          {citation.linkedIndividuals.length > 0 && (
+            <div style={{ fontSize: '0.8rem', color: '#555', marginTop: '0.25rem' }}>
+              {citation.linkedIndividuals.map((ind) => (
+                <Link
+                  key={ind.id}
+                  to="/tree/$treeId/individual/$individualId"
+                  params={{ treeId, individualId: ind.id }}
+                  style={{ color: '#06c', textDecoration: 'none', marginRight: '0.5rem' }}
+                >
+                  {ind.name}
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/workspace/CitationsSummary.tsx
+++ b/src/components/workspace/CitationsSummary.tsx
@@ -11,9 +11,7 @@ export function CitationsSummary({ treeId, sourceId }: CitationsSummaryProps): J
 
   if (isLoading) {
     return (
-      <p style={{ padding: '0.75rem', color: '#888', fontSize: '0.85rem' }}>
-        Loading citations...
-      </p>
+      <p style={{ padding: '0.75rem', color: '#888', fontSize: '0.85rem' }}>Loading citations...</p>
     );
   }
 

--- a/src/components/workspace/CreateEventButton.tsx
+++ b/src/components/workspace/CreateEventButton.tsx
@@ -36,17 +36,14 @@ function countCreations(
 
   const events = template.eventTypeTag ? 1 : 0;
   const families = template.families.filter((rule) => {
-    const childSlot = rule.members.find((m) => m.role === 'child')?.slot;
-    const parentSlot = rule.members.find((m) => m.role !== 'child')?.slot;
     if (rule.type === 'couple') {
       return rule.members.every((m) => filledSlotKeys.includes(m.slot));
     }
-    return (
-      childSlot &&
-      filledSlotKeys.includes(childSlot) &&
-      parentSlot &&
-      filledSlotKeys.includes(parentSlot)
+    const childSlot = rule.members.find((m) => m.role === 'child')?.slot;
+    const hasParent = rule.members.some(
+      (m) => m.role !== 'child' && filledSlotKeys.includes(m.slot)
     );
+    return Boolean(childSlot) && filledSlotKeys.includes(childSlot!) && hasParent;
   }).length;
 
   return { individuals, families, events, citations: 1 };

--- a/src/components/workspace/CreateEventButton.tsx
+++ b/src/components/workspace/CreateEventButton.tsx
@@ -42,7 +42,10 @@ function countCreations(
       return rule.members.every((m) => filledSlotKeys.includes(m.slot));
     }
     return (
-      childSlot && filledSlotKeys.includes(childSlot) && parentSlot && filledSlotKeys.includes(parentSlot)
+      childSlot &&
+      filledSlotKeys.includes(childSlot) &&
+      parentSlot &&
+      filledSlotKeys.includes(parentSlot)
     );
   }).length;
 
@@ -105,9 +108,7 @@ export function CreateEventButton({
       >
         {isPending ? 'Creating...' : label}
       </button>
-      <div
-        style={{ fontSize: '0.7rem', color: '#888', textAlign: 'center', marginTop: '0.4rem' }}
-      >
+      <div style={{ fontSize: '0.7rem', color: '#888', textAlign: 'center', marginTop: '0.4rem' }}>
         Will create: {summaryParts.join(', ')}
       </div>
     </div>

--- a/src/components/workspace/CreateEventButton.tsx
+++ b/src/components/workspace/CreateEventButton.tsx
@@ -1,0 +1,115 @@
+import type { TemplateDefinition } from '$/lib/templates';
+import type { PersonSlotValue } from './PersonSlot';
+
+interface CreateEventButtonProps {
+  template: TemplateDefinition;
+  slotValues: Record<string, PersonSlotValue | PersonSlotValue[] | null>;
+  freeFormValues: PersonSlotValue[];
+  isPending: boolean;
+  onSubmit: () => void;
+}
+
+function countCreations(
+  template: TemplateDefinition,
+  slotValues: Record<string, PersonSlotValue | PersonSlotValue[] | null>,
+  freeFormValues: PersonSlotValue[]
+): { individuals: number; families: number; events: number; citations: number } {
+  let individuals = 0;
+  const filledSlotKeys: string[] = [];
+
+  // Count from template slots
+  for (const slot of template.slots) {
+    const val = slotValues[slot.key];
+    if (slot.multiple && Array.isArray(val)) {
+      for (const v of val) {
+        if (v.type === 'new') individuals++;
+        filledSlotKeys.push(slot.key);
+      }
+    } else if (val && !Array.isArray(val)) {
+      if (val.type === 'new') individuals++;
+      filledSlotKeys.push(slot.key);
+    }
+  }
+
+  // Count free-form
+  individuals += freeFormValues.filter((v) => v.type === 'new').length;
+
+  const events = template.eventTypeTag ? 1 : 0;
+  const families = template.families.filter((rule) => {
+    const childSlot = rule.members.find((m) => m.role === 'child')?.slot;
+    const parentSlot = rule.members.find((m) => m.role !== 'child')?.slot;
+    if (rule.type === 'couple') {
+      return rule.members.every((m) => filledSlotKeys.includes(m.slot));
+    }
+    return (
+      childSlot && filledSlotKeys.includes(childSlot) && parentSlot && filledSlotKeys.includes(parentSlot)
+    );
+  }).length;
+
+  return { individuals, families, events, citations: 1 };
+}
+
+export function CreateEventButton({
+  template,
+  slotValues,
+  freeFormValues,
+  isPending,
+  onSubmit,
+}: CreateEventButtonProps): JSX.Element {
+  // Check if required slots are filled
+  const hasRequired = template.slots
+    .filter((s) => s.required)
+    .every((s) => {
+      const val = slotValues[s.key];
+      return val && (!Array.isArray(val) || val.length > 0);
+    });
+
+  const isGenericEmpty = template.id === 'generic' && freeFormValues.length === 0;
+  const disabled = isPending || (!hasRequired && template.slots.length > 0) || isGenericEmpty;
+
+  const counts = countCreations(template, slotValues, freeFormValues);
+  const label = template.eventTypeTag ? `Create ${template.label} Event` : 'Create Citation';
+
+  const summaryParts: string[] = [];
+  if (counts.events > 0) summaryParts.push(`${counts.events} event`);
+  if (counts.individuals > 0)
+    summaryParts.push(`${counts.individuals} individual${counts.individuals > 1 ? 's' : ''}`);
+  if (counts.families > 0)
+    summaryParts.push(`${counts.families} famil${counts.families > 1 ? 'ies' : 'y'}`);
+  summaryParts.push('1 citation');
+
+  return (
+    <div
+      style={{
+        margin: '0.75rem 1rem',
+        padding: '0.75rem',
+        background: '#fff',
+        border: '1px solid #e0e0e0',
+        borderRadius: '6px',
+      }}
+    >
+      <button
+        onClick={onSubmit}
+        disabled={disabled}
+        style={{
+          width: '100%',
+          padding: '0.6rem',
+          background: disabled ? '#999' : '#333',
+          color: '#fff',
+          border: 'none',
+          borderRadius: '4px',
+          fontSize: '0.85rem',
+          fontWeight: 600,
+          cursor: disabled ? 'not-allowed' : 'pointer',
+        }}
+      >
+        {isPending ? 'Creating...' : label}
+      </button>
+      <div
+        style={{ fontSize: '0.7rem', color: '#888', textAlign: 'center', marginTop: '0.4rem' }}
+      >
+        Will create: {summaryParts.join(', ')}
+      </div>
+    </div>
+  );
+}

--- a/src/components/workspace/EventDetails.tsx
+++ b/src/components/workspace/EventDetails.tsx
@@ -1,0 +1,59 @@
+import { PlaceAutocomplete, type PlaceValue } from './PlaceAutocomplete';
+
+interface EventDetailsProps {
+  date: string;
+  place: PlaceValue | null;
+  onDateChange: (date: string) => void;
+  onPlaceChange: (place: PlaceValue | null) => void;
+}
+
+export function EventDetails({
+  date,
+  place,
+  onDateChange,
+  onPlaceChange,
+}: EventDetailsProps): JSX.Element {
+  return (
+    <div
+      style={{
+        marginBottom: '0.75rem',
+        padding: '0.6rem',
+        border: '1px solid #e0e0e0',
+        borderRadius: '6px',
+        background: '#fff',
+      }}
+    >
+      <div
+        style={{
+          fontSize: '0.7rem',
+          color: '#888',
+          textTransform: 'uppercase',
+          marginBottom: '0.4rem',
+        }}
+      >
+        Event Details
+      </div>
+      <div style={{ marginBottom: '0.4rem' }}>
+        <div style={{ fontSize: '0.7rem', color: '#666', marginBottom: '0.15rem' }}>Date</div>
+        <input
+          type="text"
+          value={date}
+          onChange={(e) => onDateChange(e.target.value)}
+          placeholder="e.g., 15 Jun 1892"
+          style={{
+            width: '100%',
+            padding: '0.3rem 0.5rem',
+            border: '1px solid #ddd',
+            borderRadius: '4px',
+            fontSize: '0.8rem',
+            boxSizing: 'border-box',
+          }}
+        />
+      </div>
+      <div>
+        <div style={{ fontSize: '0.7rem', color: '#666', marginBottom: '0.15rem' }}>Place</div>
+        <PlaceAutocomplete value={place} onChange={onPlaceChange} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/workspace/EventDetails.tsx
+++ b/src/components/workspace/EventDetails.tsx
@@ -34,8 +34,19 @@ export function EventDetails({
         Event Details
       </div>
       <div style={{ marginBottom: '0.4rem' }}>
-        <div style={{ fontSize: '0.7rem', color: '#666', marginBottom: '0.15rem' }}>Date</div>
+        <label
+          htmlFor="event-date-input"
+          style={{
+            display: 'block',
+            fontSize: '0.7rem',
+            color: '#666',
+            marginBottom: '0.15rem',
+          }}
+        >
+          Date
+        </label>
         <input
+          id="event-date-input"
           type="text"
           value={date}
           onChange={(e) => onDateChange(e.target.value)}

--- a/src/components/workspace/EventTypeSelector.tsx
+++ b/src/components/workspace/EventTypeSelector.tsx
@@ -1,0 +1,48 @@
+import { TEMPLATES } from '$/lib/templates';
+
+interface EventTypeSelectorProps {
+  value: string;
+  onChange: (templateId: string) => void;
+}
+
+export function EventTypeSelector({ value, onChange }: EventTypeSelectorProps): JSX.Element {
+  return (
+    <div
+      style={{
+        padding: '0.75rem 1rem',
+        borderBottom: '1px solid #e0e0e0',
+        background: '#fff',
+      }}
+    >
+      <div
+        style={{
+          fontSize: '0.75rem',
+          color: '#888',
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+          marginBottom: '0.4rem',
+        }}
+      >
+        Document Type
+      </div>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={{
+          width: '100%',
+          padding: '0.5rem',
+          border: '1px solid #ddd',
+          borderRadius: '6px',
+          fontSize: '0.9rem',
+        }}
+      >
+        <option value="">Select document type...</option>
+        {TEMPLATES.map((t) => (
+          <option key={t.id} value={t.id}>
+            {t.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/workspace/EventTypeSelector.tsx
+++ b/src/components/workspace/EventTypeSelector.tsx
@@ -14,8 +14,10 @@ export function EventTypeSelector({ value, onChange }: EventTypeSelectorProps): 
         background: '#fff',
       }}
     >
-      <div
+      <label
+        htmlFor="event-template-select"
         style={{
+          display: 'block',
           fontSize: '0.75rem',
           color: '#888',
           textTransform: 'uppercase',
@@ -24,8 +26,9 @@ export function EventTypeSelector({ value, onChange }: EventTypeSelectorProps): 
         }}
       >
         Document Type
-      </div>
+      </label>
       <select
+        id="event-template-select"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         style={{

--- a/src/components/workspace/FreeFormAdd.tsx
+++ b/src/components/workspace/FreeFormAdd.tsx
@@ -35,18 +35,22 @@ export function FreeFormAdd({ values, onChange }: FreeFormAddProps): JSX.Element
       {showNew ? (
         <PersonSlot label="New Person" onChange={handleAdd} />
       ) : (
-        <div
+        <button
+          type="button"
           onClick={() => setShowNew(true)}
           style={{
+            width: '100%',
             textAlign: 'center',
             fontSize: '0.8rem',
             color: '#4a90d9',
             cursor: 'pointer',
             padding: '0.5rem',
+            background: 'none',
+            border: 'none',
           }}
         >
           + Add person
-        </div>
+        </button>
       )}
     </div>
   );

--- a/src/components/workspace/FreeFormAdd.tsx
+++ b/src/components/workspace/FreeFormAdd.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { PersonSlot, type PersonSlotValue } from './PersonSlot';
+
+interface FreeFormAddProps {
+  values: PersonSlotValue[];
+  onChange: (values: PersonSlotValue[]) => void;
+}
+
+export function FreeFormAdd({ values, onChange }: FreeFormAddProps): JSX.Element {
+  const [showNew, setShowNew] = useState(false);
+
+  function handleAdd(val: PersonSlotValue | null) {
+    if (val) {
+      onChange([...values, val]);
+    }
+    setShowNew(false);
+  }
+
+  function handleRemove(index: number) {
+    onChange(values.filter((_, i) => i !== index));
+  }
+
+  return (
+    <div style={{ padding: '0 1rem 0.75rem' }}>
+      {values.map((val, index) => (
+        <PersonSlot
+          key={`freeform-${index}`}
+          label={`Person ${index + 1}`}
+          value={val}
+          onChange={(v) => {
+            if (!v) handleRemove(index);
+          }}
+        />
+      ))}
+      {showNew ? (
+        <PersonSlot label="New Person" onChange={handleAdd} />
+      ) : (
+        <div
+          onClick={() => setShowNew(true)}
+          style={{
+            textAlign: 'center',
+            fontSize: '0.8rem',
+            color: '#4a90d9',
+            cursor: 'pointer',
+            padding: '0.5rem',
+          }}
+        >
+          + Add person
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workspace/ImageViewer.tsx
+++ b/src/components/workspace/ImageViewer.tsx
@@ -186,6 +186,7 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
       >
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
           <button
+            aria-label="Zoom out"
             onClick={() => setZoom((z) => Math.max(0.1, z - 0.25))}
             style={{
               color: '#fff',
@@ -201,6 +202,7 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
           </button>
           <span style={{ color: '#aaa', fontSize: '0.75rem' }}>{Math.round(zoom * 100)}%</span>
           <button
+            aria-label="Zoom in"
             onClick={() => setZoom((z) => Math.min(5, z + 0.25))}
             style={{
               color: '#fff',
@@ -235,6 +237,7 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
 
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
           <button
+            aria-label="Previous file"
             onClick={() => setCurrentIndex((i) => Math.max(0, i - 1))}
             disabled={currentIndex === 0}
             style={{
@@ -251,6 +254,7 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
             {currentIndex + 1} / {files.length}
           </span>
           <button
+            aria-label="Next file"
             onClick={() => setCurrentIndex((i) => Math.min(files.length - 1, i + 1))}
             disabled={currentIndex === files.length - 1}
             style={{

--- a/src/components/workspace/ImageViewer.tsx
+++ b/src/components/workspace/ImageViewer.tsx
@@ -72,7 +72,7 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
       isDragging.current = true;
       dragStart.current = { x: e.clientX - pan.x, y: e.clientY - pan.y };
     },
-    [pan],
+    [pan]
   );
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -135,9 +135,7 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
 
   const currentFile = files[currentIndex];
   const imageSrc =
-    currentFile && treePath
-      ? convertFileSrc(`${treePath}/${currentFile.relativePath}`)
-      : '';
+    currentFile && treePath ? convertFileSrc(`${treePath}/${currentFile.relativePath}`) : '';
 
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: '#1a1a1a' }}>

--- a/src/components/workspace/ImageViewer.tsx
+++ b/src/components/workspace/ImageViewer.tsx
@@ -1,0 +1,279 @@
+import React, { useState, useRef, useCallback } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useFilesBySource } from '$hooks/useFiles';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { open } from '@tauri-apps/plugin-dialog';
+import { copyFileToTree } from '$lib/file-utils';
+import { createFile, addFileToSource } from '$db-tree/files';
+import { queryKeys } from '$lib/query-keys';
+import { getCurrentTreePath } from '$/db/connection';
+
+interface ImageViewerProps {
+  sourceId: string;
+}
+
+export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
+  const { data: files, isLoading } = useFilesBySource(sourceId);
+  const queryClient = useQueryClient();
+  const treePath = getCurrentTreePath();
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const isDragging = useRef(false);
+  const dragStart = useRef({ x: 0, y: 0 });
+
+  const { mutate: attachFiles, isPending: isAttaching } = useMutation({
+    mutationFn: async () => {
+      if (!treePath) throw new Error('No tree path');
+      const selected = await open({
+        multiple: true,
+        filters: [
+          {
+            name: 'Images',
+            extensions: ['jpg', 'jpeg', 'png', 'tiff', 'tif', 'pdf'],
+          },
+        ],
+      });
+      if (!selected) return;
+      const paths = Array.isArray(selected) ? selected : [selected];
+      const mimeMap: Record<string, string> = {
+        jpg: 'image/jpeg',
+        jpeg: 'image/jpeg',
+        png: 'image/png',
+        tiff: 'image/tiff',
+        tif: 'image/tiff',
+        pdf: 'application/pdf',
+      };
+      for (const filePath of paths) {
+        const { relativePath, filename } = await copyFileToTree(filePath, treePath);
+        const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+        const fileId = await createFile({
+          originalFilename: filename,
+          relativePath,
+          mimeType: mimeMap[ext] ?? 'application/octet-stream',
+          fileSize: 0,
+        });
+        await addFileToSource({ sourceId, fileId });
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.files(sourceId) });
+    },
+  });
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    setZoom((z) => Math.max(0.1, Math.min(5, z - e.deltaY * 0.001)));
+  }, []);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      isDragging.current = true;
+      dragStart.current = { x: e.clientX - pan.x, y: e.clientY - pan.y };
+    },
+    [pan],
+  );
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isDragging.current) return;
+    setPan({ x: e.clientX - dragStart.current.x, y: e.clientY - dragStart.current.y });
+  }, []);
+
+  const handleMouseUp = useCallback(() => {
+    isDragging.current = false;
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#888',
+        }}
+      >
+        Loading files...
+      </div>
+    );
+  }
+
+  if (!files || files.length === 0) {
+    return (
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#f5f5f5',
+          padding: '2rem',
+        }}
+      >
+        <p style={{ color: '#888', marginBottom: '1rem' }}>No files attached to this source.</p>
+        <button
+          onClick={() => attachFiles()}
+          disabled={isAttaching}
+          style={{
+            padding: '0.5rem 1rem',
+            background: '#333',
+            color: '#fff',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: '0.85rem',
+          }}
+        >
+          {isAttaching ? 'Attaching...' : 'Attach Files'}
+        </button>
+      </div>
+    );
+  }
+
+  const currentFile = files[currentIndex];
+  const imageSrc =
+    currentFile && treePath
+      ? convertFileSrc(`${treePath}/${currentFile.relativePath}`)
+      : '';
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: '#1a1a1a' }}>
+      {/* Toolbar */}
+      <div
+        style={{
+          padding: '0.5rem',
+          background: '#2a2a2a',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        {/* Zoom controls */}
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <button
+            onClick={() => setZoom((z) => Math.max(0.1, z - 0.25))}
+            style={{
+              color: '#fff',
+              background: '#444',
+              border: 'none',
+              borderRadius: '3px',
+              padding: '0.2rem 0.5rem',
+              cursor: 'pointer',
+              fontSize: '0.75rem',
+            }}
+          >
+            -
+          </button>
+          <span style={{ color: '#aaa', fontSize: '0.75rem' }}>{Math.round(zoom * 100)}%</span>
+          <button
+            onClick={() => setZoom((z) => Math.min(5, z + 0.25))}
+            style={{
+              color: '#fff',
+              background: '#444',
+              border: 'none',
+              borderRadius: '3px',
+              padding: '0.2rem 0.5rem',
+              cursor: 'pointer',
+              fontSize: '0.75rem',
+            }}
+          >
+            +
+          </button>
+          <button
+            onClick={() => {
+              setZoom(1);
+              setPan({ x: 0, y: 0 });
+            }}
+            style={{
+              color: '#fff',
+              background: '#444',
+              border: 'none',
+              borderRadius: '3px',
+              padding: '0.2rem 0.5rem',
+              cursor: 'pointer',
+              fontSize: '0.75rem',
+            }}
+          >
+            Fit
+          </button>
+        </div>
+
+        {/* Navigation controls */}
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <button
+            onClick={() => setCurrentIndex((i) => Math.max(0, i - 1))}
+            disabled={currentIndex === 0}
+            style={{
+              color: currentIndex === 0 ? '#666' : '#fff',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              fontSize: '0.75rem',
+            }}
+          >
+            &laquo;
+          </button>
+          <span style={{ color: '#fff', fontSize: '0.75rem' }}>
+            {currentIndex + 1} / {files.length}
+          </span>
+          <button
+            onClick={() => setCurrentIndex((i) => Math.min(files.length - 1, i + 1))}
+            disabled={currentIndex === files.length - 1}
+            style={{
+              color: currentIndex === files.length - 1 ? '#666' : '#fff',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              fontSize: '0.75rem',
+            }}
+          >
+            &raquo;
+          </button>
+        </div>
+
+        {/* Add file */}
+        <button
+          onClick={() => attachFiles()}
+          disabled={isAttaching}
+          style={{
+            color: '#fff',
+            background: '#444',
+            border: 'none',
+            borderRadius: '3px',
+            padding: '0.2rem 0.5rem',
+            cursor: 'pointer',
+            fontSize: '0.75rem',
+          }}
+        >
+          + Add
+        </button>
+      </div>
+
+      {/* Image viewport */}
+      <div
+        style={{ flex: 1, overflow: 'hidden', cursor: isDragging.current ? 'grabbing' : 'grab' }}
+        onWheel={handleWheel}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+      >
+        <img
+          src={imageSrc}
+          alt={currentFile?.originalFilename ?? ''}
+          style={{
+            transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+            transformOrigin: '0 0',
+            maxWidth: 'none',
+            userSelect: 'none',
+            pointerEvents: 'none',
+          }}
+          draggable={false}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/workspace/ImageViewer.tsx
+++ b/src/components/workspace/ImageViewer.tsx
@@ -3,9 +3,9 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useFilesBySource } from '$hooks/useFiles';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
-import { stat } from '@tauri-apps/plugin-fs';
+import { stat, remove } from '@tauri-apps/plugin-fs';
 import { copyFileToTree } from '$lib/file-utils';
-import { createFile, addFileToSource } from '$db-tree/files';
+import { createFile, addFileToSource, deleteFile } from '$db-tree/files';
 import { queryKeys } from '$lib/query-keys';
 import { getCurrentTreePath } from '$/db/connection';
 
@@ -39,7 +39,7 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
         filters: [
           {
             name: 'Images',
-            extensions: ['jpg', 'jpeg', 'png', 'tiff', 'tif', 'pdf'],
+            extensions: ['jpg', 'jpeg', 'png', 'tiff', 'tif'],
           },
         ],
       });
@@ -51,19 +51,37 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
         png: 'image/png',
         tiff: 'image/tiff',
         tif: 'image/tiff',
-        pdf: 'application/pdf',
       };
       for (const filePath of paths) {
         const { relativePath, filename } = await copyFileToTree(filePath, treePath);
-        const ext = filename.split('.').pop()?.toLowerCase() ?? '';
-        const fileInfo = await stat(`${treePath}/${relativePath}`);
-        const fileId = await createFile({
-          originalFilename: filename,
-          relativePath,
-          mimeType: mimeMap[ext] ?? 'application/octet-stream',
-          fileSize: fileInfo.size,
-        });
-        await addFileToSource({ sourceId, fileId });
+        const copiedPath = `${treePath}/${relativePath}`;
+        let fileId: string | null = null;
+        try {
+          const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+          const fileInfo = await stat(copiedPath);
+          fileId = await createFile({
+            originalFilename: filename,
+            relativePath,
+            mimeType: mimeMap[ext] ?? 'application/octet-stream',
+            fileSize: fileInfo.size,
+          });
+          await addFileToSource({ sourceId, fileId });
+        } catch (err) {
+          // Roll back side effects for this file: DB row and copied asset.
+          if (fileId) {
+            try {
+              await deleteFile(fileId);
+            } catch {
+              // Swallow cleanup errors; surface the original failure.
+            }
+          }
+          try {
+            await remove(copiedPath);
+          } catch {
+            // Swallow cleanup errors; surface the original failure.
+          }
+          throw err;
+        }
       }
     },
     onSuccess: () => {

--- a/src/components/workspace/ImageViewer.tsx
+++ b/src/components/workspace/ImageViewer.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useFilesBySource } from '$hooks/useFiles';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
+import { stat } from '@tauri-apps/plugin-fs';
 import { copyFileToTree } from '$lib/file-utils';
 import { createFile, addFileToSource } from '$db-tree/files';
 import { queryKeys } from '$lib/query-keys';
@@ -20,8 +21,15 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
-  const isDragging = useRef(false);
+  const [isDragging, setIsDragging] = useState(false);
   const dragStart = useRef({ x: 0, y: 0 });
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
 
   const { mutate: attachFiles, isPending: isAttaching } = useMutation({
     mutationFn: async () => {
@@ -48,11 +56,12 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
       for (const filePath of paths) {
         const { relativePath, filename } = await copyFileToTree(filePath, treePath);
         const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+        const fileInfo = await stat(`${treePath}/${relativePath}`);
         const fileId = await createFile({
           originalFilename: filename,
           relativePath,
           mimeType: mimeMap[ext] ?? 'application/octet-stream',
-          fileSize: 0,
+          fileSize: fileInfo.size,
         });
         await addFileToSource({ sourceId, fileId });
       }
@@ -69,19 +78,28 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
-      isDragging.current = true;
+      setIsDragging(true);
       dragStart.current = { x: e.clientX - pan.x, y: e.clientY - pan.y };
     },
     [pan]
   );
 
-  const handleMouseMove = useCallback((e: React.MouseEvent) => {
-    if (!isDragging.current) return;
-    setPan({ x: e.clientX - dragStart.current.x, y: e.clientY - dragStart.current.y });
-  }, []);
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isDragging) return;
+      if (rafRef.current !== null) return;
+      const clientX = e.clientX;
+      const clientY = e.clientY;
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        setPan({ x: clientX - dragStart.current.x, y: clientY - dragStart.current.y });
+      });
+    },
+    [isDragging]
+  );
 
   const handleMouseUp = useCallback(() => {
-    isDragging.current = false;
+    setIsDragging(false);
   }, []);
 
   if (isLoading) {
@@ -139,7 +157,6 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
 
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: '#1a1a1a' }}>
-      {/* Toolbar */}
       <div
         style={{
           padding: '0.5rem',
@@ -149,7 +166,6 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
           alignItems: 'center',
         }}
       >
-        {/* Zoom controls */}
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
           <button
             onClick={() => setZoom((z) => Math.max(0.1, z - 0.25))}
@@ -199,7 +215,6 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
           </button>
         </div>
 
-        {/* Navigation controls */}
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
           <button
             onClick={() => setCurrentIndex((i) => Math.max(0, i - 1))}
@@ -232,7 +247,6 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
           </button>
         </div>
 
-        {/* Add file */}
         <button
           onClick={() => attachFiles()}
           disabled={isAttaching}
@@ -250,9 +264,8 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
         </button>
       </div>
 
-      {/* Image viewport */}
       <div
-        style={{ flex: 1, overflow: 'hidden', cursor: isDragging.current ? 'grabbing' : 'grab' }}
+        style={{ flex: 1, overflow: 'hidden', cursor: isDragging ? 'grabbing' : 'grab' }}
         onWheel={handleWheel}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}

--- a/src/components/workspace/LeftPanel.tsx
+++ b/src/components/workspace/LeftPanel.tsx
@@ -1,0 +1,14 @@
+import { CitationsSummary } from './CitationsSummary';
+
+interface LeftPanelProps {
+  treeId: string;
+  sourceId: string;
+}
+
+export function LeftPanel({ treeId, sourceId }: LeftPanelProps): JSX.Element {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <CitationsSummary treeId={treeId} sourceId={sourceId} />
+    </div>
+  );
+}

--- a/src/components/workspace/LeftPanel.tsx
+++ b/src/components/workspace/LeftPanel.tsx
@@ -1,4 +1,5 @@
 import { CitationsSummary } from './CitationsSummary';
+import { ImageViewer } from './ImageViewer';
 
 interface LeftPanelProps {
   treeId: string;
@@ -9,6 +10,7 @@ export function LeftPanel({ treeId, sourceId }: LeftPanelProps): JSX.Element {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <CitationsSummary treeId={treeId} sourceId={sourceId} />
+      <ImageViewer sourceId={sourceId} />
     </div>
   );
 }

--- a/src/components/workspace/PersonSlot.test.tsx
+++ b/src/components/workspace/PersonSlot.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PersonSlot, type PersonSlotValue } from './PersonSlot';
+
+// Mock the search function
+vi.mock('$db-tree/individuals', () => ({
+  searchIndividuals: vi.fn().mockResolvedValue([
+    { id: 'I-0001', gender: 'M' },
+    { id: 'I-0002', gender: 'F' },
+  ]),
+}));
+
+vi.mock('$db-tree/names', () => ({
+  getPrimaryName: vi.fn().mockImplementation((id: string) => {
+    if (id === 'I-0001') return Promise.resolve({ givenNames: 'Joseph', surname: 'Dupont' });
+    if (id === 'I-0002') return Promise.resolve({ givenNames: 'Marie', surname: 'Dupont' });
+    return Promise.resolve(null);
+  }),
+  formatName: vi.fn().mockImplementation((name) => {
+    if (!name) return { full: 'Unknown' };
+    return { full: `${name.givenNames} ${name.surname}` };
+  }),
+}));
+
+describe('PersonSlot', () => {
+  it('renders with label', () => {
+    render(<PersonSlot label="Husband" onChange={vi.fn()} />);
+    expect(screen.getByText('Husband')).toBeDefined();
+  });
+
+  it('shows search input when empty', () => {
+    render(<PersonSlot label="Husband" onChange={vi.fn()} />);
+    expect(screen.getByPlaceholderText('Search or type name...')).toBeDefined();
+  });
+
+  it('shows filled state when value is provided', () => {
+    const value: PersonSlotValue = {
+      type: 'existing',
+      id: 'I-0001',
+      displayName: 'Joseph Dupont',
+    };
+    render(<PersonSlot label="Husband" value={value} onChange={vi.fn()} />);
+    expect(screen.getByText('Joseph Dupont')).toBeDefined();
+  });
+
+  it('calls onChange with null when X is clicked on filled slot', () => {
+    const onChange = vi.fn();
+    const value: PersonSlotValue = {
+      type: 'existing',
+      id: 'I-0001',
+      displayName: 'Joseph Dupont',
+    };
+    render(<PersonSlot label="Husband" value={value} onChange={onChange} />);
+    fireEvent.click(screen.getByText('\u2715'));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/components/workspace/PersonSlot.tsx
+++ b/src/components/workspace/PersonSlot.tsx
@@ -122,9 +122,7 @@ export function PersonSlot({
           {label}
           {required && <span style={{ color: '#c00' }}> *</span>}
         </div>
-        <div
-          style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
-        >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <div>
             <div style={{ fontWeight: 600, fontSize: '0.85rem' }}>{value.displayName}</div>
             <div style={{ fontSize: '0.7rem', color: '#666' }}>

--- a/src/components/workspace/PersonSlot.tsx
+++ b/src/components/workspace/PersonSlot.tsx
@@ -1,0 +1,242 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { searchIndividuals } from '$db-tree/individuals';
+import { getPrimaryName, formatName } from '$db-tree/names';
+import type { Gender } from '$/types/database';
+
+export interface PersonSlotValue {
+  type: 'existing' | 'new';
+  id?: string; // for existing
+  displayName: string;
+  newName?: string; // for new
+  newGender?: Gender; // for new
+}
+
+interface PersonSlotProps {
+  label: string;
+  value?: PersonSlotValue | null;
+  defaultGender?: 'M' | 'F';
+  required?: boolean;
+  onChange: (value: PersonSlotValue | null) => void;
+}
+
+interface SearchResult {
+  id: string;
+  name: string;
+  gender: string;
+}
+
+export function PersonSlot({
+  label,
+  value,
+  defaultGender,
+  required,
+  onChange,
+}: PersonSlotProps): JSX.Element {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const doSearch = useCallback(async (q: string) => {
+    if (q.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+    setIsSearching(true);
+    try {
+      const individuals = await searchIndividuals(q);
+      const searchResults: SearchResult[] = [];
+      for (const ind of individuals.slice(0, 8)) {
+        const name = await getPrimaryName(ind.id);
+        const formatted = formatName(name);
+        searchResults.push({ id: ind.id, name: formatted.full, gender: ind.gender });
+      }
+      setResults(searchResults);
+      setShowDropdown(true);
+    } finally {
+      setIsSearching(false);
+    }
+  }, []);
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const val = e.target.value;
+    setQuery(val);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => doSearch(val), 300);
+  }
+
+  function handleSelectExisting(result: SearchResult) {
+    onChange({ type: 'existing', id: result.id, displayName: result.name });
+    setQuery('');
+    setShowDropdown(false);
+  }
+
+  function handleCreateNew() {
+    onChange({
+      type: 'new',
+      displayName: query.trim(),
+      newName: query.trim(),
+      newGender: defaultGender ?? 'U',
+    });
+    setQuery('');
+    setShowDropdown(false);
+  }
+
+  function handleClear() {
+    onChange(null);
+  }
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowDropdown(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  // Filled state
+  if (value) {
+    return (
+      <div
+        style={{
+          marginBottom: '0.75rem',
+          padding: '0.6rem',
+          border: '1px solid #c0dcc0',
+          borderRadius: '6px',
+          background: '#f0f8f0',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '0.7rem',
+            color: '#888',
+            textTransform: 'uppercase',
+            marginBottom: '0.3rem',
+          }}
+        >
+          {label}
+          {required && <span style={{ color: '#c00' }}> *</span>}
+        </div>
+        <div
+          style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+        >
+          <div>
+            <div style={{ fontWeight: 600, fontSize: '0.85rem' }}>{value.displayName}</div>
+            <div style={{ fontSize: '0.7rem', color: '#666' }}>
+              {value.type === 'existing' ? value.id : 'will be created'}
+            </div>
+          </div>
+          <span
+            onClick={handleClear}
+            style={{ fontSize: '0.7rem', color: '#c00', cursor: 'pointer' }}
+          >
+            {'\u2715'}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        marginBottom: '0.75rem',
+        padding: '0.6rem',
+        border: '1px dashed #ccc',
+        borderRadius: '6px',
+        background: '#fff',
+        position: 'relative',
+      }}
+    >
+      <div
+        style={{
+          fontSize: '0.7rem',
+          color: '#888',
+          textTransform: 'uppercase',
+          marginBottom: '0.3rem',
+        }}
+      >
+        {label}
+        {required && <span style={{ color: '#c00' }}> *</span>}
+      </div>
+      <input
+        type="text"
+        placeholder="Search or type name..."
+        value={query}
+        onChange={handleInputChange}
+        onFocus={() => {
+          if (results.length > 0) setShowDropdown(true);
+        }}
+        style={{
+          width: '100%',
+          padding: '0.35rem 0.5rem',
+          border: '1px solid #ddd',
+          borderRadius: '4px',
+          fontSize: '0.8rem',
+          boxSizing: 'border-box',
+        }}
+      />
+      {showDropdown && (
+        <div
+          style={{
+            position: 'absolute',
+            left: '0.6rem',
+            right: '0.6rem',
+            top: '100%',
+            background: '#fff',
+            border: '1px solid #ddd',
+            borderRadius: '4px',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            zIndex: 10,
+            maxHeight: '200px',
+            overflow: 'auto',
+          }}
+        >
+          {results.map((r) => (
+            <div
+              key={r.id}
+              onClick={() => handleSelectExisting(r)}
+              style={{
+                padding: '0.4rem 0.6rem',
+                cursor: 'pointer',
+                fontSize: '0.8rem',
+                borderBottom: '1px solid #f0f0f0',
+              }}
+            >
+              <span style={{ fontWeight: 500 }}>{r.name}</span>
+              <span style={{ color: '#888', marginLeft: '0.5rem' }}>
+                {r.gender} — {r.id}
+              </span>
+            </div>
+          ))}
+          {query.trim() && (
+            <div
+              onClick={handleCreateNew}
+              style={{
+                padding: '0.4rem 0.6rem',
+                cursor: 'pointer',
+                fontSize: '0.8rem',
+                color: '#4a90d9',
+                fontWeight: 500,
+              }}
+            >
+              Create &quot;{query.trim()}&quot;
+            </div>
+          )}
+          {isSearching && (
+            <div style={{ padding: '0.4rem 0.6rem', fontSize: '0.8rem', color: '#888' }}>
+              Searching...
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workspace/PersonSlot.tsx
+++ b/src/components/workspace/PersonSlot.tsx
@@ -38,8 +38,10 @@ export function PersonSlot({
   const [isSearching, setIsSearching] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const requestSeqRef = useRef(0);
 
   const doSearch = useCallback(async (q: string) => {
+    const requestId = ++requestSeqRef.current;
     if (q.trim().length < 2) {
       setResults([]);
       return;
@@ -54,10 +56,18 @@ export function PersonSlot({
         name: formatName(names[i]).full,
         gender: ind.gender,
       }));
-      setResults(searchResults);
-      setShowDropdown(true);
+      if (requestId === requestSeqRef.current) {
+        setResults(searchResults);
+        setShowDropdown(true);
+      }
+    } catch {
+      if (requestId === requestSeqRef.current) {
+        setResults([]);
+      }
     } finally {
-      setIsSearching(false);
+      if (requestId === requestSeqRef.current) {
+        setIsSearching(false);
+      }
     }
   }, []);
 
@@ -65,7 +75,9 @@ export function PersonSlot({
     const val = e.target.value;
     setQuery(val);
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => doSearch(val), 300);
+    debounceRef.current = setTimeout(() => {
+      void doSearch(val);
+    }, 300);
   }
 
   function handleSelectExisting(result: SearchResult) {

--- a/src/components/workspace/PersonSlot.tsx
+++ b/src/components/workspace/PersonSlot.tsx
@@ -47,12 +47,13 @@ export function PersonSlot({
     setIsSearching(true);
     try {
       const individuals = await searchIndividuals(q);
-      const searchResults: SearchResult[] = [];
-      for (const ind of individuals.slice(0, 8)) {
-        const name = await getPrimaryName(ind.id);
-        const formatted = formatName(name);
-        searchResults.push({ id: ind.id, name: formatted.full, gender: ind.gender });
-      }
+      const top = individuals.slice(0, 8);
+      const names = await Promise.all(top.map((ind) => getPrimaryName(ind.id)));
+      const searchResults = top.map((ind, i) => ({
+        id: ind.id,
+        name: formatName(names[i]).full,
+        gender: ind.gender,
+      }));
       setResults(searchResults);
       setShowDropdown(true);
     } finally {
@@ -88,7 +89,6 @@ export function PersonSlot({
     onChange(null);
   }
 
-  // Close dropdown on outside click
   useEffect(() => {
     function handleClick(e: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
@@ -99,7 +99,12 @@ export function PersonSlot({
     return () => document.removeEventListener('mousedown', handleClick);
   }, []);
 
-  // Filled state
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
   if (value) {
     return (
       <div
@@ -140,7 +145,6 @@ export function PersonSlot({
     );
   }
 
-  // Empty state
   return (
     <div
       ref={containerRef}

--- a/src/components/workspace/PlaceAutocomplete.tsx
+++ b/src/components/workspace/PlaceAutocomplete.tsx
@@ -24,6 +24,7 @@ export function PlaceAutocomplete({ value, onChange }: PlaceAutocompleteProps): 
     const requestId = ++requestSeqRef.current;
     if (q.trim().length < 2) {
       setResults([]);
+      setShowDropdown(false);
       return;
     }
     try {

--- a/src/components/workspace/PlaceAutocomplete.tsx
+++ b/src/components/workspace/PlaceAutocomplete.tsx
@@ -46,6 +46,12 @@ export function PlaceAutocomplete({ value, onChange }: PlaceAutocompleteProps): 
     return () => document.removeEventListener('mousedown', handleClick);
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
   if (value) {
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>

--- a/src/components/workspace/PlaceAutocomplete.tsx
+++ b/src/components/workspace/PlaceAutocomplete.tsx
@@ -18,22 +18,34 @@ export function PlaceAutocomplete({ value, onChange }: PlaceAutocompleteProps): 
   const [showDropdown, setShowDropdown] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const requestSeqRef = useRef(0);
 
   const doSearch = useCallback(async (q: string) => {
+    const requestId = ++requestSeqRef.current;
     if (q.trim().length < 2) {
       setResults([]);
       return;
     }
-    const places = await searchPlaces(q);
-    setResults(places.slice(0, 8).map((p) => ({ id: p.id, name: p.name })));
-    setShowDropdown(true);
+    try {
+      const places = await searchPlaces(q);
+      if (requestId === requestSeqRef.current) {
+        setResults(places.slice(0, 8).map((p) => ({ id: p.id, name: p.name })));
+        setShowDropdown(true);
+      }
+    } catch {
+      if (requestId === requestSeqRef.current) {
+        setResults([]);
+      }
+    }
   }, []);
 
   function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
     const val = e.target.value;
     setQuery(val);
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => doSearch(val), 300);
+    debounceRef.current = setTimeout(() => {
+      void doSearch(val);
+    }, 300);
   }
 
   useEffect(() => {
@@ -56,12 +68,21 @@ export function PlaceAutocomplete({ value, onChange }: PlaceAutocompleteProps): 
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
         <span style={{ fontSize: '0.8rem' }}>{value.name}</span>
-        <span
+        <button
+          type="button"
+          aria-label="Clear place"
           onClick={() => onChange(null)}
-          style={{ fontSize: '0.7rem', color: '#c00', cursor: 'pointer' }}
+          style={{
+            fontSize: '0.7rem',
+            color: '#c00',
+            cursor: 'pointer',
+            background: 'none',
+            border: 'none',
+            padding: 0,
+          }}
         >
           {'\u2715'}
-        </span>
+        </button>
       </div>
     );
   }
@@ -102,7 +123,8 @@ export function PlaceAutocomplete({ value, onChange }: PlaceAutocompleteProps): 
           }}
         >
           {results.map((r) => (
-            <div
+            <button
+              type="button"
               key={r.id}
               onClick={() => {
                 onChange({ type: 'existing', id: r.id, name: r.name });
@@ -110,32 +132,46 @@ export function PlaceAutocomplete({ value, onChange }: PlaceAutocompleteProps): 
                 setShowDropdown(false);
               }}
               style={{
+                display: 'block',
+                width: '100%',
+                textAlign: 'left',
                 padding: '0.4rem 0.6rem',
                 cursor: 'pointer',
                 fontSize: '0.8rem',
                 borderBottom: '1px solid #f0f0f0',
+                background: 'none',
+                border: 'none',
+                borderTop: 'none',
+                borderLeft: 'none',
+                borderRight: 'none',
               }}
             >
               {r.name}
-            </div>
+            </button>
           ))}
           {query.trim() && (
-            <div
+            <button
+              type="button"
               onClick={() => {
                 onChange({ type: 'new', name: query.trim() });
                 setQuery('');
                 setShowDropdown(false);
               }}
               style={{
+                display: 'block',
+                width: '100%',
+                textAlign: 'left',
                 padding: '0.4rem 0.6rem',
                 cursor: 'pointer',
                 fontSize: '0.8rem',
                 color: '#4a90d9',
                 fontWeight: 500,
+                background: 'none',
+                border: 'none',
               }}
             >
               Create &quot;{query.trim()}&quot;
-            </div>
+            </button>
           )}
         </div>
       )}

--- a/src/components/workspace/PlaceAutocomplete.tsx
+++ b/src/components/workspace/PlaceAutocomplete.tsx
@@ -1,0 +1,138 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { searchPlaces } from '$db-tree/places';
+
+export interface PlaceValue {
+  type: 'existing' | 'new';
+  id?: string;
+  name: string;
+}
+
+interface PlaceAutocompleteProps {
+  value?: PlaceValue | null;
+  onChange: (value: PlaceValue | null) => void;
+}
+
+export function PlaceAutocomplete({ value, onChange }: PlaceAutocompleteProps): JSX.Element {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<{ id: string; name: string }[]>([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const doSearch = useCallback(async (q: string) => {
+    if (q.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+    const places = await searchPlaces(q);
+    setResults(places.slice(0, 8).map((p) => ({ id: p.id, name: p.name })));
+    setShowDropdown(true);
+  }, []);
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const val = e.target.value;
+    setQuery(val);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => doSearch(val), 300);
+  }
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowDropdown(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  if (value) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <span style={{ fontSize: '0.8rem' }}>{value.name}</span>
+        <span
+          onClick={() => onChange(null)}
+          style={{ fontSize: '0.7rem', color: '#c00', cursor: 'pointer' }}
+        >
+          {'\u2715'}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative' }}>
+      <input
+        type="text"
+        placeholder="Search or type place..."
+        value={query}
+        onChange={handleInputChange}
+        onFocus={() => {
+          if (results.length > 0) setShowDropdown(true);
+        }}
+        style={{
+          width: '100%',
+          padding: '0.3rem 0.5rem',
+          border: '1px solid #ddd',
+          borderRadius: '4px',
+          fontSize: '0.8rem',
+          boxSizing: 'border-box',
+        }}
+      />
+      {showDropdown && (
+        <div
+          style={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            top: '100%',
+            background: '#fff',
+            border: '1px solid #ddd',
+            borderRadius: '4px',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            zIndex: 10,
+            maxHeight: '150px',
+            overflow: 'auto',
+          }}
+        >
+          {results.map((r) => (
+            <div
+              key={r.id}
+              onClick={() => {
+                onChange({ type: 'existing', id: r.id, name: r.name });
+                setQuery('');
+                setShowDropdown(false);
+              }}
+              style={{
+                padding: '0.4rem 0.6rem',
+                cursor: 'pointer',
+                fontSize: '0.8rem',
+                borderBottom: '1px solid #f0f0f0',
+              }}
+            >
+              {r.name}
+            </div>
+          ))}
+          {query.trim() && (
+            <div
+              onClick={() => {
+                onChange({ type: 'new', name: query.trim() });
+                setQuery('');
+                setShowDropdown(false);
+              }}
+              style={{
+                padding: '0.4rem 0.6rem',
+                cursor: 'pointer',
+                fontSize: '0.8rem',
+                color: '#4a90d9',
+                fontWeight: 500,
+              }}
+            >
+              Create &quot;{query.trim()}&quot;
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workspace/PlaceAutocomplete.tsx
+++ b/src/components/workspace/PlaceAutocomplete.tsx
@@ -138,12 +138,11 @@ export function PlaceAutocomplete({ value, onChange }: PlaceAutocompleteProps): 
                 padding: '0.4rem 0.6rem',
                 cursor: 'pointer',
                 fontSize: '0.8rem',
-                borderBottom: '1px solid #f0f0f0',
                 background: 'none',
-                border: 'none',
                 borderTop: 'none',
                 borderLeft: 'none',
                 borderRight: 'none',
+                borderBottom: '1px solid #f0f0f0',
               }}
             >
               {r.name}

--- a/src/components/workspace/RightPanel.tsx
+++ b/src/components/workspace/RightPanel.tsx
@@ -85,7 +85,10 @@ export function RightPanel({ sourceId }: RightPanelProps): JSX.Element {
     const hasFilled = Object.values(slotValues).some(
       (v) => v !== null && (!Array.isArray(v) || v.length > 0)
     );
-    if (hasFilled && !window.confirm('Changing the template will clear all filled slots. Continue?')) {
+    if (
+      hasFilled &&
+      !window.confirm('Changing the template will clear all filled slots. Continue?')
+    ) {
       return;
     }
     setTemplateId(newId);
@@ -128,12 +131,7 @@ export function RightPanel({ sourceId }: RightPanelProps): JSX.Element {
             onChange={handleSlotChange}
             onAddMultiple={handleAddMultiple}
           />
-          <EventDetails
-            date={date}
-            place={place}
-            onDateChange={setDate}
-            onPlaceChange={setPlace}
-          />
+          <EventDetails date={date} place={place} onDateChange={setDate} onPlaceChange={setPlace} />
           <FreeFormAdd values={freeFormValues} onChange={setFreeFormValues} />
           <CreateEventButton
             template={template}

--- a/src/components/workspace/RightPanel.tsx
+++ b/src/components/workspace/RightPanel.tsx
@@ -33,7 +33,6 @@ export function RightPanel({ sourceId }: RightPanelProps): JSX.Element {
     mutationFn: async () => {
       if (!template) throw new Error('No template selected');
 
-      // Build slot values for manager
       const slots: SlotValue[] = [];
 
       for (const slot of template.slots) {
@@ -47,7 +46,6 @@ export function RightPanel({ sourceId }: RightPanelProps): JSX.Element {
         }
       }
 
-      // Free-form
       for (let i = 0; i < freeFormValues.length; i++) {
         slots.push(personSlotToSlotValue(`freeform_${i}`, freeFormValues[i]));
       }
@@ -62,7 +60,6 @@ export function RightPanel({ sourceId }: RightPanelProps): JSX.Element {
       });
     },
     onSuccess: (result) => {
-      // Clear form
       setSlotValues({});
       setDate('');
       setPlace(null);
@@ -72,7 +69,6 @@ export function RightPanel({ sourceId }: RightPanelProps): JSX.Element {
       );
       setTimeout(() => setSuccessMessage(null), 4000);
 
-      // Invalidate queries
       void queryClient.invalidateQueries({ queryKey: queryKeys.citationsWithDetails(sourceId) });
       void queryClient.invalidateQueries({ queryKey: queryKeys.citations(sourceId) });
       void queryClient.invalidateQueries({ queryKey: queryKeys.individuals });
@@ -115,22 +111,13 @@ export function RightPanel({ sourceId }: RightPanelProps): JSX.Element {
     [template]
   );
 
-  const handleAddMultiple = useCallback(() => {
-    // No-op — adding is handled by handleSlotChange with index
-  }, []);
-
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <EventTypeSelector value={templateId} onChange={handleTemplateChange} />
 
       {template && (
         <>
-          <TemplateSlots
-            template={template}
-            values={slotValues}
-            onChange={handleSlotChange}
-            onAddMultiple={handleAddMultiple}
-          />
+          <TemplateSlots template={template} values={slotValues} onChange={handleSlotChange} />
           <EventDetails date={date} place={place} onDateChange={setDate} onPlaceChange={setPlace} />
           <FreeFormAdd values={freeFormValues} onChange={setFreeFormValues} />
           <CreateEventButton

--- a/src/components/workspace/RightPanel.tsx
+++ b/src/components/workspace/RightPanel.tsx
@@ -1,0 +1,185 @@
+import { useState, useCallback } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { EventTypeSelector } from './EventTypeSelector';
+import { TemplateSlots } from './TemplateSlots';
+import { EventDetails } from './EventDetails';
+import { CreateEventButton } from './CreateEventButton';
+import { FreeFormAdd } from './FreeFormAdd';
+import { getTemplateById } from '$/lib/templates';
+import { SourceWorkspaceManager } from '$/managers/SourceWorkspaceManager';
+import { queryKeys } from '$/lib/query-keys';
+import type { PersonSlotValue } from './PersonSlot';
+import type { PlaceValue } from './PlaceAutocomplete';
+import type { SlotValue } from '$/managers/SourceWorkspaceManager';
+
+interface RightPanelProps {
+  sourceId: string;
+}
+
+export function RightPanel({ sourceId }: RightPanelProps): JSX.Element {
+  const queryClient = useQueryClient();
+  const [templateId, setTemplateId] = useState('');
+  const [slotValues, setSlotValues] = useState<
+    Record<string, PersonSlotValue | PersonSlotValue[] | null>
+  >({});
+  const [date, setDate] = useState('');
+  const [place, setPlace] = useState<PlaceValue | null>(null);
+  const [freeFormValues, setFreeFormValues] = useState<PersonSlotValue[]>([]);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const template = templateId ? getTemplateById(templateId) : null;
+
+  const { mutate: submit, isPending } = useMutation({
+    mutationFn: async () => {
+      if (!template) throw new Error('No template selected');
+
+      // Build slot values for manager
+      const slots: SlotValue[] = [];
+
+      for (const slot of template.slots) {
+        const val = slotValues[slot.key];
+        if (slot.multiple && Array.isArray(val)) {
+          for (const v of val) {
+            slots.push(personSlotToSlotValue(slot.key, v));
+          }
+        } else if (val && !Array.isArray(val)) {
+          slots.push(personSlotToSlotValue(slot.key, val));
+        }
+      }
+
+      // Free-form
+      for (let i = 0; i < freeFormValues.length; i++) {
+        slots.push(personSlotToSlotValue(`freeform_${i}`, freeFormValues[i]));
+      }
+
+      return SourceWorkspaceManager.createFromTemplate({
+        sourceId,
+        templateId: template.id,
+        slots,
+        date: date || undefined,
+        place: place?.type === 'new' ? place.name : undefined,
+        existingPlaceId: place?.type === 'existing' ? place.id : undefined,
+      });
+    },
+    onSuccess: (result) => {
+      // Clear form
+      setSlotValues({});
+      setDate('');
+      setPlace(null);
+      setFreeFormValues([]);
+      setSuccessMessage(
+        `Created${result.eventId ? ' event' : ''}: ${result.createdIndividuals.length} individual(s), ${result.createdFamilies.length} family(ies), 1 citation`
+      );
+      setTimeout(() => setSuccessMessage(null), 4000);
+
+      // Invalidate queries
+      void queryClient.invalidateQueries({ queryKey: queryKeys.citationsWithDetails(sourceId) });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.citations(sourceId) });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.individuals });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.families });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.events });
+    },
+  });
+
+  function handleTemplateChange(newId: string) {
+    const hasFilled = Object.values(slotValues).some(
+      (v) => v !== null && (!Array.isArray(v) || v.length > 0)
+    );
+    if (hasFilled && !window.confirm('Changing the template will clear all filled slots. Continue?')) {
+      return;
+    }
+    setTemplateId(newId);
+    setSlotValues({});
+  }
+
+  const handleSlotChange = useCallback(
+    (slotKey: string, value: PersonSlotValue | null, index?: number) => {
+      setSlotValues((prev) => {
+        const slot = template?.slots.find((s) => s.key === slotKey);
+        if (slot?.multiple) {
+          const arr = (prev[slotKey] as PersonSlotValue[] | null) ?? [];
+          const newArr = [...arr];
+          if (value) {
+            newArr[index ?? arr.length] = value;
+          } else if (index !== undefined) {
+            newArr.splice(index, 1);
+          }
+          return { ...prev, [slotKey]: newArr };
+        }
+        return { ...prev, [slotKey]: value };
+      });
+    },
+    [template]
+  );
+
+  const handleAddMultiple = useCallback(() => {
+    // No-op — adding is handled by handleSlotChange with index
+  }, []);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <EventTypeSelector value={templateId} onChange={handleTemplateChange} />
+
+      {template && (
+        <>
+          <TemplateSlots
+            template={template}
+            values={slotValues}
+            onChange={handleSlotChange}
+            onAddMultiple={handleAddMultiple}
+          />
+          <EventDetails
+            date={date}
+            place={place}
+            onDateChange={setDate}
+            onPlaceChange={setPlace}
+          />
+          <FreeFormAdd values={freeFormValues} onChange={setFreeFormValues} />
+          <CreateEventButton
+            template={template}
+            slotValues={slotValues}
+            freeFormValues={freeFormValues}
+            isPending={isPending}
+            onSubmit={() => submit()}
+          />
+        </>
+      )}
+
+      {successMessage && (
+        <div
+          style={{
+            margin: '0 1rem',
+            padding: '0.5rem',
+            background: '#e8f5e9',
+            borderRadius: '4px',
+            fontSize: '0.8rem',
+            color: '#2e7d32',
+            textAlign: 'center',
+          }}
+        >
+          {successMessage}
+        </div>
+      )}
+
+      {!template && (
+        <div
+          style={{
+            padding: '2rem 1rem',
+            textAlign: 'center',
+            color: '#888',
+            fontSize: '0.85rem',
+          }}
+        >
+          Select a document type above to begin.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function personSlotToSlotValue(slotKey: string, psv: PersonSlotValue): SlotValue {
+  if (psv.type === 'existing') {
+    return { slotKey, existingId: psv.id };
+  }
+  return { slotKey, newName: psv.newName, newGender: psv.newGender };
+}

--- a/src/components/workspace/TemplateSlots.tsx
+++ b/src/components/workspace/TemplateSlots.tsx
@@ -1,0 +1,59 @@
+import { PersonSlot, type PersonSlotValue } from './PersonSlot';
+import type { TemplateDefinition } from '$/lib/templates';
+
+interface TemplateSlotsProps {
+  template: TemplateDefinition;
+  values: Record<string, PersonSlotValue | PersonSlotValue[] | null>;
+  onChange: (slotKey: string, value: PersonSlotValue | null, index?: number) => void;
+  onAddMultiple: (slotKey: string) => void;
+}
+
+export function TemplateSlots({
+  template,
+  values,
+  onChange,
+  onAddMultiple,
+}: TemplateSlotsProps): JSX.Element {
+  return (
+    <div style={{ padding: '0.75rem 1rem' }}>
+      {template.slots.map((slot) => {
+        if (slot.multiple) {
+          const entries = (values[slot.key] as PersonSlotValue[] | null) ?? [];
+          return (
+            <div key={slot.key}>
+              {entries.map((entry, index) => (
+                <PersonSlot
+                  key={`${slot.key}-${index}`}
+                  label={`${slot.label} ${index + 1}`}
+                  value={entry}
+                  defaultGender={slot.gender}
+                  onChange={(val) => onChange(slot.key, val, index)}
+                />
+              ))}
+              <PersonSlot
+                key={`${slot.key}-new`}
+                label={entries.length === 0 ? slot.label : `${slot.label} ${entries.length + 1}`}
+                defaultGender={slot.gender}
+                onChange={(val) => {
+                  if (val) onAddMultiple(slot.key);
+                  onChange(slot.key, val, entries.length);
+                }}
+              />
+            </div>
+          );
+        }
+
+        return (
+          <PersonSlot
+            key={slot.key}
+            label={slot.label}
+            value={values[slot.key] as PersonSlotValue | null}
+            defaultGender={slot.gender}
+            required={slot.required}
+            onChange={(val) => onChange(slot.key, val)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/workspace/TemplateSlots.tsx
+++ b/src/components/workspace/TemplateSlots.tsx
@@ -5,15 +5,9 @@ interface TemplateSlotsProps {
   template: TemplateDefinition;
   values: Record<string, PersonSlotValue | PersonSlotValue[] | null>;
   onChange: (slotKey: string, value: PersonSlotValue | null, index?: number) => void;
-  onAddMultiple: (slotKey: string) => void;
 }
 
-export function TemplateSlots({
-  template,
-  values,
-  onChange,
-  onAddMultiple,
-}: TemplateSlotsProps): JSX.Element {
+export function TemplateSlots({ template, values, onChange }: TemplateSlotsProps): JSX.Element {
   return (
     <div style={{ padding: '0.75rem 1rem' }}>
       {template.slots.map((slot) => {
@@ -34,10 +28,7 @@ export function TemplateSlots({
                 key={`${slot.key}-new`}
                 label={entries.length === 0 ? slot.label : `${slot.label} ${entries.length + 1}`}
                 defaultGender={slot.gender}
-                onChange={(val) => {
-                  if (val) onAddMultiple(slot.key);
-                  onChange(slot.key, val, entries.length);
-                }}
+                onChange={(val) => onChange(slot.key, val, entries.length)}
               />
             </div>
           );

--- a/src/components/workspace/WorkspaceHeader.tsx
+++ b/src/components/workspace/WorkspaceHeader.tsx
@@ -1,0 +1,44 @@
+import { Link } from '@tanstack/react-router';
+import type { Source } from '$/types/database';
+
+interface WorkspaceHeaderProps {
+  treeId: string;
+  sourceId: string;
+  source: Source;
+}
+
+export function WorkspaceHeader({ treeId, sourceId, source }: WorkspaceHeaderProps): JSX.Element {
+  return (
+    <div
+      style={{
+        padding: '0.75rem 1rem',
+        borderBottom: '2px solid #ddd',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}
+    >
+      <div>
+        <div style={{ fontWeight: 700, fontSize: '1rem' }}>{source.title}</div>
+        <div style={{ fontSize: '0.8rem', color: '#666', marginTop: '2px' }}>
+          {sourceId}
+          {source.author && <> &middot; {source.author}</>}
+        </div>
+      </div>
+      <Link
+        to="/tree/$treeId/source/$sourceId"
+        params={{ treeId, sourceId }}
+        style={{
+          padding: '0.3rem 0.6rem',
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          fontSize: '0.85rem',
+          textDecoration: 'none',
+          color: '#333',
+        }}
+      >
+        &larr; Back
+      </Link>
+    </div>
+  );
+}

--- a/src/components/workspace/WorkspaceLayout.tsx
+++ b/src/components/workspace/WorkspaceLayout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+interface WorkspaceLayoutProps {
+  left: ReactNode;
+  right: ReactNode;
+}
+
+export function WorkspaceLayout({ left, right }: WorkspaceLayoutProps): JSX.Element {
+  return (
+    <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+      <div style={{ flex: 1, overflow: 'auto', borderRight: '2px solid #ddd' }}>{left}</div>
+      <div style={{ width: '400px', overflow: 'auto', background: '#fafafa' }}>{right}</div>
+    </div>
+  );
+}

--- a/src/db/trees/citations-with-details.test.ts
+++ b/src/db/trees/citations-with-details.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTreeInMemoryDb } from '$/test/sqlite-memory';
+import { getCitationDetailsForSource } from './citations-with-details';
+import { createSource } from './sources';
+import { SourceWorkspaceManager } from '$/managers/SourceWorkspaceManager';
+
+// A single in-memory DB shared across all tests in this file.
+const db = createTreeInMemoryDb();
+
+vi.mock('../connection', () => ({
+  getTreeDb: vi.fn(),
+}));
+
+// Lazily resolve the mock after the module is loaded
+import('../connection').then(({ getTreeDb }) => {
+  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+});
+
+beforeEach(async () => {
+  const { getTreeDb } = await import('../connection');
+  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  db._raw.exec('DELETE FROM citation_links');
+  db._raw.exec('DELETE FROM source_citations');
+  db._raw.exec('DELETE FROM event_participants');
+  db._raw.exec('DELETE FROM events');
+  db._raw.exec('DELETE FROM family_members');
+  db._raw.exec('DELETE FROM families');
+  db._raw.exec('DELETE FROM names');
+  db._raw.exec('DELETE FROM individuals');
+  db._raw.exec('DELETE FROM sources');
+  db._raw.exec('DELETE FROM places');
+});
+
+describe('getCitationDetailsForSource', () => {
+  it('returns empty array for source with no citations', async () => {
+    const sourceId = await createSource({ title: 'Empty Source' });
+    const details = await getCitationDetailsForSource(sourceId);
+    expect(details).toHaveLength(0);
+  });
+
+  it('returns citation details with event and individuals', async () => {
+    const sourceId = await createSource({ title: 'Marriage Certificate' });
+    await SourceWorkspaceManager.createFromTemplate({
+      sourceId,
+      templateId: 'marriage',
+      slots: [
+        { slotKey: 'husband', newName: 'Joseph Dupont', newGender: 'M' },
+        { slotKey: 'wife', newName: 'Marie Tremblay', newGender: 'F' },
+      ],
+      date: '15 Jun 1892',
+      citationPage: 'p. 42',
+    });
+
+    const details = await getCitationDetailsForSource(sourceId);
+    expect(details).toHaveLength(1);
+    expect(details[0].page).toBe('p. 42');
+    expect(details[0].eventTypeName).toBeTruthy();
+    expect(details[0].eventDate).toBe('15 Jun 1892');
+    expect(details[0].linkedIndividuals).toHaveLength(2);
+  });
+
+  it('includes the formatted event ID', async () => {
+    const sourceId = await createSource({ title: 'Birth Record' });
+    await SourceWorkspaceManager.createFromTemplate({
+      sourceId,
+      templateId: 'birth',
+      slots: [{ slotKey: 'individual', newName: 'Jean Martin', newGender: 'M' }],
+      date: '3 Mar 1870',
+      citationPage: 'folio 7',
+    });
+
+    const details = await getCitationDetailsForSource(sourceId);
+    expect(details).toHaveLength(1);
+    expect(details[0].eventId).toMatch(/^E-\d{4}$/);
+    expect(details[0].citationId).toBeTruthy();
+  });
+
+  it('returns correct individual names', async () => {
+    const sourceId = await createSource({ title: 'Marriage Certificate' });
+    await SourceWorkspaceManager.createFromTemplate({
+      sourceId,
+      templateId: 'marriage',
+      slots: [
+        { slotKey: 'husband', newName: 'Joseph Dupont', newGender: 'M' },
+        { slotKey: 'wife', newName: 'Marie Tremblay', newGender: 'F' },
+      ],
+      date: '15 Jun 1892',
+    });
+
+    const details = await getCitationDetailsForSource(sourceId);
+    const names = details[0].linkedIndividuals.map((i) => i.name).sort();
+    expect(names).toContain('Joseph Dupont');
+    expect(names).toContain('Marie Tremblay');
+  });
+
+  it('returns null event fields for citations with no event link', async () => {
+    const sourceId = await createSource({ title: 'Standalone Source' });
+    // Create a citation manually (no event link)
+    const { createCitation } = await import('./citations');
+    await createCitation({ sourceId, page: 'p. 1' });
+
+    const details = await getCitationDetailsForSource(sourceId);
+    expect(details).toHaveLength(1);
+    expect(details[0].eventId).toBeNull();
+    expect(details[0].eventTypeName).toBeNull();
+    expect(details[0].eventDate).toBeNull();
+    expect(details[0].linkedIndividuals).toHaveLength(0);
+  });
+
+  it('handles multiple citations for the same source independently', async () => {
+    const sourceId = await createSource({ title: 'Parish Register' });
+
+    await SourceWorkspaceManager.createFromTemplate({
+      sourceId,
+      templateId: 'marriage',
+      slots: [
+        { slotKey: 'husband', newName: 'Pierre Lefebvre', newGender: 'M' },
+        { slotKey: 'wife', newName: 'Anne Bouchard', newGender: 'F' },
+      ],
+      date: '12 Apr 1880',
+      citationPage: 'p. 10',
+    });
+
+    await SourceWorkspaceManager.createFromTemplate({
+      sourceId,
+      templateId: 'marriage',
+      slots: [
+        { slotKey: 'husband', newName: 'Louis Bernard', newGender: 'M' },
+        { slotKey: 'wife', newName: 'Claire Morin', newGender: 'F' },
+      ],
+      date: '5 May 1882',
+      citationPage: 'p. 15',
+    });
+
+    const details = await getCitationDetailsForSource(sourceId);
+    expect(details).toHaveLength(2);
+
+    const pages = details.map((d) => d.page).sort();
+    expect(pages).toEqual(['p. 10', 'p. 15']);
+
+    for (const detail of details) {
+      expect(detail.linkedIndividuals).toHaveLength(2);
+    }
+  });
+});

--- a/src/db/trees/citations-with-details.ts
+++ b/src/db/trees/citations-with-details.ts
@@ -106,7 +106,12 @@ export async function getCitationDetailsForSource(sourceId: string): Promise<Cit
     );
 
     const rawParticipants = await db.select<
-      { event_id: number; individual_id: number; given_names: string | null; surname: string | null }[]
+      {
+        event_id: number;
+        individual_id: number;
+        given_names: string | null;
+        surname: string | null;
+      }[]
     >(
       `SELECT
          ep.event_id                            AS event_id,

--- a/src/db/trees/citations-with-details.ts
+++ b/src/db/trees/citations-with-details.ts
@@ -1,0 +1,168 @@
+import { getTreeDb } from '../connection';
+import { formatEntityId, parseEntityId } from '$/lib/entityId';
+import type { CitationDetail } from '$/types/database';
+
+// =============================================================================
+// Raw database row types (snake_case as in SQLite)
+// =============================================================================
+
+interface RawCitationRow {
+  citation_id: number;
+  page: string | null;
+  event_id: number | null;
+  event_type_name: string | null;
+  event_date: string | null;
+}
+
+interface RawIndividualRow {
+  citation_id: number;
+  individual_id: number;
+  given_names: string | null;
+  surname: string | null;
+}
+
+// =============================================================================
+// Query
+// =============================================================================
+
+/**
+ * Get citation details for a source.
+ *
+ * Returns one CitationDetail per citation, with event info and all linked
+ * individuals (aggregated from event_participants and direct citation_links).
+ * Individuals linked via both routes are deduplicated.
+ */
+export async function getCitationDetailsForSource(sourceId: string): Promise<CitationDetail[]> {
+  const db = await getTreeDb();
+  const sourceDbId = parseEntityId(sourceId);
+
+  // Step 1: get all citations for this source, with optional event details
+  // A citation may link to an event via citation_links (entity_type = 'event').
+  // COALESCE(et.custom_name, et.tag) gives the human-readable event type name
+  // for both system types (tag non-null, custom_name null) and
+  // custom types (custom_name non-null, tag null).
+  const citationRows = await db.select<RawCitationRow[]>(
+    `SELECT
+       sc.id                                    AS citation_id,
+       sc.page                                  AS page,
+       e.id                                     AS event_id,
+       COALESCE(et.custom_name, et.tag)         AS event_type_name,
+       e.date_original                          AS event_date
+     FROM source_citations sc
+     LEFT JOIN citation_links cl_event
+       ON cl_event.citation_id = sc.id
+       AND cl_event.entity_type = 'event'
+     LEFT JOIN events e
+       ON e.id = cl_event.entity_id
+     LEFT JOIN event_types et
+       ON et.id = e.event_type_id
+     WHERE sc.source_id = $1
+     ORDER BY sc.id`,
+    [sourceDbId]
+  );
+
+  if (citationRows.length === 0) {
+    return [];
+  }
+
+  const citationDbIds = citationRows.map((r) => r.citation_id);
+
+  // Step 2: collect all individuals linked to these citations.
+  // An individual can be linked via:
+  //   (a) a direct citation_link of entity_type = 'individual', or
+  //   (b) event_participants for the event linked to the citation.
+  // We gather both sets and deduplicate per citation.
+
+  // (a) Direct individual links
+  const directRows = await db.select<RawIndividualRow[]>(
+    `SELECT
+       cl.citation_id                           AS citation_id,
+       i.id                                     AS individual_id,
+       n.given_names                            AS given_names,
+       n.surname                                AS surname
+     FROM citation_links cl
+     JOIN individuals i
+       ON i.id = cl.entity_id
+     LEFT JOIN names n
+       ON n.individual_id = i.id
+       AND n.is_primary = 1
+     WHERE cl.citation_id IN (${citationDbIds.map((_, idx) => `$${idx + 1}`).join(', ')})
+       AND cl.entity_type = 'individual'
+     ORDER BY cl.citation_id, i.id`,
+    citationDbIds
+  );
+
+  // (b) Individuals linked via the event (event_participants)
+  // Only for citations that have an event link
+  const eventLinkedCitations = citationRows.filter((r) => r.event_id !== null);
+  let participantRows: RawIndividualRow[] = [];
+
+  if (eventLinkedCitations.length > 0) {
+    // Build a mapping: event_id → citation_id (we know there is at most one
+    // event per citation from the query above)
+    const eventIds = eventLinkedCitations.map((r) => r.event_id as number);
+    const eventIdToCitationId = new Map<number, number>(
+      eventLinkedCitations.map((r) => [r.event_id as number, r.citation_id])
+    );
+
+    const rawParticipants = await db.select<
+      { event_id: number; individual_id: number; given_names: string | null; surname: string | null }[]
+    >(
+      `SELECT
+         ep.event_id                            AS event_id,
+         i.id                                   AS individual_id,
+         n.given_names                          AS given_names,
+         n.surname                              AS surname
+       FROM event_participants ep
+       JOIN individuals i
+         ON i.id = ep.individual_id
+       LEFT JOIN names n
+         ON n.individual_id = i.id
+         AND n.is_primary = 1
+       WHERE ep.event_id IN (${eventIds.map((_, idx) => `$${idx + 1}`).join(', ')})
+         AND ep.individual_id IS NOT NULL
+       ORDER BY ep.event_id, i.id`,
+      eventIds
+    );
+
+    participantRows = rawParticipants.map((r) => ({
+      citation_id: eventIdToCitationId.get(r.event_id)!,
+      individual_id: r.individual_id,
+      given_names: r.given_names,
+      surname: r.surname,
+    }));
+  }
+
+  // Step 3: merge and deduplicate individuals per citation
+  const individualsByCitation = new Map<number, Map<number, { id: string; name: string }>>();
+
+  for (const row of [...directRows, ...participantRows]) {
+    if (!individualsByCitation.has(row.citation_id)) {
+      individualsByCitation.set(row.citation_id, new Map());
+    }
+    const map = individualsByCitation.get(row.citation_id)!;
+    if (!map.has(row.individual_id)) {
+      const parts = [row.given_names, row.surname].filter(Boolean);
+      const name = parts.length > 0 ? parts.join(' ') : 'Unknown';
+      map.set(row.individual_id, {
+        id: formatEntityId('I', row.individual_id),
+        name,
+      });
+    }
+  }
+
+  // Step 4: assemble the final result
+  return citationRows.map((row): CitationDetail => {
+    const individualsMap = individualsByCitation.get(row.citation_id);
+    const linkedIndividuals = individualsMap ? [...individualsMap.values()] : [];
+
+    return {
+      citationId: String(row.citation_id),
+      page: row.page,
+      eventId: row.event_id !== null ? formatEntityId('E', row.event_id) : null,
+      eventTypeName: row.event_type_name,
+      eventDate: row.event_date,
+      linkedIndividuals,
+    };
+  });
+}

--- a/src/hooks/useCitationsWithDetails.ts
+++ b/src/hooks/useCitationsWithDetails.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '$lib/query-keys';
+import { getCitationDetailsForSource } from '$db-tree/citations-with-details';
+
+export function useCitationsWithDetails(sourceId: string) {
+  return useQuery({
+    queryKey: queryKeys.citationsWithDetails(sourceId),
+    queryFn: () => getCitationDetailsForSource(sourceId),
+  });
+}

--- a/src/lib/__snapshots__/templates.test.ts.snap
+++ b/src/lib/__snapshots__/templates.test.ts.snap
@@ -1,0 +1,303 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`templates > all templates match snapshot 1`] = `
+[
+  {
+    "eventTypeTag": "MARR",
+    "families": [
+      {
+        "members": [
+          {
+            "role": "husband",
+            "slot": "husband",
+          },
+          {
+            "role": "wife",
+            "slot": "wife",
+          },
+        ],
+        "type": "couple",
+      },
+      {
+        "members": [
+          {
+            "role": "husband",
+            "slot": "husband_father",
+          },
+          {
+            "role": "wife",
+            "slot": "husband_mother",
+          },
+          {
+            "role": "child",
+            "slot": "husband",
+          },
+        ],
+        "type": "parent-child",
+      },
+      {
+        "members": [
+          {
+            "role": "husband",
+            "slot": "wife_father",
+          },
+          {
+            "role": "wife",
+            "slot": "wife_mother",
+          },
+          {
+            "role": "child",
+            "slot": "wife",
+          },
+        ],
+        "type": "parent-child",
+      },
+    ],
+    "hasDate": true,
+    "hasPlace": true,
+    "id": "marriage",
+    "label": "Marriage",
+    "slots": [
+      {
+        "gender": "M",
+        "key": "husband",
+        "label": "Husband",
+        "multiple": false,
+        "participantRole": "principal",
+        "required": true,
+      },
+      {
+        "gender": "F",
+        "key": "wife",
+        "label": "Wife",
+        "multiple": false,
+        "participantRole": "principal",
+        "required": true,
+      },
+      {
+        "gender": "M",
+        "key": "husband_father",
+        "label": "Husband's Father",
+        "multiple": false,
+        "required": false,
+      },
+      {
+        "gender": "F",
+        "key": "husband_mother",
+        "label": "Husband's Mother",
+        "multiple": false,
+        "required": false,
+      },
+      {
+        "gender": "M",
+        "key": "wife_father",
+        "label": "Wife's Father",
+        "multiple": false,
+        "required": false,
+      },
+      {
+        "gender": "F",
+        "key": "wife_mother",
+        "label": "Wife's Mother",
+        "multiple": false,
+        "required": false,
+      },
+      {
+        "key": "witness",
+        "label": "Witness",
+        "multiple": true,
+        "participantRole": "witness",
+        "required": false,
+      },
+    ],
+  },
+  {
+    "eventTypeTag": "BAPM",
+    "families": [
+      {
+        "members": [
+          {
+            "role": "husband",
+            "slot": "father",
+          },
+          {
+            "role": "wife",
+            "slot": "mother",
+          },
+          {
+            "role": "child",
+            "slot": "child",
+          },
+        ],
+        "type": "parent-child",
+      },
+    ],
+    "hasDate": true,
+    "hasPlace": true,
+    "id": "baptism",
+    "label": "Baptism",
+    "slots": [
+      {
+        "key": "child",
+        "label": "Child",
+        "multiple": false,
+        "participantRole": "principal",
+        "required": true,
+      },
+      {
+        "gender": "M",
+        "key": "father",
+        "label": "Father",
+        "multiple": false,
+        "required": false,
+      },
+      {
+        "gender": "F",
+        "key": "mother",
+        "label": "Mother",
+        "multiple": false,
+        "required": false,
+      },
+      {
+        "gender": "M",
+        "key": "godfather",
+        "label": "Godfather",
+        "multiple": false,
+        "participantRole": "godparent",
+        "required": false,
+      },
+      {
+        "gender": "F",
+        "key": "godmother",
+        "label": "Godmother",
+        "multiple": false,
+        "participantRole": "godparent",
+        "required": false,
+      },
+    ],
+  },
+  {
+    "eventTypeTag": "BIRT",
+    "families": [
+      {
+        "members": [
+          {
+            "role": "husband",
+            "slot": "father",
+          },
+          {
+            "role": "wife",
+            "slot": "mother",
+          },
+          {
+            "role": "child",
+            "slot": "child",
+          },
+        ],
+        "type": "parent-child",
+      },
+    ],
+    "hasDate": true,
+    "hasPlace": true,
+    "id": "birth",
+    "label": "Birth",
+    "slots": [
+      {
+        "key": "child",
+        "label": "Child",
+        "multiple": false,
+        "participantRole": "principal",
+        "required": true,
+      },
+      {
+        "gender": "M",
+        "key": "father",
+        "label": "Father",
+        "multiple": false,
+        "required": false,
+      },
+      {
+        "gender": "F",
+        "key": "mother",
+        "label": "Mother",
+        "multiple": false,
+        "required": false,
+      },
+    ],
+  },
+  {
+    "eventTypeTag": "DEAT",
+    "families": [],
+    "hasDate": true,
+    "hasPlace": true,
+    "id": "death",
+    "label": "Death",
+    "slots": [
+      {
+        "key": "deceased",
+        "label": "Deceased",
+        "multiple": false,
+        "participantRole": "principal",
+        "required": true,
+      },
+      {
+        "key": "informant",
+        "label": "Informant",
+        "multiple": false,
+        "participantRole": "informant",
+        "required": false,
+      },
+    ],
+  },
+  {
+    "eventTypeTag": "BURI",
+    "families": [],
+    "hasDate": true,
+    "hasPlace": true,
+    "id": "burial",
+    "label": "Burial",
+    "slots": [
+      {
+        "key": "deceased",
+        "label": "Deceased",
+        "multiple": false,
+        "participantRole": "principal",
+        "required": true,
+      },
+    ],
+  },
+  {
+    "eventTypeTag": "CENS",
+    "families": [],
+    "hasDate": true,
+    "hasPlace": true,
+    "id": "census",
+    "label": "Census",
+    "slots": [
+      {
+        "key": "head",
+        "label": "Head of Household",
+        "multiple": false,
+        "participantRole": "principal",
+        "required": true,
+      },
+      {
+        "key": "member",
+        "label": "Member",
+        "multiple": true,
+        "participantRole": "other",
+        "required": false,
+      },
+    ],
+  },
+  {
+    "eventTypeTag": "",
+    "families": [],
+    "hasDate": true,
+    "hasPlace": true,
+    "id": "generic",
+    "label": "Generic",
+    "slots": [],
+  },
+]
+`;

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -19,5 +19,6 @@ export const queryKeys = {
   repositories: ['repositories'] as const,
   repository: (id: string) => ['repositories', id] as const,
   citations: (sourceId: string) => ['citations', sourceId] as const,
+  citationsWithDetails: (sourceId: string) => ['citationsWithDetails', sourceId] as const,
   files: (sourceId: string) => ['files', sourceId] as const,
 };

--- a/src/lib/templates.test.ts
+++ b/src/lib/templates.test.ts
@@ -36,7 +36,7 @@ describe('templates', () => {
   it('family-only slots have no participantRole', () => {
     const marriage = getTemplateById('marriage');
     const familyOnly = marriage!.slots.filter((s) =>
-      ['husband_father', 'husband_mother', 'wife_father', 'wife_mother'].includes(s.key),
+      ['husband_father', 'husband_mother', 'wife_father', 'wife_mother'].includes(s.key)
     );
     for (const slot of familyOnly) {
       expect(slot.participantRole).toBeUndefined();

--- a/src/lib/templates.test.ts
+++ b/src/lib/templates.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { TEMPLATES, getTemplateById } from './templates';
+
+describe('templates', () => {
+  it('exports 7 templates', () => {
+    expect(TEMPLATES).toHaveLength(7);
+  });
+
+  it('each template has a unique id', () => {
+    const ids = TEMPLATES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('marriage template has correct slots', () => {
+    const marriage = getTemplateById('marriage');
+    expect(marriage).toBeDefined();
+    expect(marriage!.slots.map((s) => s.key)).toEqual([
+      'husband',
+      'wife',
+      'husband_father',
+      'husband_mother',
+      'wife_father',
+      'wife_mother',
+      'witness',
+    ]);
+  });
+
+  it('marriage template has 3 family rules', () => {
+    const marriage = getTemplateById('marriage');
+    expect(marriage!.families).toHaveLength(3);
+    expect(marriage!.families[0].type).toBe('couple');
+    expect(marriage!.families[1].type).toBe('parent-child');
+    expect(marriage!.families[2].type).toBe('parent-child');
+  });
+
+  it('family-only slots have no participantRole', () => {
+    const marriage = getTemplateById('marriage');
+    const familyOnly = marriage!.slots.filter((s) =>
+      ['husband_father', 'husband_mother', 'wife_father', 'wife_mother'].includes(s.key),
+    );
+    for (const slot of familyOnly) {
+      expect(slot.participantRole).toBeUndefined();
+    }
+  });
+
+  it('principal slots have participantRole "principal"', () => {
+    const marriage = getTemplateById('marriage');
+    const principals = marriage!.slots.filter((s) => ['husband', 'wife'].includes(s.key));
+    for (const slot of principals) {
+      expect(slot.participantRole).toBe('principal');
+    }
+  });
+
+  it('generic template has empty slots and families', () => {
+    const generic = getTemplateById('generic');
+    expect(generic!.slots).toHaveLength(0);
+    expect(generic!.families).toHaveLength(0);
+    expect(generic!.eventTypeTag).toBe('');
+  });
+
+  it('baptism template has godparent roles', () => {
+    const baptism = getTemplateById('baptism');
+    const godfather = baptism!.slots.find((s) => s.key === 'godfather');
+    const godmother = baptism!.slots.find((s) => s.key === 'godmother');
+    expect(godfather!.participantRole).toBe('godparent');
+    expect(godmother!.participantRole).toBe('godparent');
+  });
+
+  it('getTemplateById returns undefined for unknown id', () => {
+    expect(getTemplateById('nonexistent')).toBeUndefined();
+  });
+
+  it('all templates match snapshot', () => {
+    expect(TEMPLATES).toMatchSnapshot();
+  });
+});

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,0 +1,277 @@
+import type { ParticipantRole } from '$/types/database';
+
+export interface TemplateSlot {
+  key: string;
+  label: string;
+  participantRole?: ParticipantRole;
+  gender?: 'M' | 'F';
+  required: boolean;
+  multiple: boolean;
+}
+
+export interface FamilyRule {
+  type: 'couple' | 'parent-child';
+  members: { slot: string; role: 'husband' | 'wife' | 'child' }[];
+}
+
+export interface TemplateDefinition {
+  id: string;
+  label: string;
+  eventTypeTag: string;
+  slots: TemplateSlot[];
+  families: FamilyRule[];
+  hasDate: boolean;
+  hasPlace: boolean;
+}
+
+const marriage: TemplateDefinition = {
+  id: 'marriage',
+  label: 'Marriage',
+  eventTypeTag: 'MARR',
+  slots: [
+    {
+      key: 'husband',
+      label: 'Husband',
+      participantRole: 'principal',
+      gender: 'M',
+      required: true,
+      multiple: false,
+    },
+    {
+      key: 'wife',
+      label: 'Wife',
+      participantRole: 'principal',
+      gender: 'F',
+      required: true,
+      multiple: false,
+    },
+    {
+      key: 'husband_father',
+      label: "Husband's Father",
+      gender: 'M',
+      required: false,
+      multiple: false,
+    },
+    {
+      key: 'husband_mother',
+      label: "Husband's Mother",
+      gender: 'F',
+      required: false,
+      multiple: false,
+    },
+    {
+      key: 'wife_father',
+      label: "Wife's Father",
+      gender: 'M',
+      required: false,
+      multiple: false,
+    },
+    {
+      key: 'wife_mother',
+      label: "Wife's Mother",
+      gender: 'F',
+      required: false,
+      multiple: false,
+    },
+    {
+      key: 'witness',
+      label: 'Witness',
+      participantRole: 'witness',
+      required: false,
+      multiple: true,
+    },
+  ],
+  families: [
+    {
+      type: 'couple',
+      members: [
+        { slot: 'husband', role: 'husband' },
+        { slot: 'wife', role: 'wife' },
+      ],
+    },
+    {
+      type: 'parent-child',
+      members: [
+        { slot: 'husband_father', role: 'husband' },
+        { slot: 'husband_mother', role: 'wife' },
+        { slot: 'husband', role: 'child' },
+      ],
+    },
+    {
+      type: 'parent-child',
+      members: [
+        { slot: 'wife_father', role: 'husband' },
+        { slot: 'wife_mother', role: 'wife' },
+        { slot: 'wife', role: 'child' },
+      ],
+    },
+  ],
+  hasDate: true,
+  hasPlace: true,
+};
+
+const baptism: TemplateDefinition = {
+  id: 'baptism',
+  label: 'Baptism',
+  eventTypeTag: 'BAPM',
+  slots: [
+    {
+      key: 'child',
+      label: 'Child',
+      participantRole: 'principal',
+      required: true,
+      multiple: false,
+    },
+    { key: 'father', label: 'Father', gender: 'M', required: false, multiple: false },
+    { key: 'mother', label: 'Mother', gender: 'F', required: false, multiple: false },
+    {
+      key: 'godfather',
+      label: 'Godfather',
+      participantRole: 'godparent',
+      gender: 'M',
+      required: false,
+      multiple: false,
+    },
+    {
+      key: 'godmother',
+      label: 'Godmother',
+      participantRole: 'godparent',
+      gender: 'F',
+      required: false,
+      multiple: false,
+    },
+  ],
+  families: [
+    {
+      type: 'parent-child',
+      members: [
+        { slot: 'father', role: 'husband' },
+        { slot: 'mother', role: 'wife' },
+        { slot: 'child', role: 'child' },
+      ],
+    },
+  ],
+  hasDate: true,
+  hasPlace: true,
+};
+
+const birth: TemplateDefinition = {
+  id: 'birth',
+  label: 'Birth',
+  eventTypeTag: 'BIRT',
+  slots: [
+    {
+      key: 'child',
+      label: 'Child',
+      participantRole: 'principal',
+      required: true,
+      multiple: false,
+    },
+    { key: 'father', label: 'Father', gender: 'M', required: false, multiple: false },
+    { key: 'mother', label: 'Mother', gender: 'F', required: false, multiple: false },
+  ],
+  families: [
+    {
+      type: 'parent-child',
+      members: [
+        { slot: 'father', role: 'husband' },
+        { slot: 'mother', role: 'wife' },
+        { slot: 'child', role: 'child' },
+      ],
+    },
+  ],
+  hasDate: true,
+  hasPlace: true,
+};
+
+const death: TemplateDefinition = {
+  id: 'death',
+  label: 'Death',
+  eventTypeTag: 'DEAT',
+  slots: [
+    {
+      key: 'deceased',
+      label: 'Deceased',
+      participantRole: 'principal',
+      required: true,
+      multiple: false,
+    },
+    {
+      key: 'informant',
+      label: 'Informant',
+      participantRole: 'informant',
+      required: false,
+      multiple: false,
+    },
+  ],
+  families: [],
+  hasDate: true,
+  hasPlace: true,
+};
+
+const burial: TemplateDefinition = {
+  id: 'burial',
+  label: 'Burial',
+  eventTypeTag: 'BURI',
+  slots: [
+    {
+      key: 'deceased',
+      label: 'Deceased',
+      participantRole: 'principal',
+      required: true,
+      multiple: false,
+    },
+  ],
+  families: [],
+  hasDate: true,
+  hasPlace: true,
+};
+
+const census: TemplateDefinition = {
+  id: 'census',
+  label: 'Census',
+  eventTypeTag: 'CENS',
+  slots: [
+    {
+      key: 'head',
+      label: 'Head of Household',
+      participantRole: 'principal',
+      required: true,
+      multiple: false,
+    },
+    {
+      key: 'member',
+      label: 'Member',
+      participantRole: 'other',
+      required: false,
+      multiple: true,
+    },
+  ],
+  families: [],
+  hasDate: true,
+  hasPlace: true,
+};
+
+const generic: TemplateDefinition = {
+  id: 'generic',
+  label: 'Generic',
+  eventTypeTag: '',
+  slots: [],
+  families: [],
+  hasDate: true,
+  hasPlace: true,
+};
+
+export const TEMPLATES: TemplateDefinition[] = [
+  marriage,
+  baptism,
+  birth,
+  death,
+  burial,
+  census,
+  generic,
+];
+
+export function getTemplateById(id: string): TemplateDefinition | undefined {
+  return TEMPLATES.find((t) => t.id === id);
+}

--- a/src/managers/SourceWorkspaceManager.test.ts
+++ b/src/managers/SourceWorkspaceManager.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTreeInMemoryDb } from '$/test/sqlite-memory';
 import { getIndividualById } from '$db-tree/individuals';
 import { getPrimaryName } from '$db-tree/names';
+import { getEventById, getEventParticipants, getEventTypeByTag } from '$db-tree/events';
 import { SourceWorkspaceManager, parseName, type SlotValue } from './SourceWorkspaceManager';
 import type { TemplateDefinition } from '$lib/templates';
 
@@ -20,6 +21,8 @@ import('$/db/connection').then(({ getTreeDb }) => {
 beforeEach(async () => {
   const { getTreeDb } = await import('$/db/connection');
   (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  db._raw.exec('DELETE FROM event_participants');
+  db._raw.exec('DELETE FROM events');
   db._raw.exec('DELETE FROM names');
   db._raw.exec('DELETE FROM individuals');
 });
@@ -111,6 +114,16 @@ const marriageTemplate: TemplateDefinition = {
       ],
     },
   ],
+  hasDate: true,
+  hasPlace: true,
+};
+
+const genericTemplate: TemplateDefinition = {
+  id: 'generic',
+  label: 'Generic',
+  eventTypeTag: '',
+  slots: [],
+  families: [],
   hasDate: true,
   hasPlace: true,
 };
@@ -242,5 +255,99 @@ describe('SourceWorkspaceManager.resolveIndividuals', () => {
     expect(resolved).toHaveLength(1);
     const individual = await getIndividualById(resolved[0].individualId);
     expect(individual!.gender).toBe('F');
+  });
+});
+
+// =============================================================================
+// Task 3: createEventFromTemplate
+// =============================================================================
+
+describe('SourceWorkspaceManager.createEventFromTemplate', () => {
+  it('creates event with participants for marriage template', async () => {
+    const slots: SlotValue[] = [
+      { slotKey: 'husband', newName: 'Jean Dupont' },
+      { slotKey: 'wife', newName: 'Marie Martin' },
+    ];
+    const resolvedSlots = await SourceWorkspaceManager.resolveIndividuals(slots, marriageTemplate);
+
+    const eventId = await SourceWorkspaceManager.createEventFromTemplate(
+      marriageTemplate,
+      resolvedSlots,
+      { date: '15 JAN 1850' }
+    );
+
+    expect(eventId).toBeDefined();
+
+    // Verify event was created
+    const event = await getEventById(eventId!);
+    expect(event).not.toBeNull();
+    expect(event!.dateOriginal).toBe('15 JAN 1850');
+
+    // Verify event type is MARR
+    const marrType = await getEventTypeByTag('MARR');
+    expect(event!.eventTypeId).toBe(marrType!.id);
+
+    // Verify participants
+    const participants = await getEventParticipants(eventId!);
+    expect(participants).toHaveLength(2);
+    expect(participants.every((p) => p.role === 'principal')).toBe(true);
+  });
+
+  it('skips event creation when template has no event type tag (generic)', async () => {
+    const resolvedSlots = await SourceWorkspaceManager.resolveIndividuals([], genericTemplate);
+
+    const eventId = await SourceWorkspaceManager.createEventFromTemplate(
+      genericTemplate,
+      resolvedSlots,
+      {}
+    );
+
+    expect(eventId).toBeUndefined();
+  });
+
+  it('uses eventTypeTag override for generic template', async () => {
+    const slots: SlotValue[] = [{ slotKey: 'person', newName: 'Jean Dupont' }];
+    const resolvedSlots = await SourceWorkspaceManager.resolveIndividuals(slots, genericTemplate);
+
+    const eventId = await SourceWorkspaceManager.createEventFromTemplate(
+      genericTemplate,
+      resolvedSlots,
+      { eventTypeTag: 'BIRT' }
+    );
+
+    expect(eventId).toBeDefined();
+
+    const event = await getEventById(eventId!);
+    const birtType = await getEventTypeByTag('BIRT');
+    expect(event!.eventTypeId).toBe(birtType!.id);
+
+    // Free-form slot (not in template.slots) should be added as 'other'
+    const participants = await getEventParticipants(eventId!);
+    expect(participants).toHaveLength(1);
+    expect(participants[0].role).toBe('other');
+  });
+
+  it('only adds slots with participantRole as event participants', async () => {
+    const slots: SlotValue[] = [
+      { slotKey: 'husband', newName: 'Jean Dupont' },
+      { slotKey: 'wife', newName: 'Marie Martin' },
+      { slotKey: 'husband_father', newName: 'Pierre Dupont' },
+      { slotKey: 'witness', newName: 'Paul Thibault' },
+    ];
+    const resolvedSlots = await SourceWorkspaceManager.resolveIndividuals(slots, marriageTemplate);
+
+    const eventId = await SourceWorkspaceManager.createEventFromTemplate(
+      marriageTemplate,
+      resolvedSlots,
+      {}
+    );
+
+    // husband (principal), wife (principal), witness (witness) = 3 participants
+    // husband_father has no participantRole so should NOT be added
+    const participants = await getEventParticipants(eventId!);
+    expect(participants).toHaveLength(3);
+
+    const roles = participants.map((p) => p.role).sort();
+    expect(roles).toEqual(['principal', 'principal', 'witness']);
   });
 });

--- a/src/managers/SourceWorkspaceManager.test.ts
+++ b/src/managers/SourceWorkspaceManager.test.ts
@@ -4,6 +4,8 @@ import { getIndividualById } from '$db-tree/individuals';
 import { getPrimaryName } from '$db-tree/names';
 import { getEventById, getEventParticipants, getEventTypeByTag } from '$db-tree/events';
 import { getFamilyMembers } from '$db-tree/families';
+import { getCitationsBySourceId, getCitationLinksForCitation } from '$db-tree/citations';
+import { createSource } from '$db-tree/sources';
 import { SourceWorkspaceManager, parseName, type SlotValue } from './SourceWorkspaceManager';
 import type { TemplateDefinition } from '$lib/templates';
 
@@ -22,12 +24,16 @@ import('$/db/connection').then(({ getTreeDb }) => {
 beforeEach(async () => {
   const { getTreeDb } = await import('$/db/connection');
   (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  db._raw.exec('DELETE FROM citation_links');
+  db._raw.exec('DELETE FROM source_citations');
   db._raw.exec('DELETE FROM event_participants');
   db._raw.exec('DELETE FROM events');
   db._raw.exec('DELETE FROM family_members');
   db._raw.exec('DELETE FROM families');
   db._raw.exec('DELETE FROM names');
   db._raw.exec('DELETE FROM individuals');
+  db._raw.exec('DELETE FROM sources');
+  db._raw.exec('DELETE FROM places');
 });
 
 // =============================================================================
@@ -130,6 +136,10 @@ const genericTemplate: TemplateDefinition = {
   hasDate: true,
   hasPlace: true,
 };
+
+async function seedSource(title = 'Parish Register'): Promise<string> {
+  return createSource({ title });
+}
 
 // =============================================================================
 // Task 2: parseName
@@ -438,5 +448,143 @@ describe('SourceWorkspaceManager.createFamilies', () => {
     const parentChildMembers = await getFamilyMembers(familyIds[1]);
     // Only father + child (mother missing)
     expect(parentChildMembers).toHaveLength(2);
+  });
+});
+
+// =============================================================================
+// Task 5: createFromTemplate (full orchestration)
+// =============================================================================
+
+describe('SourceWorkspaceManager.createFromTemplate', () => {
+  it('creates full marriage record (event + 2 individuals + 1 family + citation + 4 citation links)', async () => {
+    const sourceId = await seedSource();
+
+    const result = await SourceWorkspaceManager.createFromTemplate({
+      sourceId,
+      templateId: 'marriage',
+      slots: [
+        { slotKey: 'husband', newName: 'Jean Dupont' },
+        { slotKey: 'wife', newName: 'Marie Martin' },
+      ],
+      date: '15 JAN 1850',
+      citationPage: 'folio 12',
+    });
+
+    expect(result.eventId).toBeDefined();
+    expect(result.createdIndividuals).toHaveLength(2);
+    expect(result.createdFamilies).toHaveLength(1);
+    expect(result.citationId).toBeDefined();
+    // Links: 1 event + 2 individuals + 1 family = 4
+    expect(result.citationLinkIds).toHaveLength(4);
+
+    // Verify citation was created with correct page
+    const citations = await getCitationsBySourceId(sourceId);
+    expect(citations).toHaveLength(1);
+    expect(citations[0].page).toBe('folio 12');
+
+    // Verify citation links
+    const links = await getCitationLinksForCitation(result.citationId);
+    expect(links).toHaveLength(4);
+    const entityTypes = links.map((l) => l.entityType).sort();
+    expect(entityTypes).toEqual(['event', 'family', 'individual', 'individual']);
+  });
+
+  it('creates record with no event for generic template', async () => {
+    const sourceId = await seedSource();
+    const { createIndividual } = await import('$db-tree/individuals');
+    const existingId = await createIndividual({ gender: 'M' });
+
+    const result = await SourceWorkspaceManager.createFromTemplate({
+      sourceId,
+      templateId: 'generic',
+      slots: [{ slotKey: 'person', existingId }],
+    });
+
+    expect(result.eventId).toBeUndefined();
+    expect(result.createdIndividuals).toHaveLength(0); // existing, not created
+    expect(result.createdFamilies).toHaveLength(0);
+    expect(result.citationId).toBeDefined();
+    // Links: 1 individual (no event, no family)
+    expect(result.citationLinkIds).toHaveLength(1);
+  });
+
+  it('creates marriage with parents and witnesses (5 individuals + 2 families + 8 citation links)', async () => {
+    const sourceId = await seedSource();
+
+    const result = await SourceWorkspaceManager.createFromTemplate({
+      sourceId,
+      templateId: 'marriage',
+      slots: [
+        { slotKey: 'husband', newName: 'Jean Dupont' },
+        { slotKey: 'wife', newName: 'Marie Martin' },
+        { slotKey: 'husband_father', newName: 'Pierre Dupont' },
+        { slotKey: 'husband_mother', newName: 'Anne Leclerc' },
+        { slotKey: 'witness', newName: 'Paul Thibault' },
+      ],
+      date: '15 JAN 1850',
+      place: 'Paris',
+    });
+
+    // 5 individuals created
+    expect(result.createdIndividuals).toHaveLength(5);
+
+    // 2 families: couple + husband's parent-child
+    expect(result.createdFamilies).toHaveLength(2);
+
+    // Event should exist
+    expect(result.eventId).toBeDefined();
+
+    // Citation links: 1 event + 5 individuals + 2 families = 8
+    expect(result.citationLinkIds).toHaveLength(8);
+  });
+
+  it('resolves an existing place when existingPlaceId is provided', async () => {
+    const sourceId = await seedSource();
+    const { createPlace } = await import('$db-tree/places');
+    const placeId = await createPlace({ name: 'Paris' });
+
+    const result = await SourceWorkspaceManager.createFromTemplate({
+      sourceId,
+      templateId: 'marriage',
+      slots: [
+        { slotKey: 'husband', newName: 'Jean Dupont' },
+        { slotKey: 'wife', newName: 'Marie Martin' },
+      ],
+      existingPlaceId: placeId,
+    });
+
+    // Verify the event uses the existing place
+    const event = await getEventById(result.eventId!);
+    expect(event!.placeId).toBe(placeId);
+  });
+
+  it('creates a new place when place string is provided', async () => {
+    const sourceId = await seedSource();
+
+    const result = await SourceWorkspaceManager.createFromTemplate({
+      sourceId,
+      templateId: 'marriage',
+      slots: [
+        { slotKey: 'husband', newName: 'Jean Dupont' },
+        { slotKey: 'wife', newName: 'Marie Martin' },
+      ],
+      place: 'Lyon',
+    });
+
+    const event = await getEventById(result.eventId!);
+    expect(event!.placeId).toBeDefined();
+    expect(event!.placeId).not.toBeNull();
+  });
+
+  it('throws when template ID is invalid', async () => {
+    const sourceId = await seedSource();
+
+    await expect(
+      SourceWorkspaceManager.createFromTemplate({
+        sourceId,
+        templateId: 'nonexistent',
+        slots: [],
+      })
+    ).rejects.toThrow('Template not found: nonexistent');
   });
 });

--- a/src/managers/SourceWorkspaceManager.test.ts
+++ b/src/managers/SourceWorkspaceManager.test.ts
@@ -3,6 +3,7 @@ import { createTreeInMemoryDb } from '$/test/sqlite-memory';
 import { getIndividualById } from '$db-tree/individuals';
 import { getPrimaryName } from '$db-tree/names';
 import { getEventById, getEventParticipants, getEventTypeByTag } from '$db-tree/events';
+import { getFamilyMembers } from '$db-tree/families';
 import { SourceWorkspaceManager, parseName, type SlotValue } from './SourceWorkspaceManager';
 import type { TemplateDefinition } from '$lib/templates';
 
@@ -23,6 +24,8 @@ beforeEach(async () => {
   (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
   db._raw.exec('DELETE FROM event_participants');
   db._raw.exec('DELETE FROM events');
+  db._raw.exec('DELETE FROM family_members');
+  db._raw.exec('DELETE FROM families');
   db._raw.exec('DELETE FROM names');
   db._raw.exec('DELETE FROM individuals');
 });
@@ -349,5 +352,91 @@ describe('SourceWorkspaceManager.createEventFromTemplate', () => {
 
     const roles = participants.map((p) => p.role).sort();
     expect(roles).toEqual(['principal', 'principal', 'witness']);
+  });
+});
+
+// =============================================================================
+// Task 4: createFamilies
+// =============================================================================
+
+describe('SourceWorkspaceManager.createFamilies', () => {
+  it('creates couple family from marriage template', async () => {
+    const slots: SlotValue[] = [
+      { slotKey: 'husband', newName: 'Jean Dupont' },
+      { slotKey: 'wife', newName: 'Marie Martin' },
+    ];
+    const resolvedSlots = await SourceWorkspaceManager.resolveIndividuals(slots, marriageTemplate);
+
+    const familyIds = await SourceWorkspaceManager.createFamilies(marriageTemplate, resolvedSlots);
+
+    // Only the couple family should be created (parent-child families need child + parent)
+    expect(familyIds).toHaveLength(1);
+
+    const members = await getFamilyMembers(familyIds[0]);
+    expect(members).toHaveLength(2);
+    expect(members.find((m) => m.role === 'husband')).toBeDefined();
+    expect(members.find((m) => m.role === 'wife')).toBeDefined();
+  });
+
+  it('creates parent-child family when parents are filled', async () => {
+    const slots: SlotValue[] = [
+      { slotKey: 'husband', newName: 'Jean Dupont' },
+      { slotKey: 'wife', newName: 'Marie Martin' },
+      { slotKey: 'husband_father', newName: 'Pierre Dupont' },
+      { slotKey: 'husband_mother', newName: 'Anne Leclerc' },
+    ];
+    const resolvedSlots = await SourceWorkspaceManager.resolveIndividuals(slots, marriageTemplate);
+
+    const familyIds = await SourceWorkspaceManager.createFamilies(marriageTemplate, resolvedSlots);
+
+    // couple family + husband's parent-child family = 2
+    expect(familyIds).toHaveLength(2);
+
+    // Second family should be the parent-child family
+    const parentChildMembers = await getFamilyMembers(familyIds[1]);
+    expect(parentChildMembers).toHaveLength(3);
+    expect(parentChildMembers.find((m) => m.role === 'child')).toBeDefined();
+  });
+
+  it('skips parent-child family when child slot is missing', async () => {
+    // Only fill parents, skip the husband (child in parent-child rule)
+    const slots: SlotValue[] = [
+      { slotKey: 'husband_father', newName: 'Pierre Dupont' },
+      { slotKey: 'husband_mother', newName: 'Anne Leclerc' },
+    ];
+    const resolvedSlots = await SourceWorkspaceManager.resolveIndividuals(slots, marriageTemplate);
+
+    const familyIds = await SourceWorkspaceManager.createFamilies(marriageTemplate, resolvedSlots);
+
+    // No families should be created (couple needs both, parent-child needs child)
+    expect(familyIds).toHaveLength(0);
+  });
+
+  it('skips couple family when both spouses are missing', async () => {
+    const slots: SlotValue[] = [{ slotKey: 'witness', newName: 'Paul Thibault' }];
+    const resolvedSlots = await SourceWorkspaceManager.resolveIndividuals(slots, marriageTemplate);
+
+    const familyIds = await SourceWorkspaceManager.createFamilies(marriageTemplate, resolvedSlots);
+
+    expect(familyIds).toHaveLength(0);
+  });
+
+  it('creates parent-child family with only one parent', async () => {
+    const slots: SlotValue[] = [
+      { slotKey: 'husband', newName: 'Jean Dupont' },
+      { slotKey: 'wife', newName: 'Marie Martin' },
+      { slotKey: 'husband_father', newName: 'Pierre Dupont' },
+      // husband_mother not filled
+    ];
+    const resolvedSlots = await SourceWorkspaceManager.resolveIndividuals(slots, marriageTemplate);
+
+    const familyIds = await SourceWorkspaceManager.createFamilies(marriageTemplate, resolvedSlots);
+
+    // couple + parent-child (with one parent) = 2
+    expect(familyIds).toHaveLength(2);
+
+    const parentChildMembers = await getFamilyMembers(familyIds[1]);
+    // Only father + child (mother missing)
+    expect(parentChildMembers).toHaveLength(2);
   });
 });

--- a/src/managers/SourceWorkspaceManager.test.ts
+++ b/src/managers/SourceWorkspaceManager.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTreeInMemoryDb } from '$/test/sqlite-memory';
+import { getIndividualById } from '$db-tree/individuals';
+import { getPrimaryName } from '$db-tree/names';
+import { SourceWorkspaceManager, parseName, type SlotValue } from './SourceWorkspaceManager';
+import type { TemplateDefinition } from '$lib/templates';
+
+// A single in-memory DB shared across all tests in this file.
+const db = createTreeInMemoryDb();
+
+vi.mock('$/db/connection', () => ({
+  getTreeDb: vi.fn(),
+}));
+
+// Lazily resolve the mock after the module is loaded
+import('$/db/connection').then(({ getTreeDb }) => {
+  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+});
+
+beforeEach(async () => {
+  const { getTreeDb } = await import('$/db/connection');
+  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  db._raw.exec('DELETE FROM names');
+  db._raw.exec('DELETE FROM individuals');
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Marriage template for testing -- mirrors the real template structure */
+const marriageTemplate: TemplateDefinition = {
+  id: 'marriage',
+  label: 'Marriage',
+  eventTypeTag: 'MARR',
+  slots: [
+    {
+      key: 'husband',
+      label: 'Husband',
+      participantRole: 'principal',
+      gender: 'M',
+      required: true,
+      multiple: false,
+    },
+    {
+      key: 'wife',
+      label: 'Wife',
+      participantRole: 'principal',
+      gender: 'F',
+      required: true,
+      multiple: false,
+    },
+    {
+      key: 'husband_father',
+      label: "Husband's Father",
+      gender: 'M',
+      required: false,
+      multiple: false,
+    },
+    {
+      key: 'husband_mother',
+      label: "Husband's Mother",
+      gender: 'F',
+      required: false,
+      multiple: false,
+    },
+    {
+      key: 'wife_father',
+      label: "Wife's Father",
+      gender: 'M',
+      required: false,
+      multiple: false,
+    },
+    {
+      key: 'wife_mother',
+      label: "Wife's Mother",
+      gender: 'F',
+      required: false,
+      multiple: false,
+    },
+    {
+      key: 'witness',
+      label: 'Witness',
+      participantRole: 'witness',
+      required: false,
+      multiple: true,
+    },
+  ],
+  families: [
+    {
+      type: 'couple',
+      members: [
+        { slot: 'husband', role: 'husband' },
+        { slot: 'wife', role: 'wife' },
+      ],
+    },
+    {
+      type: 'parent-child',
+      members: [
+        { slot: 'husband_father', role: 'husband' },
+        { slot: 'husband_mother', role: 'wife' },
+        { slot: 'husband', role: 'child' },
+      ],
+    },
+    {
+      type: 'parent-child',
+      members: [
+        { slot: 'wife_father', role: 'husband' },
+        { slot: 'wife_mother', role: 'wife' },
+        { slot: 'wife', role: 'child' },
+      ],
+    },
+  ],
+  hasDate: true,
+  hasPlace: true,
+};
+
+// =============================================================================
+// Task 2: parseName
+// =============================================================================
+
+describe('parseName', () => {
+  it('parses a two-part name into givenNames and surname', () => {
+    expect(parseName('Jean Dupont')).toEqual({
+      givenNames: 'Jean',
+      surname: 'Dupont',
+    });
+  });
+
+  it('parses multiple given names correctly', () => {
+    expect(parseName('Jean Pierre Marie Dupont')).toEqual({
+      givenNames: 'Jean Pierre Marie',
+      surname: 'Dupont',
+    });
+  });
+
+  it('treats a single name as surname only', () => {
+    expect(parseName('Dupont')).toEqual({
+      surname: 'Dupont',
+    });
+  });
+
+  it('returns empty object for empty string', () => {
+    expect(parseName('')).toEqual({});
+  });
+
+  it('returns empty object for whitespace-only string', () => {
+    expect(parseName('   ')).toEqual({});
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(parseName('  Jean Dupont  ')).toEqual({
+      givenNames: 'Jean',
+      surname: 'Dupont',
+    });
+  });
+
+  it('handles multiple spaces between names', () => {
+    expect(parseName('Jean   Pierre   Dupont')).toEqual({
+      givenNames: 'Jean Pierre',
+      surname: 'Dupont',
+    });
+  });
+});
+
+// =============================================================================
+// Task 2: resolveIndividuals
+// =============================================================================
+
+describe('SourceWorkspaceManager.resolveIndividuals', () => {
+  it('creates new individuals with names from slot values', async () => {
+    const slots: SlotValue[] = [
+      { slotKey: 'husband', newName: 'Jean Dupont' },
+      { slotKey: 'wife', newName: 'Marie Martin' },
+    ];
+
+    const resolved = await SourceWorkspaceManager.resolveIndividuals(slots, marriageTemplate);
+
+    expect(resolved).toHaveLength(2);
+    expect(resolved[0].slotKey).toBe('husband');
+    expect(resolved[0].created).toBe(true);
+    expect(resolved[1].slotKey).toBe('wife');
+    expect(resolved[1].created).toBe(true);
+
+    // Verify the individuals were created with correct gender
+    const husband = await getIndividualById(resolved[0].individualId);
+    expect(husband).not.toBeNull();
+    expect(husband!.gender).toBe('M');
+
+    const wife = await getIndividualById(resolved[1].individualId);
+    expect(wife).not.toBeNull();
+    expect(wife!.gender).toBe('F');
+
+    // Verify names were created
+    const husbandName = await getPrimaryName(resolved[0].individualId);
+    expect(husbandName).not.toBeNull();
+    expect(husbandName!.givenNames).toBe('Jean');
+    expect(husbandName!.surname).toBe('Dupont');
+
+    const wifeName = await getPrimaryName(resolved[1].individualId);
+    expect(wifeName).not.toBeNull();
+    expect(wifeName!.givenNames).toBe('Marie');
+    expect(wifeName!.surname).toBe('Martin');
+  });
+
+  it('uses existing individual when existingId provided', async () => {
+    const { createIndividual } = await import('$db-tree/individuals');
+    const existingId = await createIndividual({ gender: 'M' });
+
+    const slots: SlotValue[] = [
+      { slotKey: 'husband', existingId },
+      { slotKey: 'wife', newName: 'Marie Martin' },
+    ];
+
+    const resolved = await SourceWorkspaceManager.resolveIndividuals(slots, marriageTemplate);
+
+    expect(resolved).toHaveLength(2);
+    expect(resolved[0].slotKey).toBe('husband');
+    expect(resolved[0].individualId).toBe(existingId);
+    expect(resolved[0].created).toBe(false);
+    expect(resolved[1].created).toBe(true);
+  });
+
+  it('skips empty slots (no existingId and no newName)', async () => {
+    const slots: SlotValue[] = [
+      { slotKey: 'husband', newName: 'Jean Dupont' },
+      { slotKey: 'wife' },
+      { slotKey: 'witness', newName: '  ' },
+    ];
+
+    const resolved = await SourceWorkspaceManager.resolveIndividuals(slots, marriageTemplate);
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].slotKey).toBe('husband');
+  });
+
+  it('uses explicit newGender over template default', async () => {
+    const slots: SlotValue[] = [{ slotKey: 'witness', newName: 'Alex Smith', newGender: 'F' }];
+
+    const resolved = await SourceWorkspaceManager.resolveIndividuals(slots, marriageTemplate);
+
+    expect(resolved).toHaveLength(1);
+    const individual = await getIndividualById(resolved[0].individualId);
+    expect(individual!.gender).toBe('F');
+  });
+});

--- a/src/managers/SourceWorkspaceManager.ts
+++ b/src/managers/SourceWorkspaceManager.ts
@@ -1,0 +1,98 @@
+import { createIndividual } from '$db-tree/individuals';
+import { createName } from '$db-tree/names';
+import type { TemplateDefinition } from '$lib/templates';
+import type { Gender } from '$/types/database';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface SlotValue {
+  slotKey: string;
+  existingId?: string;
+  newName?: string;
+  newGender?: Gender;
+}
+
+interface ResolvedSlot {
+  slotKey: string;
+  individualId: string;
+  created: boolean;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Parse a full name string into given names and surname.
+ * The last word is treated as the surname; everything else is given names.
+ * Single-word names become the surname with no given names.
+ */
+export function parseName(fullName: string): { givenNames?: string; surname?: string } {
+  const trimmed = fullName.trim();
+  if (!trimmed) return {};
+
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) {
+    return { surname: parts[0] };
+  }
+
+  const surname = parts[parts.length - 1];
+  const givenNames = parts.slice(0, -1).join(' ');
+  return { givenNames, surname };
+}
+
+// =============================================================================
+// SourceWorkspaceManager
+// =============================================================================
+
+export class SourceWorkspaceManager {
+  /**
+   * Resolve slot values into individuals. Creates new individuals with
+   * primary names for slots that don't reference an existing individual.
+   * Skips slots with neither existingId nor newName.
+   */
+  static async resolveIndividuals(
+    slots: SlotValue[],
+    template: TemplateDefinition
+  ): Promise<ResolvedSlot[]> {
+    const resolved: ResolvedSlot[] = [];
+
+    for (const slot of slots) {
+      if (slot.existingId) {
+        resolved.push({
+          slotKey: slot.slotKey,
+          individualId: slot.existingId,
+          created: false,
+        });
+        continue;
+      }
+
+      if (!slot.newName || !slot.newName.trim()) {
+        continue;
+      }
+
+      // Determine gender: explicit from slot, or default from template slot definition
+      const templateSlot = template.slots.find((s) => s.key === slot.slotKey);
+      const gender: Gender = slot.newGender ?? templateSlot?.gender ?? 'U';
+
+      const individualId = await createIndividual({ gender });
+      const { givenNames, surname } = parseName(slot.newName);
+      await createName({
+        individualId,
+        givenNames,
+        surname,
+        isPrimary: true,
+      });
+
+      resolved.push({
+        slotKey: slot.slotKey,
+        individualId,
+        created: true,
+      });
+    }
+
+    return resolved;
+  }
+}

--- a/src/managers/SourceWorkspaceManager.ts
+++ b/src/managers/SourceWorkspaceManager.ts
@@ -1,5 +1,6 @@
 import { createIndividual } from '$db-tree/individuals';
 import { createName } from '$db-tree/names';
+import { getEventTypeByTag, createEvent, addEventParticipant } from '$db-tree/events';
 import type { TemplateDefinition } from '$lib/templates';
 import type { Gender } from '$/types/database';
 
@@ -94,5 +95,59 @@ export class SourceWorkspaceManager {
     }
 
     return resolved;
+  }
+
+  /**
+   * Create an event from template configuration and add participants.
+   * Returns the event ID, or undefined if the template has no event type tag
+   * and no override is provided.
+   */
+  static async createEventFromTemplate(
+    template: TemplateDefinition,
+    resolvedSlots: ResolvedSlot[],
+    options: {
+      eventTypeTag?: string;
+      date?: string;
+      placeId?: string;
+    }
+  ): Promise<string | undefined> {
+    const tag = options.eventTypeTag || template.eventTypeTag;
+    if (!tag) return undefined;
+
+    const eventType = await getEventTypeByTag(tag);
+    if (!eventType) return undefined;
+
+    const eventId = await createEvent({
+      eventTypeId: eventType.id,
+      dateOriginal: options.date,
+      placeId: options.placeId,
+    });
+
+    // Build a set of slot keys that are defined in the template
+    const templateSlotKeys = new Set(template.slots.map((s) => s.key));
+
+    for (const resolved of resolvedSlots) {
+      const templateSlot = template.slots.find((s) => s.key === resolved.slotKey);
+
+      if (templateSlot) {
+        // Only add as participant if the template slot has a participantRole
+        if (templateSlot.participantRole) {
+          await addEventParticipant({
+            eventId,
+            individualId: resolved.individualId,
+            role: templateSlot.participantRole,
+          });
+        }
+      } else if (!templateSlotKeys.has(resolved.slotKey)) {
+        // Free-form slot (not defined in template) — add with role 'other'
+        await addEventParticipant({
+          eventId,
+          individualId: resolved.individualId,
+          role: 'other',
+        });
+      }
+    }
+
+    return eventId;
   }
 }

--- a/src/managers/SourceWorkspaceManager.ts
+++ b/src/managers/SourceWorkspaceManager.ts
@@ -1,6 +1,7 @@
 import { createIndividual } from '$db-tree/individuals';
 import { createName } from '$db-tree/names';
 import { getEventTypeByTag, createEvent, addEventParticipant } from '$db-tree/events';
+import { createFamily, addFamilyMember } from '$db-tree/families';
 import type { TemplateDefinition } from '$lib/templates';
 import type { Gender } from '$/types/database';
 
@@ -149,5 +150,59 @@ export class SourceWorkspaceManager {
     }
 
     return eventId;
+  }
+
+  /**
+   * Create families based on template family rules and resolved slots.
+   * Returns an array of created family IDs.
+   */
+  static async createFamilies(
+    template: TemplateDefinition,
+    resolvedSlots: ResolvedSlot[]
+  ): Promise<string[]> {
+    const slotMap = new Map(resolvedSlots.map((r) => [r.slotKey, r.individualId]));
+    const familyIds: string[] = [];
+
+    for (const rule of template.families) {
+      if (rule.type === 'couple') {
+        // Need both members present
+        const allPresent = rule.members.every((m) => slotMap.has(m.slot));
+        if (!allPresent) continue;
+
+        const familyId = await createFamily({});
+        for (const member of rule.members) {
+          const individualId = slotMap.get(member.slot)!;
+          await addFamilyMember({
+            familyId,
+            individualId,
+            role: member.role,
+          });
+        }
+        familyIds.push(familyId);
+      } else if (rule.type === 'parent-child') {
+        // Need the child + at least one parent
+        const childMember = rule.members.find((m) => m.role === 'child');
+        if (!childMember || !slotMap.has(childMember.slot)) continue;
+
+        const parentMembers = rule.members.filter((m) => m.role !== 'child');
+        const hasAtLeastOneParent = parentMembers.some((m) => slotMap.has(m.slot));
+        if (!hasAtLeastOneParent) continue;
+
+        const familyId = await createFamily({});
+        for (const member of rule.members) {
+          const individualId = slotMap.get(member.slot);
+          if (individualId) {
+            await addFamilyMember({
+              familyId,
+              individualId,
+              role: member.role,
+            });
+          }
+        }
+        familyIds.push(familyId);
+      }
+    }
+
+    return familyIds;
   }
 }

--- a/src/managers/SourceWorkspaceManager.ts
+++ b/src/managers/SourceWorkspaceManager.ts
@@ -239,35 +239,28 @@ export class SourceWorkspaceManager {
       throw new Error(`Template not found: ${input.templateId}`);
     }
 
-    // 1. Resolve place
     let placeId = input.existingPlaceId;
     if (!placeId && input.place?.trim()) {
       placeId = await createPlace({ name: input.place.trim() });
     }
 
-    // 2. Resolve individuals
     const resolvedSlots = await SourceWorkspaceManager.resolveIndividuals(input.slots, template);
 
-    // 3. Create event
     const eventId = await SourceWorkspaceManager.createEventFromTemplate(template, resolvedSlots, {
       eventTypeTag: input.eventTypeTag,
       date: input.date,
       placeId,
     });
 
-    // 4. Create families
     const createdFamilies = await SourceWorkspaceManager.createFamilies(template, resolvedSlots);
 
-    // 5. Create citation
     const citationId = await createCitation({
       sourceId: input.sourceId,
       page: input.citationPage,
     });
 
-    // 6. Create citation links
     const citationLinkIds: string[] = [];
 
-    // Link to event
     if (eventId) {
       const linkId = await createCitationLink({
         citationId,
@@ -277,7 +270,6 @@ export class SourceWorkspaceManager {
       citationLinkIds.push(linkId);
     }
 
-    // Link to each individual
     for (const resolved of resolvedSlots) {
       const linkId = await createCitationLink({
         citationId,
@@ -287,7 +279,6 @@ export class SourceWorkspaceManager {
       citationLinkIds.push(linkId);
     }
 
-    // Link to each family
     for (const familyId of createdFamilies) {
       const linkId = await createCitationLink({
         citationId,

--- a/src/managers/SourceWorkspaceManager.ts
+++ b/src/managers/SourceWorkspaceManager.ts
@@ -145,9 +145,6 @@ export class SourceWorkspaceManager {
       placeId: options.placeId,
     });
 
-    // Build a set of slot keys that are defined in the template
-    const templateSlotKeys = new Set(template.slots.map((s) => s.key));
-
     for (const resolved of resolvedSlots) {
       const templateSlot = template.slots.find((s) => s.key === resolved.slotKey);
 
@@ -160,7 +157,7 @@ export class SourceWorkspaceManager {
             role: templateSlot.participantRole,
           });
         }
-      } else if (!templateSlotKeys.has(resolved.slotKey)) {
+      } else {
         // Free-form slot (not defined in template) — add with role 'other'
         await addEventParticipant({
           eventId,

--- a/src/managers/SourceWorkspaceManager.ts
+++ b/src/managers/SourceWorkspaceManager.ts
@@ -2,7 +2,9 @@ import { createIndividual } from '$db-tree/individuals';
 import { createName } from '$db-tree/names';
 import { getEventTypeByTag, createEvent, addEventParticipant } from '$db-tree/events';
 import { createFamily, addFamilyMember } from '$db-tree/families';
-import type { TemplateDefinition } from '$lib/templates';
+import { createCitation, createCitationLink } from '$db-tree/citations';
+import { createPlace } from '$db-tree/places';
+import { getTemplateById, type TemplateDefinition } from '$lib/templates';
 import type { Gender } from '$/types/database';
 
 // =============================================================================
@@ -14,6 +16,25 @@ export interface SlotValue {
   existingId?: string;
   newName?: string;
   newGender?: Gender;
+}
+
+export interface CreateFromTemplateInput {
+  sourceId: string;
+  templateId: string;
+  slots: SlotValue[];
+  eventTypeTag?: string;
+  date?: string;
+  place?: string;
+  existingPlaceId?: string;
+  citationPage?: string;
+}
+
+export interface CreateFromTemplateResult {
+  eventId?: string;
+  createdIndividuals: { slotKey: string; id: string }[];
+  createdFamilies: string[];
+  citationId: string;
+  citationLinkIds: string[];
 }
 
 interface ResolvedSlot {
@@ -204,5 +225,86 @@ export class SourceWorkspaceManager {
     }
 
     return familyIds;
+  }
+
+  /**
+   * Main orchestration method. Creates all entities from a template:
+   * individuals, event, families, citation, and citation links.
+   */
+  static async createFromTemplate(
+    input: CreateFromTemplateInput
+  ): Promise<CreateFromTemplateResult> {
+    const template = getTemplateById(input.templateId);
+    if (!template) {
+      throw new Error(`Template not found: ${input.templateId}`);
+    }
+
+    // 1. Resolve place
+    let placeId = input.existingPlaceId;
+    if (!placeId && input.place?.trim()) {
+      placeId = await createPlace({ name: input.place.trim() });
+    }
+
+    // 2. Resolve individuals
+    const resolvedSlots = await SourceWorkspaceManager.resolveIndividuals(input.slots, template);
+
+    // 3. Create event
+    const eventId = await SourceWorkspaceManager.createEventFromTemplate(template, resolvedSlots, {
+      eventTypeTag: input.eventTypeTag,
+      date: input.date,
+      placeId,
+    });
+
+    // 4. Create families
+    const createdFamilies = await SourceWorkspaceManager.createFamilies(template, resolvedSlots);
+
+    // 5. Create citation
+    const citationId = await createCitation({
+      sourceId: input.sourceId,
+      page: input.citationPage,
+    });
+
+    // 6. Create citation links
+    const citationLinkIds: string[] = [];
+
+    // Link to event
+    if (eventId) {
+      const linkId = await createCitationLink({
+        citationId,
+        entityType: 'event',
+        entityId: eventId,
+      });
+      citationLinkIds.push(linkId);
+    }
+
+    // Link to each individual
+    for (const resolved of resolvedSlots) {
+      const linkId = await createCitationLink({
+        citationId,
+        entityType: 'individual',
+        entityId: resolved.individualId,
+      });
+      citationLinkIds.push(linkId);
+    }
+
+    // Link to each family
+    for (const familyId of createdFamilies) {
+      const linkId = await createCitationLink({
+        citationId,
+        entityType: 'family',
+        entityId: familyId,
+      });
+      citationLinkIds.push(linkId);
+    }
+
+    return {
+      eventId,
+      createdIndividuals: resolvedSlots
+        .filter((r) => r.created)
+        .map((r) => ({ slotKey: r.slotKey, id: r.individualId })),
+      createdFamilies,
+      citationId,
+      citationLinkIds,
+    };
   }
 }

--- a/src/pages/SourceViewPage.tsx
+++ b/src/pages/SourceViewPage.tsx
@@ -384,6 +384,22 @@ export function SourceViewPage({ treeId, sourceId }: SourceViewPageProps): JSX.E
           <div style={{ color: '#666', marginTop: '0.25rem', fontSize: '0.9rem' }}>{source.id}</div>
         </div>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <Link
+            to="/tree/$treeId/source/$sourceId/edit"
+            params={{ treeId, sourceId }}
+            style={{
+              padding: '0.5rem 1rem',
+              cursor: 'pointer',
+              background: '#333',
+              border: 'none',
+              borderRadius: '4px',
+              color: '#fff',
+              fontSize: '0.9rem',
+              textDecoration: 'none',
+            }}
+          >
+            Edit
+          </Link>
           <button
             onClick={openEdit}
             style={{
@@ -396,7 +412,7 @@ export function SourceViewPage({ treeId, sourceId }: SourceViewPageProps): JSX.E
               fontSize: '0.9rem',
             }}
           >
-            Edit
+            Edit Details
           </button>
           <button
             onClick={() => setConfirmDeleteOpen(true)}

--- a/src/pages/SourceWorkspacePage.tsx
+++ b/src/pages/SourceWorkspacePage.tsx
@@ -2,6 +2,7 @@ import { useSource } from '$/hooks/useSources';
 import { WorkspaceHeader } from '$/components/workspace/WorkspaceHeader';
 import { WorkspaceLayout } from '$/components/workspace/WorkspaceLayout';
 import { LeftPanel } from '$/components/workspace/LeftPanel';
+import { RightPanel } from '$/components/workspace/RightPanel';
 
 interface SourceWorkspacePageProps {
   treeId: string;
@@ -24,7 +25,7 @@ export function SourceWorkspacePage({ treeId, sourceId }: SourceWorkspacePagePro
       <WorkspaceHeader treeId={treeId} sourceId={sourceId} source={source} />
       <WorkspaceLayout
         left={<LeftPanel treeId={treeId} sourceId={sourceId} />}
-        right={<div style={{ padding: '1rem', color: '#888' }}>Right panel (templates)</div>}
+        right={<RightPanel sourceId={sourceId} />}
       />
     </div>
   );

--- a/src/pages/SourceWorkspacePage.tsx
+++ b/src/pages/SourceWorkspacePage.tsx
@@ -1,0 +1,32 @@
+import { useSource } from '$/hooks/useSources';
+import { WorkspaceHeader } from '$/components/workspace/WorkspaceHeader';
+import { WorkspaceLayout } from '$/components/workspace/WorkspaceLayout';
+
+interface SourceWorkspacePageProps {
+  treeId: string;
+  sourceId: string;
+}
+
+export function SourceWorkspacePage({ treeId, sourceId }: SourceWorkspacePageProps): JSX.Element {
+  const { data: source, isLoading, isError } = useSource(sourceId);
+
+  if (isLoading) {
+    return <p style={{ padding: '1rem', color: '#666' }}>Loading...</p>;
+  }
+
+  if (isError || !source) {
+    return <p style={{ padding: '1rem', color: '#c00' }}>Source not found.</p>;
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <WorkspaceHeader treeId={treeId} sourceId={sourceId} source={source} />
+      <WorkspaceLayout
+        left={<div style={{ padding: '1rem', color: '#888' }}>Left panel (citations + images)</div>}
+        right={
+          <div style={{ padding: '1rem', color: '#888' }}>Right panel (templates)</div>
+        }
+      />
+    </div>
+  );
+}

--- a/src/pages/SourceWorkspacePage.tsx
+++ b/src/pages/SourceWorkspacePage.tsx
@@ -1,6 +1,7 @@
 import { useSource } from '$/hooks/useSources';
 import { WorkspaceHeader } from '$/components/workspace/WorkspaceHeader';
 import { WorkspaceLayout } from '$/components/workspace/WorkspaceLayout';
+import { LeftPanel } from '$/components/workspace/LeftPanel';
 
 interface SourceWorkspacePageProps {
   treeId: string;
@@ -22,10 +23,8 @@ export function SourceWorkspacePage({ treeId, sourceId }: SourceWorkspacePagePro
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <WorkspaceHeader treeId={treeId} sourceId={sourceId} source={source} />
       <WorkspaceLayout
-        left={<div style={{ padding: '1rem', color: '#888' }}>Left panel (citations + images)</div>}
-        right={
-          <div style={{ padding: '1rem', color: '#888' }}>Right panel (templates)</div>
-        }
+        left={<LeftPanel treeId={treeId} sourceId={sourceId} />}
+        right={<div style={{ padding: '1rem', color: '#888' }}>Right panel (templates)</div>}
       />
     </div>
   );

--- a/src/pages/SourceWorkspacePage.tsx
+++ b/src/pages/SourceWorkspacePage.tsx
@@ -16,7 +16,11 @@ export function SourceWorkspacePage({ treeId, sourceId }: SourceWorkspacePagePro
     return <p style={{ padding: '1rem', color: '#666' }}>Loading...</p>;
   }
 
-  if (isError || !source) {
+  if (isError) {
+    return <p style={{ padding: '1rem', color: '#c00' }}>Failed to load source.</p>;
+  }
+
+  if (!source) {
     return <p style={{ padding: '1rem', color: '#c00' }}>Source not found.</p>;
   }
 

--- a/src/routes/tree/$treeId/source/$sourceId.tsx
+++ b/src/routes/tree/$treeId/source/$sourceId.tsx
@@ -1,9 +1,7 @@
-import { createFileRoute } from '@tanstack/react-router';
-import { SourceViewPage } from '$/pages/SourceViewPage';
+import { createFileRoute, Outlet } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/tree/$treeId/source/$sourceId')({
-  component: function SourceViewRoute() {
-    const { treeId, sourceId } = Route.useParams();
-    return <SourceViewPage treeId={treeId} sourceId={sourceId} />;
+  component: function SourceLayout() {
+    return <Outlet />;
   },
 });

--- a/src/routes/tree/$treeId/source/$sourceId/edit.tsx
+++ b/src/routes/tree/$treeId/source/$sourceId/edit.tsx
@@ -1,13 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { SourceWorkspacePage } from '$/pages/SourceWorkspacePage';
 
 export const Route = createFileRoute('/tree/$treeId/source/$sourceId/edit')({
   component: function SourceWorkspaceRoute() {
-    const { sourceId } = Route.useParams();
-    return (
-      <div>
-        <p>Source Workspace — {sourceId}</p>
-        <p>Coming soon...</p>
-      </div>
-    );
+    const { treeId, sourceId } = Route.useParams();
+    return <SourceWorkspacePage treeId={treeId} sourceId={sourceId} />;
   },
 });

--- a/src/routes/tree/$treeId/source/$sourceId/edit.tsx
+++ b/src/routes/tree/$treeId/source/$sourceId/edit.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/tree/$treeId/source/$sourceId/edit')({
+  component: function SourceWorkspaceRoute() {
+    const { sourceId } = Route.useParams();
+    return (
+      <div>
+        <p>Source Workspace — {sourceId}</p>
+        <p>Coming soon...</p>
+      </div>
+    );
+  },
+});

--- a/src/routes/tree/$treeId/source/$sourceId/index.tsx
+++ b/src/routes/tree/$treeId/source/$sourceId/index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { SourceViewPage } from '$/pages/SourceViewPage';
+
+export const Route = createFileRoute('/tree/$treeId/source/$sourceId/')({
+  component: function SourceViewRoute() {
+    const { treeId, sourceId } = Route.useParams();
+    return <SourceViewPage treeId={treeId} sourceId={sourceId} />;
+  },
+});

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -502,6 +502,19 @@ export interface UpdateFileInput {
 }
 
 // =============================================================================
+// Citation Detail (joined query result)
+// =============================================================================
+
+export interface CitationDetail {
+  citationId: string;
+  page: string | null;
+  eventId: string | null;
+  eventTypeName: string | null;
+  eventDate: string | null;
+  linkedIndividuals: { id: string; name: string }[];
+}
+
+// =============================================================================
 // Source File (junction)
 // =============================================================================
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**', '.worktrees/**'],
     coverage: {
       provider: 'v8',
       exclude: ['src/routeTree.gen.ts', 'src/main.tsx'],


### PR DESCRIPTION
## Summary

- Implements MVP4 Phase 3: source-centric workspace for extracting genealogical data from source documents
- Side-by-side layout (citations summary + image viewer on left, template-driven linking panel on right)
- 7 event-type templates (Marriage, Baptism, Birth, Death, Burial, Census, Generic) with auto-citation

## Architecture

- **Templates as data**: pure TypeScript objects defining slots, family rules, and event types
- **Thin manager**: `SourceWorkspaceManager.createFromTemplate()` reads the template and orchestrates DB operations (individuals → event → families → citation → citation links)
- **Split routes**: `/source/$sourceId` stays read-only; `/source/$sourceId/edit` is the workspace

## Key deliverables

- 17 new UI components (workspace shell, image viewer with zoom/pan, autocomplete slots, template renderer)
- `SourceWorkspaceManager` with 26 tests covering the full flow
- `useCitationsWithDetails` joined query for the citations summary
- File attachment via Tauri file dialog → `media/` directory
- 54 new tests (521 total passing)

## Test plan

- [ ] Navigate to an existing source → click "Edit" → workspace opens
- [ ] Select Marriage template → fill husband + wife slots with new names → enter date → "Create Marriage Event" works
- [ ] Verify citation appears in left panel after creation
- [ ] Attach image files to a source → zoom/pan works
- [ ] Generic template (no event type selected) creates only citations + individuals
- [ ] Template with family rules (marriage + parents) creates parent-child families

Spec: \`docs/superpowers/specs/2026-04-04-source-workspace-design.md\`
Plan: \`docs/superpowers/plans/2026-04-04-source-workspace.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Source Workspace: editable workspace with left citations summary + image viewer, right-side event-creation panel with templates (now 7, includes Generic), slot autocomplete (300ms), inline person/place creation (name+gender only), create-summary and success feedback; image attach, zoom, pan, multi-file navigation.
* **Documentation**
  * MVP Phase 3 checklist updated to reflect completed workspace items.
* **Tests**
  * New suites covering templates, citation details, and workspace orchestration.
* **Chores**
  * Desktop config: allow file stat and permit asset: images; lint/test ignore list updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->