### PR TITLE
feat: MVP4 Phase 4 — Entity Timeline Integration

### DIFF
--- a/docs/mvps/mvp-4-sources-media/README.md
+++ b/docs/mvps/mvp-4-sources-media/README.md
@@ -71,12 +71,12 @@ UI is HTML-only with minimal CSS (shadcn/ui comes in MVP6).
 
 ### Phase 4: Entity Timeline Integration
 
-- [ ] EventTimeline component: chronological event list
-- [ ] Source media thumbnails inline with events
-- [ ] Thumbnail generation for image files
-- [ ] Click-through: thumbnail → source workspace
-- [ ] Empty state: "Add source" link on unsourced events
-- [ ] Update individual profile view to use EventTimeline
+- [x] EventTimeline component: chronological event list
+- [x] Source media thumbnails inline with events
+- [x] Thumbnail generation for image files
+- [x] Click-through: thumbnail → source workspace
+- [x] Empty state: "Add source" link on unsourced events
+- [x] Update individual profile view to use EventTimeline
 
 ## Key Design Decisions
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-store = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "tiff"] }
 tauri-plugin-mcp-bridge = "0.10"
 
 [profile.release]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,24 @@
+use image::ImageReader;
+
+#[tauri::command]
+async fn generate_thumbnail(
+    source_path: String,
+    dest_path: String,
+    max_width: u32,
+) -> Result<(), String> {
+    let img = ImageReader::open(&source_path)
+        .map_err(|e| format!("Failed to open image: {e}"))?
+        .decode()
+        .map_err(|e| format!("Failed to decode image: {e}"))?;
+
+    let thumbnail = img.thumbnail(max_width, u32::MAX);
+    thumbnail
+        .save(&dest_path)
+        .map_err(|e| format!("Failed to save thumbnail: {e}"))?;
+
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let mut builder = tauri::Builder::default()
@@ -12,6 +33,7 @@ pub fn run() {
     }
 
     builder
+        .invoke_handler(tauri::generate_handler![generate_thumbnail])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/components/EventTimeline.tsx
+++ b/src/components/EventTimeline.tsx
@@ -1,0 +1,126 @@
+import { Link } from '@tanstack/react-router';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { useEventTimeline } from '$hooks/useEventTimeline';
+import { getEventTypeLabel } from '$lib/event-type-labels';
+import { getCurrentTreePath } from '$/db/connection';
+import type { EventTimelineEntry, EventTimelineThumbnail } from '$/types/database';
+
+interface EventTimelineProps {
+  treeId: string;
+  individualId: string;
+}
+
+const MAX_THUMBNAILS = 3;
+
+function ThumbnailImage({
+  thumb,
+  treeId,
+  treePath,
+}: {
+  thumb: EventTimelineThumbnail;
+  treeId: string;
+  treePath: string;
+}): JSX.Element {
+  const src = convertFileSrc(`${treePath}/${thumb.thumbnailPath}`);
+
+  return (
+    <Link
+      to="/tree/$treeId/source/$sourceId/edit"
+      params={{ treeId, sourceId: thumb.sourceId }}
+      title={thumb.sourceTitle}
+      style={{ display: 'inline-block', lineHeight: 0 }}
+    >
+      <img
+        src={src}
+        alt={thumb.originalFilename}
+        style={{
+          height: '48px',
+          borderRadius: '4px',
+          border: '1px solid #ddd',
+          objectFit: 'cover',
+        }}
+      />
+    </Link>
+  );
+}
+
+function TimelineRow({
+  entry,
+  treeId,
+  treePath,
+}: {
+  entry: EventTimelineEntry;
+  treeId: string;
+  treePath: string | null;
+}): JSX.Element {
+  const label = getEventTypeLabel(entry.eventType);
+  const displayThumbnails = entry.thumbnails.slice(0, MAX_THUMBNAILS);
+  const extraCount = entry.thumbnails.length - MAX_THUMBNAILS;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '1rem',
+        padding: '0.5rem 0',
+        borderBottom: '1px solid #eee',
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div>
+          <strong>{label}</strong>
+        </div>
+        <div style={{ color: '#666', fontSize: '0.9rem' }}>
+          {entry.dateOriginal ?? '(no date)'}
+          {entry.place && <> — {entry.place.fullName}</>}
+        </div>
+        {!entry.hasCitations && (
+          <Link
+            to="/tree/$treeId/sources"
+            params={{ treeId }}
+            style={{ fontSize: '0.8rem', color: '#888', textDecoration: 'underline' }}
+          >
+            Add source
+          </Link>
+        )}
+      </div>
+
+      {treePath && displayThumbnails.length > 0 && (
+        <div style={{ display: 'flex', gap: '4px', alignItems: 'center', flexShrink: 0 }}>
+          {displayThumbnails.map((thumb) => (
+            <ThumbnailImage key={thumb.fileId} thumb={thumb} treeId={treeId} treePath={treePath} />
+          ))}
+          {extraCount > 0 && (
+            <span style={{ fontSize: '0.75rem', color: '#888' }}>+{extraCount}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function EventTimeline({ treeId, individualId }: EventTimelineProps): JSX.Element {
+  const { data: entries, isLoading, isError } = useEventTimeline(individualId);
+  const treePath = getCurrentTreePath();
+
+  if (isLoading) {
+    return <p style={{ color: '#666' }}>Loading events...</p>;
+  }
+
+  if (isError) {
+    return <p style={{ color: '#c00' }}>Failed to load events.</p>;
+  }
+
+  if (!entries || entries.length === 0) {
+    return <p style={{ color: '#666' }}>No events recorded.</p>;
+  }
+
+  return (
+    <div>
+      {entries.map((entry) => (
+        <TimelineRow key={entry.id} entry={entry} treeId={treeId} treePath={treePath} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/workspace/ImageViewer.tsx
+++ b/src/components/workspace/ImageViewer.tsx
@@ -5,7 +5,8 @@ import { convertFileSrc } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
 import { stat, remove } from '@tauri-apps/plugin-fs';
 import { copyFileToTree } from '$lib/file-utils';
-import { createFile, addFileToSource, deleteFile } from '$db-tree/files';
+import { generateThumbnail } from '$lib/thumbnails';
+import { createFile, addFileToSource, updateFile, deleteFile } from '$db-tree/files';
 import { queryKeys } from '$lib/query-keys';
 import { getCurrentTreePath } from '$/db/connection';
 
@@ -59,12 +60,17 @@ export function ImageViewer({ sourceId }: ImageViewerProps): JSX.Element {
         try {
           const ext = filename.split('.').pop()?.toLowerCase() ?? '';
           const fileInfo = await stat(copiedPath);
+          const mimeType = mimeMap[ext] ?? 'application/octet-stream';
           fileId = await createFile({
             originalFilename: filename,
             relativePath,
-            mimeType: mimeMap[ext] ?? 'application/octet-stream',
+            mimeType,
             fileSize: fileInfo.size,
           });
+          const thumbnailPath = await generateThumbnail(treePath, relativePath, mimeType);
+          if (thumbnailPath) {
+            await updateFile(fileId, { thumbnailPath });
+          }
           await addFileToSource({ sourceId, fileId });
         } catch (err) {
           // Roll back side effects for this file: DB row and copied asset.

--- a/src/db/trees/event-timeline.test.ts
+++ b/src/db/trees/event-timeline.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTreeInMemoryDb } from '$/test/sqlite-memory';
+import { getEventTimelineForIndividual } from './event-timeline';
+import { createIndividual } from './individuals';
+import { createEvent, addEventParticipant, getEventTypes } from './events';
+import { createSource } from './sources';
+import { createCitation, createCitationLink } from './citations';
+import { createFile, addFileToSource } from './files';
+
+// A single in-memory DB shared across all tests in this file.
+const db = createTreeInMemoryDb();
+
+vi.mock('../connection', () => ({
+  getTreeDb: vi.fn(),
+}));
+
+// Lazily resolve the mock after the module is loaded
+import('../connection').then(({ getTreeDb }) => {
+  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+});
+
+beforeEach(async () => {
+  const { getTreeDb } = await import('../connection');
+  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  db._raw.exec('DELETE FROM source_files');
+  db._raw.exec('DELETE FROM files');
+  db._raw.exec('DELETE FROM citation_links');
+  db._raw.exec('DELETE FROM source_citations');
+  db._raw.exec('DELETE FROM sources');
+  db._raw.exec('DELETE FROM event_participants');
+  db._raw.exec('DELETE FROM events');
+  db._raw.exec('DELETE FROM names');
+  db._raw.exec('DELETE FROM individuals');
+});
+
+describe('getEventTimelineForIndividual', () => {
+  it('returns empty array for individual with no events', async () => {
+    const individualId = await createIndividual({ gender: 'M' });
+    const result = await getEventTimelineForIndividual(individualId);
+    expect(result).toEqual([]);
+  });
+
+  it('returns entries with hasCitations false and empty thumbnails when events have no citations', async () => {
+    const individualId = await createIndividual({ gender: 'M' });
+    const types = await getEventTypes();
+    const eventId = await createEvent({ eventTypeId: types[0].id });
+    await addEventParticipant({ eventId, individualId, role: 'principal' });
+
+    const result = await getEventTimelineForIndividual(individualId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(eventId);
+    expect(result[0].hasCitations).toBe(false);
+    expect(result[0].thumbnails).toEqual([]);
+  });
+
+  it('returns hasCitations true with empty thumbnails when citations exist but source has no files', async () => {
+    const individualId = await createIndividual({ gender: 'F' });
+    const types = await getEventTypes();
+    const eventId = await createEvent({ eventTypeId: types[0].id, dateOriginal: '1 Jan 1900' });
+    await addEventParticipant({ eventId, individualId, role: 'principal' });
+
+    // Create source + citation + link to event
+    const sourceId = await createSource({ title: 'Birth Certificate' });
+    const citationId = await createCitation({ sourceId, page: 'p. 1' });
+    await createCitationLink({ citationId, entityType: 'event', entityId: eventId });
+
+    const result = await getEventTimelineForIndividual(individualId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].hasCitations).toBe(true);
+    expect(result[0].thumbnails).toEqual([]);
+  });
+
+  it('returns hasCitations true with empty thumbnails when source has files without thumbnails', async () => {
+    const individualId = await createIndividual({ gender: 'M' });
+    const types = await getEventTypes();
+    const eventId = await createEvent({ eventTypeId: types[0].id });
+    await addEventParticipant({ eventId, individualId, role: 'principal' });
+
+    const sourceId = await createSource({ title: 'Marriage Record' });
+    const citationId = await createCitation({ sourceId });
+    await createCitationLink({ citationId, entityType: 'event', entityId: eventId });
+
+    // File without thumbnail
+    const fileId = await createFile({
+      originalFilename: 'scan.pdf',
+      relativePath: 'files/scan.pdf',
+      mimeType: 'application/pdf',
+      fileSize: 1024,
+    });
+    await addFileToSource({ sourceId, fileId });
+
+    const result = await getEventTimelineForIndividual(individualId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].hasCitations).toBe(true);
+    expect(result[0].thumbnails).toEqual([]);
+  });
+
+  it('returns populated thumbnails for full chain: event -> citation -> source -> file with thumbnail', async () => {
+    const individualId = await createIndividual({ gender: 'F' });
+    const types = await getEventTypes();
+    const eventId = await createEvent({
+      eventTypeId: types[0].id,
+      dateOriginal: '15 Jun 1892',
+    });
+    await addEventParticipant({ eventId, individualId, role: 'principal' });
+
+    const sourceId = await createSource({ title: 'Parish Register' });
+    const citationId = await createCitation({ sourceId, page: 'folio 42' });
+    await createCitationLink({ citationId, entityType: 'event', entityId: eventId });
+
+    const fileId = await createFile({
+      originalFilename: 'baptism_record.jpg',
+      relativePath: 'files/baptism_record.jpg',
+      mimeType: 'image/jpeg',
+      fileSize: 204800,
+      width: 1200,
+      height: 800,
+      thumbnailPath: 'thumbs/baptism_record_thumb.jpg',
+    });
+    await addFileToSource({ sourceId, fileId });
+
+    const result = await getEventTimelineForIndividual(individualId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].hasCitations).toBe(true);
+    expect(result[0].thumbnails).toHaveLength(1);
+    expect(result[0].thumbnails[0]).toEqual({
+      fileId,
+      thumbnailPath: 'thumbs/baptism_record_thumb.jpg',
+      originalFilename: 'baptism_record.jpg',
+      sourceId,
+      sourceTitle: 'Parish Register',
+    });
+  });
+
+  it('aggregates thumbnails from multiple sources on the same event', async () => {
+    const individualId = await createIndividual({ gender: 'M' });
+    const types = await getEventTypes();
+    const eventId = await createEvent({ eventTypeId: types[0].id });
+    await addEventParticipant({ eventId, individualId, role: 'principal' });
+
+    // Source 1 with a thumbnail
+    const sourceId1 = await createSource({ title: 'Source A' });
+    const citationId1 = await createCitation({ sourceId: sourceId1, page: 'p. 1' });
+    await createCitationLink({ citationId: citationId1, entityType: 'event', entityId: eventId });
+    const fileId1 = await createFile({
+      originalFilename: 'doc1.jpg',
+      relativePath: 'files/doc1.jpg',
+      mimeType: 'image/jpeg',
+      fileSize: 1024,
+      thumbnailPath: 'thumbs/doc1_thumb.jpg',
+    });
+    await addFileToSource({ sourceId: sourceId1, fileId: fileId1 });
+
+    // Source 2 with a thumbnail
+    const sourceId2 = await createSource({ title: 'Source B' });
+    const citationId2 = await createCitation({ sourceId: sourceId2, page: 'p. 5' });
+    await createCitationLink({ citationId: citationId2, entityType: 'event', entityId: eventId });
+    const fileId2 = await createFile({
+      originalFilename: 'doc2.png',
+      relativePath: 'files/doc2.png',
+      mimeType: 'image/png',
+      fileSize: 2048,
+      thumbnailPath: 'thumbs/doc2_thumb.png',
+    });
+    await addFileToSource({ sourceId: sourceId2, fileId: fileId2 });
+
+    const result = await getEventTimelineForIndividual(individualId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].thumbnails).toHaveLength(2);
+
+    const filenames = result[0].thumbnails.map((t) => t.originalFilename).sort();
+    expect(filenames).toEqual(['doc1.jpg', 'doc2.png']);
+
+    const sourceTitles = result[0].thumbnails.map((t) => t.sourceTitle).sort();
+    expect(sourceTitles).toEqual(['Source A', 'Source B']);
+  });
+
+  it('returns multiple timeline entries for an individual with multiple events', async () => {
+    const individualId = await createIndividual({ gender: 'F' });
+    const types = await getEventTypes();
+
+    const eventId1 = await createEvent({
+      eventTypeId: types[0].id,
+      dateOriginal: '1870',
+    });
+    await addEventParticipant({ eventId: eventId1, individualId, role: 'principal' });
+
+    const eventId2 = await createEvent({
+      eventTypeId: types[1].id,
+      dateOriginal: '1950',
+    });
+    await addEventParticipant({ eventId: eventId2, individualId, role: 'principal' });
+
+    const result = await getEventTimelineForIndividual(individualId);
+
+    expect(result).toHaveLength(2);
+    const ids = result.map((e) => e.id);
+    expect(ids).toContain(eventId1);
+    expect(ids).toContain(eventId2);
+
+    // Both should have no citations
+    for (const entry of result) {
+      expect(entry.hasCitations).toBe(false);
+      expect(entry.thumbnails).toEqual([]);
+    }
+  });
+});

--- a/src/db/trees/event-timeline.ts
+++ b/src/db/trees/event-timeline.ts
@@ -1,0 +1,110 @@
+import { getTreeDb } from '../connection';
+import { parseEntityId, formatEntityId } from '$/lib/entityId';
+import { getEventsByIndividualIdWithDetails } from './events';
+import type { EventTimelineEntry, EventTimelineThumbnail } from '$/types/database';
+
+interface RawCitationSource {
+  event_id: number;
+  source_id: number;
+  source_title: string;
+}
+
+interface RawSourceThumbnail {
+  source_id: number;
+  file_id: number;
+  thumbnail_path: string;
+  original_filename: string;
+}
+
+/**
+ * Get all events for an individual, enriched with source media thumbnails.
+ * Uses a layered query approach:
+ * 1. Get events with details (reuses existing function)
+ * 2. Batch-fetch citation sources for those events
+ * 3. Batch-fetch files with thumbnails for those sources
+ */
+export async function getEventTimelineForIndividual(
+  individualId: string
+): Promise<EventTimelineEntry[]> {
+  const events = await getEventsByIndividualIdWithDetails(individualId);
+
+  if (events.length === 0) {
+    return [];
+  }
+
+  const db = await getTreeDb();
+
+  // Step 2: Get citation sources for all events
+  const eventDbIds = events.map((e) => parseEntityId(e.id));
+  const placeholders = eventDbIds.map((_, i) => `$${i + 1}`).join(', ');
+
+  const citationRows = await db.select<RawCitationSource[]>(
+    `SELECT DISTINCT cl.entity_id AS event_id, s.id AS source_id, s.title AS source_title
+     FROM citation_links cl
+     JOIN source_citations sc ON sc.id = cl.citation_id
+     JOIN sources s ON s.id = sc.source_id
+     WHERE cl.entity_type = 'event'
+       AND cl.entity_id IN (${placeholders})`,
+    eventDbIds
+  );
+
+  // Build map: eventDbId -> { sourceId, sourceTitle }[]
+  const eventSourceMap = new Map<number, { sourceId: number; sourceTitle: string }[]>();
+  for (const row of citationRows) {
+    const list = eventSourceMap.get(row.event_id) ?? [];
+    list.push({ sourceId: row.source_id, sourceTitle: row.source_title });
+    eventSourceMap.set(row.event_id, list);
+  }
+
+  // Step 3: Get files with thumbnails for all sources
+  const allSourceIds = [...new Set(citationRows.map((r) => r.source_id))];
+
+  const sourceThumbnailMap = new Map<number, RawSourceThumbnail[]>();
+
+  if (allSourceIds.length > 0) {
+    const srcPlaceholders = allSourceIds.map((_, i) => `$${i + 1}`).join(', ');
+
+    const thumbnailRows = await db.select<RawSourceThumbnail[]>(
+      `SELECT sf.source_id, f.id AS file_id, f.thumbnail_path, f.original_filename
+       FROM source_files sf
+       JOIN files f ON f.id = sf.file_id
+       WHERE sf.source_id IN (${srcPlaceholders})
+         AND f.thumbnail_path IS NOT NULL
+       ORDER BY sf.sort_order`,
+      allSourceIds
+    );
+
+    for (const row of thumbnailRows) {
+      const list = sourceThumbnailMap.get(row.source_id) ?? [];
+      list.push(row);
+      sourceThumbnailMap.set(row.source_id, list);
+    }
+  }
+
+  // Step 4: Assemble EventTimelineEntry[]
+  return events.map((event) => {
+    const eventDbId = parseEntityId(event.id);
+    const sources = eventSourceMap.get(eventDbId) ?? [];
+    const hasCitations = sources.length > 0;
+
+    const thumbnails: EventTimelineThumbnail[] = [];
+    for (const src of sources) {
+      const files = sourceThumbnailMap.get(src.sourceId) ?? [];
+      for (const file of files) {
+        thumbnails.push({
+          fileId: String(file.file_id),
+          thumbnailPath: file.thumbnail_path,
+          originalFilename: file.original_filename,
+          sourceId: formatEntityId('S', src.sourceId),
+          sourceTitle: src.sourceTitle,
+        });
+      }
+    }
+
+    return {
+      ...event,
+      thumbnails,
+      hasCitations,
+    };
+  });
+}

--- a/src/hooks/useEventTimeline.ts
+++ b/src/hooks/useEventTimeline.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '$/lib/query-keys';
+import { getEventTimelineForIndividual } from '$db-tree/event-timeline';
+
+export function useEventTimeline(individualId: string) {
+  return useQuery({
+    queryKey: queryKeys.eventTimeline(individualId),
+    queryFn: () => getEventTimelineForIndividual(individualId),
+  });
+}

--- a/src/lib/event-type-labels.test.ts
+++ b/src/lib/event-type-labels.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EventType } from '$/types/database';
+
+import { getEventTypeLabel } from './event-type-labels';
+
+function makeEventType(overrides: Partial<EventType> = {}): EventType {
+  return {
+    id: 'ET-0001',
+    tag: null,
+    category: 'individual',
+    isSystem: true,
+    customName: null,
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+describe('getEventTypeLabel', () => {
+  it('returns readable labels for system GEDCOM tags', () => {
+    expect(getEventTypeLabel(makeEventType({ tag: 'BIRT' }))).toBe('Birth');
+    expect(getEventTypeLabel(makeEventType({ tag: 'DEAT' }))).toBe('Death');
+    expect(getEventTypeLabel(makeEventType({ tag: 'MARR', category: 'family' }))).toBe('Marriage');
+    expect(getEventTypeLabel(makeEventType({ tag: 'CREM' }))).toBe('Cremation');
+    expect(getEventTypeLabel(makeEventType({ tag: 'ANUL', category: 'family' }))).toBe('Annulment');
+  });
+
+  it('returns customName when set', () => {
+    const eventType = makeEventType({
+      tag: 'BIRT',
+      isSystem: false,
+      customName: 'Naming Ceremony',
+    });
+    expect(getEventTypeLabel(eventType)).toBe('Naming Ceremony');
+  });
+
+  it('returns customName even when tag is null', () => {
+    const eventType = makeEventType({
+      tag: null,
+      isSystem: false,
+      customName: 'DNA Test',
+    });
+    expect(getEventTypeLabel(eventType)).toBe('DNA Test');
+  });
+
+  it('falls back to raw tag for unknown tags', () => {
+    const eventType = makeEventType({ tag: 'XTAG' });
+    expect(getEventTypeLabel(eventType)).toBe('XTAG');
+  });
+
+  it('returns Unknown when both tag and customName are null', () => {
+    const eventType = makeEventType({ tag: null, customName: null });
+    expect(getEventTypeLabel(eventType)).toBe('Unknown');
+  });
+});

--- a/src/lib/event-type-labels.ts
+++ b/src/lib/event-type-labels.ts
@@ -1,0 +1,52 @@
+import type { EventType } from '$/types/database';
+
+const GEDCOM_EVENT_TYPE_LABELS: Record<string, string> = {
+  // Individual events
+  BIRT: 'Birth',
+  CHR: 'Christening',
+  DEAT: 'Death',
+  BURI: 'Burial',
+  CREM: 'Cremation',
+  ADOP: 'Adoption',
+  BAPM: 'Baptism',
+  BARM: 'Bar Mitzvah',
+  BASM: 'Bas Mitzvah',
+  CONF: 'Confirmation',
+  FCOM: 'First Communion',
+  ORDN: 'Ordination',
+  NATU: 'Naturalization',
+  EMIG: 'Emigration',
+  IMMI: 'Immigration',
+  CENS: 'Census',
+  PROB: 'Probate',
+  WILL: 'Will',
+  GRAD: 'Graduation',
+  RETI: 'Retirement',
+  OCCU: 'Occupation',
+  RESI: 'Residence',
+  EDUC: 'Education',
+  RELI: 'Religion',
+
+  // Family events
+  MARR: 'Marriage',
+  MARB: 'Marriage Banns',
+  MARC: 'Marriage Contract',
+  MARL: 'Marriage License',
+  MARS: 'Marriage Settlement',
+  ENGA: 'Engagement',
+  DIV: 'Divorce',
+  DIVF: 'Divorce Filed',
+  ANUL: 'Annulment',
+};
+
+export function getEventTypeLabel(eventType: EventType): string {
+  if (eventType.customName !== null) {
+    return eventType.customName;
+  }
+
+  if (eventType.tag !== null && eventType.tag in GEDCOM_EVENT_TYPE_LABELS) {
+    return GEDCOM_EVENT_TYPE_LABELS[eventType.tag];
+  }
+
+  return eventType.tag ?? 'Unknown';
+}

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -21,4 +21,5 @@ export const queryKeys = {
   citations: (sourceId: string) => ['citations', sourceId] as const,
   citationsWithDetails: (sourceId: string) => ['citationsWithDetails', sourceId] as const,
   files: (sourceId: string) => ['files', sourceId] as const,
+  eventTimeline: (individualId: string) => ['eventTimeline', individualId] as const,
 };

--- a/src/lib/thumbnails.ts
+++ b/src/lib/thumbnails.ts
@@ -20,8 +20,7 @@ export async function generateThumbnail(
 
   const sourcePath = `${treePath}/${relativePath}`;
   const filename = relativePath.split('/').pop() ?? '';
-  const nameWithoutExt = filename.replace(/\.[^.]+$/, '');
-  const thumbFilename = `thumb_${nameWithoutExt}.jpg`;
+  const thumbFilename = `thumb_${filename.replace(/\./g, '_')}.jpg`;
   const thumbRelativePath = `${THUMBNAILS_DIR}/${thumbFilename}`;
   const thumbAbsolutePath = `${treePath}/${thumbRelativePath}`;
   const thumbDir = `${treePath}/${THUMBNAILS_DIR}`;

--- a/src/lib/thumbnails.ts
+++ b/src/lib/thumbnails.ts
@@ -1,0 +1,45 @@
+import { invoke } from '@tauri-apps/api/core';
+import { mkdir, exists } from '@tauri-apps/plugin-fs';
+
+const IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/tiff'];
+const THUMBNAIL_MAX_WIDTH = 200;
+const THUMBNAILS_DIR = 'media/thumbnails';
+
+/**
+ * Generate a thumbnail for an image file in the tree's media directory.
+ * Returns the relative path to the thumbnail, or null if generation fails or file is not an image.
+ */
+export async function generateThumbnail(
+  treePath: string,
+  relativePath: string,
+  mimeType: string
+): Promise<string | null> {
+  if (!IMAGE_MIME_TYPES.includes(mimeType)) {
+    return null;
+  }
+
+  const sourcePath = `${treePath}/${relativePath}`;
+  const filename = relativePath.split('/').pop() ?? '';
+  const nameWithoutExt = filename.replace(/\.[^.]+$/, '');
+  const thumbFilename = `thumb_${nameWithoutExt}.jpg`;
+  const thumbRelativePath = `${THUMBNAILS_DIR}/${thumbFilename}`;
+  const thumbAbsolutePath = `${treePath}/${thumbRelativePath}`;
+  const thumbDir = `${treePath}/${THUMBNAILS_DIR}`;
+
+  try {
+    const dirExists = await exists(thumbDir);
+    if (!dirExists) {
+      await mkdir(thumbDir, { recursive: true });
+    }
+
+    await invoke('generate_thumbnail', {
+      sourcePath,
+      destPath: thumbAbsolutePath,
+      maxWidth: THUMBNAIL_MAX_WIDTH,
+    });
+
+    return thumbRelativePath;
+  } catch {
+    return null;
+  }
+}

--- a/src/pages/IndividualViewPage.tsx
+++ b/src/pages/IndividualViewPage.tsx
@@ -1,29 +1,12 @@
 import { Link } from '@tanstack/react-router';
 import { useIndividual } from '$/hooks/useIndividuals';
+import { EventTimeline } from '$components/EventTimeline';
 import { formatName } from '$/db/trees/names';
 import { GENDER_LABELS } from '$/lib/constants';
-import type { EventWithDetails } from '$/types/database';
 
 interface IndividualViewPageProps {
   treeId: string;
   individualId: string;
-}
-
-function EventInfo({
-  label,
-  event,
-}: {
-  label: string;
-  event: EventWithDetails | null;
-}): JSX.Element | null {
-  if (!event) return null;
-
-  return (
-    <li>
-      <strong>{label}:</strong> {event.dateOriginal ?? '(no date)'}
-      {event.place && <> — {event.place.fullName}</>}
-    </li>
-  );
 }
 
 export function IndividualViewPage({ treeId, individualId }: IndividualViewPageProps): JSX.Element {
@@ -145,14 +128,7 @@ export function IndividualViewPage({ treeId, individualId }: IndividualViewPageP
 
       <section>
         <h2 style={{ fontSize: '1.1rem', marginBottom: '0.5rem' }}>Events</h2>
-        {!individual.birthEvent && !individual.deathEvent ? (
-          <p style={{ color: '#666' }}>No events recorded.</p>
-        ) : (
-          <ul style={{ margin: 0, paddingLeft: '1.25rem' }}>
-            <EventInfo label="Birth" event={individual.birthEvent} />
-            <EventInfo label="Death" event={individual.deathEvent} />
-          </ul>
-        )}
+        <EventTimeline treeId={treeId} individualId={individualId} />
       </section>
     </div>
   );

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -531,3 +531,20 @@ export interface CreateSourceFileInput {
   fileId: string;
   sortOrder?: number;
 }
+
+// =============================================================================
+// Event Timeline (enriched for individual profile)
+// =============================================================================
+
+export interface EventTimelineThumbnail {
+  fileId: string;
+  thumbnailPath: string;
+  originalFilename: string;
+  sourceId: string;
+  sourceTitle: string;
+}
+
+export interface EventTimelineEntry extends EventWithDetails {
+  thumbnails: EventTimelineThumbnail[];
+  hasCitations: boolean;
+}


### PR DESCRIPTION
## Summary

- Add **EventTimeline** component to individual profile view showing all events chronologically (replaces birth/death-only display)
- Add **Rust thumbnail generation** via `image` crate Tauri command, with TypeScript wrapper that generates thumbnails on file attachment
- Add **event timeline DB query** with layered approach: events → citation sources → file thumbnails (3 efficient queries)
- Source media **thumbnails displayed inline** with events (48px, up to 3 per event)
- **Click-through** from thumbnail to source workspace (`/tree/$treeId/source/$sourceId/edit`)
- **"Add source"** link on unsourced events
- Add **event type label utility** mapping 33 GEDCOM tags to human-readable English labels

## Files changed

| File | Change |
|------|--------|
| `src/lib/event-type-labels.ts` | New — GEDCOM tag → label mapping |
| `src-tauri/Cargo.toml` | Add `image` crate |
| `src-tauri/src/lib.rs` | Add `generate_thumbnail` Tauri command |
| `src/lib/thumbnails.ts` | New — TS thumbnail generation wrapper |
| `src/components/workspace/ImageViewer.tsx` | Generate thumbnails on file attach |
| `src/db/trees/event-timeline.ts` | New — layered timeline query |
| `src/types/database.ts` | Add timeline types |
| `src/lib/query-keys.ts` | Add `eventTimeline` key |
| `src/hooks/useEventTimeline.ts` | New — React Query hook |
| `src/components/EventTimeline.tsx` | New — timeline UI component |
| `src/pages/IndividualViewPage.tsx` | Replace EventInfo with EventTimeline |

## Test plan

- [x] 532 tests passing (12 new: 5 for labels, 7 for timeline DB query)
- [x] TypeScript + Vite build passes
- [x] ESLint clean
- [ ] Manual: navigate to individual profile, verify full event timeline
- [ ] Manual: attach image to source, verify thumbnail generation
- [ ] Manual: click thumbnail → opens source workspace
- [ ] Manual: verify "Add source" link on unsourced events

🤖 Generated with [Claude Code](https://claude.com/claude-code)