### PR TITLE
docs: add worktree + PR workflow rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,17 @@ const rows = await db
 
 ---
 
-# Granular Commits
+# Git Workflow
+
+## Worktree + PR
+
+All new development must be done in a **git worktree** on a dedicated feature branch, then submitted as a **pull request**. Never commit new work directly to `main`.
+
+1. Create a worktree with a feature branch
+2. Do all work in the isolated worktree
+3. Commit, push, and open a PR to `main`
+
+## Granular Commits
 
 Commit early and often. Each commit should represent a single, complete unit of work that can be reverted independently.
 


### PR DESCRIPTION
## Summary

- Add a **Worktree + PR** section to CLAUDE.md enforcing that all new development uses git worktrees on feature branches and goes through pull requests

## Test plan

- [x] Verify the rule appears in CLAUDE.md under the new "Git Workflow" heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)