### PR TITLE
perf(ui): fix search input freeze

### DIFF
--- a/openspec/changes/archive/2026-04-10-fix-search-input-freeze/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-10-fix-search-input-freeze/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/archive/2026-04-10-fix-search-input-freeze/design.md
+++ b/openspec/changes/archive/2026-04-10-fix-search-input-freeze/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The shared `DataTable` component (`src/components/data-table.tsx`) is used by the Individuals, Families, Sources, and Repositories pages. Typing in its search input currently freezes the app. Investigation identified four compounding causes:
+
+1. **No debouncing** — `src/components/data-table.tsx:80` calls `setGlobalFilter(e.target.value)` synchronously on every keystroke. TanStack Table's `getFilteredRowModel()` runs `includesString` over the entire dataset for each character.
+2. **Columns recreated per render** — All four pages build their `columns: ColumnDef[]` array inline inside the component body (e.g., `IndividualsPage.tsx:19-46`). When the parent re-renders, a new array reference is passed to `DataTable`, which causes `useReactTable` to recompute internal state and all row/cell memoization to invalidate.
+3. **N+1 queries in managers** — `IndividualManager.getAll()` (`src/managers/IndividualManager.ts:81-93`) loops over base individuals and calls `getById(id)` per row, which itself fires 3 more queries (`getPrimaryName`, `getNamesByIndividualId`, `getEventsByIndividualIdWithDetails`). For a tree with 500 individuals, that's ~2,000 SQL calls per `useIndividuals()` load. `FamilyManager.getAll()` (`src/managers/FamilyManager.ts:107-119`) has the same pattern.
+4. **Heavy `IndividualWithDetails` payload** — each row returned to the table carries all names, birth event details, and death event details. Filtering iterates over every row's nested objects repeatedly.
+
+Issues 1 and 2 are the primary causes of the typing freeze. Issue 3 makes the initial load and any cache invalidation very slow. Issue 4 amplifies both.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Typing in any search input is responsive — characters appear immediately, no frame drops
+- Filtering runs against in-memory cached data, not against SQL queries
+- Initial page load for Individuals / Families completes in a single SQL round-trip per logical entity (constant number of queries, independent of row count)
+- No change to visible behavior — same columns, same filter semantics (substring match), same pagination
+
+**Non-Goals:**
+
+- Virtualized rendering of table rows (not needed once debounce + memoization are in place for typical tree sizes)
+- Server-side / DB-side filtering (in-memory filter is fine once the data is shaped correctly)
+- Rewriting TanStack Table usage or swapping libraries
+- Adding new search features (fuzzy match, field-specific filters, etc.)
+- Changing the data model or adding indexes — the queries are fast individually; the problem is volume
+
+## Decisions
+
+### D1: Debounce the input value with a 250 ms delay
+
+**Decision**: Introduce a small `useDebouncedValue<T>(value, delay)` hook (~15 lines) and use it in `DataTable` so that the `<Input>` remains controlled by an immediate `useState` (instant visual feedback), while `globalFilter` is set from the debounced value.
+
+**Rationale**: The input must update immediately so the user sees their keystrokes. The expensive operation (`getFilteredRowModel`) must only run when typing pauses. Two-state decoupling is the standard React pattern.
+
+**Alternative considered**: Debounce directly inside `onChange`. Rejected because that would also delay the visible input value, making the input feel laggy.
+
+**Alternative considered**: `useDeferredValue`. Rejected because it doesn't guarantee a coalescing window — under sustained keystrokes on a slow machine the filter can still run on every intermediate value. A fixed 250 ms debounce is simpler and more predictable.
+
+### D2: Memoize columns arrays in every page using DataTable
+
+**Decision**: Wrap each page's `columns` definition in `useMemo(() => [...], [t])`. Depend only on translation function `t` (for column headers) so the array reference is stable across unrelated re-renders.
+
+**Rationale**: TanStack Table's `useReactTable` treats `columns` as a dependency. Passing a new array on every render invalidates its internal memoization, which means `getFilteredRowModel` must recompute from scratch on every keystroke-driven re-render. Stable references fix this at the root.
+
+**Alternative considered**: Move columns to module scope (outside component). Rejected because columns need `t()` for headers and cell renderers reference hooks like `useTranslation`.
+
+### D3: Rewrite `IndividualManager.getAll()` and `FamilyManager.getAll()` with batch queries
+
+**Decision**: Replace the per-row loop with a fixed number of SQL calls that fetch all rows at once, then assemble the enriched objects in JS:
+
+For individuals:
+
+1. `SELECT ... FROM individuals ORDER BY id` — all individuals
+2. `SELECT ... FROM names WHERE is_primary = 1 ORDER BY individual_id` — all primary names
+3. `SELECT ... FROM names ORDER BY individual_id, is_primary DESC` — all names grouped by individual
+4. Birth and death events: either a single query joining `events` + `event_participants` filtered by `event_type IN ('BIRT','DEAT')` and role `principal`, or two targeted queries
+5. In JS, build maps keyed by `individual_id` and assemble `IndividualWithDetails[]`
+
+**Rationale**: This turns O(N) queries into O(1). For the list view we only need primary name + birth/death summary; heavier detail loads stay on the individual detail page via the existing `getById` path.
+
+**Alternative considered**: A single large JOIN query returning denormalized rows. Rejected because it complicates row mapping (cartesian products with multiple names/events) and obscures the SQL. Separate focused queries are easier to reason about and still constant-time.
+
+### D4: Keep the "enriched" shape of list rows but load it cheaply
+
+**Decision**: The list rows still expose `primaryName`, `birthEvent`, `deathEvent` so the existing column definitions keep working unchanged. Only the loading strategy changes.
+
+**Rationale**: Minimizes blast radius — no changes to column definitions, no changes to table rendering logic, no changes to consumer code beyond the manager.
+
+**Alternative considered**: Introduce a slimmer `IndividualListRow` type. Rejected as scope creep — the performance problem is the query count, not the payload size.
+
+### D5: Do not memoize `DataTable` with `React.memo`
+
+**Decision**: Rely on stable `columns` + `data` props + debounced filter state. Do not wrap `DataTable` in `React.memo`.
+
+**Rationale**: Once D1 + D2 land, re-renders of the parent page become cheap and infrequent (only on actual data/filter changes). `React.memo` adds equality-check cost on every render and is unnecessary.
+
+**Revisit if**: profiling after D1–D4 still shows render storms.
+
+## Risks / Trade-offs
+
+- **Debounce delay feels sluggish on fast typists** → 250 ms is short enough to feel snappy; can tune to 150–300 ms based on feel after implementation. The filter result appearing 250 ms after the last keystroke is industry standard.
+- **Batch query assumes all data fits in memory** → Trees can have thousands of individuals. JS maps over thousands of rows are fine; the in-memory filter is fine too. If trees ever reach 100k+, we'd move to server-side filtering — out of scope now.
+- **Code duplication in batch assembly** → Both `IndividualManager.getAll` and `FamilyManager.getAll` need similar "fetch all, build map, assemble" logic. Each manager stays self-contained; no premature shared abstraction.
+- **Refactor touches hot code** → Mitigated by keeping return types unchanged and relying on existing unit/integration tests for the managers.
+- **`useMemo` deps easy to get wrong** → If a column cell uses a closure over a prop, forgetting that in the deps array causes stale renders. Mitigation: keep column definitions pure / only depend on `t`, and extract any prop-dependent logic to a separate memoized value.

--- a/openspec/changes/archive/2026-04-10-fix-search-input-freeze/proposal.md
+++ b/openspec/changes/archive/2026-04-10-fix-search-input-freeze/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Every search input in the app (Individuals, Families, Sources, Repositories pages) freezes the UI when typing: characters don't appear, the main thread blocks, and users must restart the app. Root causes are compounding performance problems in the shared `DataTable` component and the manager layer: no input debouncing, column definitions recreated on every render (breaking TanStack Table memoization), and N+1 query patterns in `IndividualManager.getAll()` / `FamilyManager.getAll()` that load hundreds of rows with 3–5 extra queries per row. This makes the app essentially unusable on any non-trivial tree.
+
+## What Changes
+
+- **Debounce search input** in `DataTable` so `globalFilter` state only updates after the user stops typing (~250ms), decoupling typing from the filter computation
+- **Memoize column definitions** in all pages using `DataTable` (Individuals, Families, Sources, Repositories) via `useMemo` so `useReactTable` doesn't recompute internal state on every render
+- **Fix N+1 queries** in `IndividualManager.getAll()` and `FamilyManager.getAll()` by fetching aggregate data in a single query (or a small fixed number of joined queries) instead of looping with per-row `getById` calls
+- **Optional**: memoize the `DataTable` component itself (`React.memo`) and the cell renderers to reduce cascade re-renders
+
+## Capabilities
+
+### New Capabilities
+
+- `data-table-search-performance`: Behavioral requirements for the shared DataTable's search input — responsiveness while typing, debouncing, and stable column references
+- `bulk-entity-fetch`: Efficient loading of enriched entity lists (individuals, families) without N+1 queries
+
+### Modified Capabilities
+
+_None — no existing spec-level requirements are changing._
+
+## Impact
+
+- **Components**: `src/components/data-table.tsx` — debounce logic, possibly `React.memo`
+- **Pages**: `src/pages/IndividualsPage.tsx`, `src/pages/FamiliesPage.tsx`, `src/pages/SourcesPage.tsx`, `src/pages/RepositoriesPage.tsx` — wrap column definitions in `useMemo`
+- **Managers**: `src/managers/IndividualManager.ts`, `src/managers/FamilyManager.ts` — rewrite `getAll()` to avoid per-row queries
+- **DB layer**: Possibly new batch-fetch functions in `src/db/trees/individuals.ts`, `src/db/trees/names.ts`, `src/db/trees/events.ts`, `src/db/trees/families.ts` to support loading all primary names / birth-death events / family memberships in one query each
+- **No schema changes** — purely a performance and render-behavior fix
+- **No new dependencies** — debouncing can be implemented inline with `setTimeout`/`useEffect` or a tiny custom hook

--- a/openspec/changes/archive/2026-04-10-fix-search-input-freeze/specs/bulk-entity-fetch/spec.md
+++ b/openspec/changes/archive/2026-04-10-fix-search-input-freeze/specs/bulk-entity-fetch/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Constant-query individual list fetch
+
+`IndividualManager.getAll()` SHALL load all enriched individuals using a fixed number of SQL queries, independent of the number of individuals.
+
+#### Scenario: Loading a tree with many individuals
+
+- **WHEN** `IndividualManager.getAll()` is called on a tree with N individuals
+- **THEN** the total number of SQL queries executed SHALL be a small constant (not proportional to N)
+- **THEN** the returned array SHALL contain one `IndividualWithDetails` entry per individual in the tree
+
+#### Scenario: Each row still exposes list-view fields
+
+- **WHEN** `IndividualManager.getAll()` returns
+- **THEN** each entry SHALL expose `primaryName`, `names`, `birthEvent`, and `deathEvent` as previously
+- **THEN** existing consumers of the list (columns in `IndividualsPage`) SHALL continue to work without code changes
+
+#### Scenario: Individual with no primary name
+
+- **WHEN** an individual has no name marked `is_primary`
+- **THEN** `primaryName` SHALL be `null` in the returned entry
+
+#### Scenario: Individual with no birth or death event
+
+- **WHEN** an individual has no birth or death event recorded
+- **THEN** `birthEvent` and/or `deathEvent` SHALL be `null` in the returned entry
+
+### Requirement: Constant-query family list fetch
+
+`FamilyManager.getAll()` SHALL load all enriched families using a fixed number of SQL queries, independent of the number of families.
+
+#### Scenario: Loading a tree with many families
+
+- **WHEN** `FamilyManager.getAll()` is called on a tree with N families
+- **THEN** the total number of SQL queries executed SHALL be a small constant (not proportional to N)
+- **THEN** the returned array SHALL contain one `FamilyWithMembers` entry per family in the tree
+
+#### Scenario: Each family exposes member summaries
+
+- **WHEN** `FamilyManager.getAll()` returns
+- **THEN** each entry SHALL expose `husband`, `wife`, `children`, and `marriageEvent` as previously
+- **THEN** existing consumers of the list (columns in `FamiliesPage`) SHALL continue to work without code changes

--- a/openspec/changes/archive/2026-04-10-fix-search-input-freeze/specs/data-table-search-performance/spec.md
+++ b/openspec/changes/archive/2026-04-10-fix-search-input-freeze/specs/data-table-search-performance/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Responsive search input
+
+The DataTable search input SHALL reflect each keystroke visually within one frame, regardless of dataset size.
+
+#### Scenario: Typing in search input
+
+- **WHEN** the user types characters into the DataTable search input
+- **THEN** each typed character SHALL appear in the input immediately without perceptible delay
+- **THEN** the main thread SHALL NOT block long enough to drop keystrokes
+
+#### Scenario: Typing quickly on a large dataset
+
+- **WHEN** the dataset contains at least several hundred rows and the user types a 10-character query without pausing
+- **THEN** all 10 characters SHALL appear in the input
+- **THEN** the app SHALL remain responsive to other interactions (scrolling, clicking)
+
+### Requirement: Debounced filter computation
+
+The DataTable SHALL debounce the global filter so that row filtering only runs after the user pauses typing.
+
+#### Scenario: Continuous typing
+
+- **WHEN** the user is actively typing characters into the search input
+- **THEN** the filtered row model SHALL NOT be recomputed on every keystroke
+
+#### Scenario: Pause after typing
+
+- **WHEN** the user stops typing for the debounce interval
+- **THEN** the filtered row model SHALL be recomputed using the current input value
+- **THEN** the visible rows SHALL reflect the filter result
+
+#### Scenario: Clearing the input
+
+- **WHEN** the user clears the search input
+- **THEN** after the debounce interval, all rows SHALL be shown again
+
+### Requirement: Stable column references
+
+Pages using DataTable SHALL pass a stable `columns` reference that does not change between unrelated re-renders.
+
+#### Scenario: Re-render from unrelated state change
+
+- **WHEN** the parent page re-renders for a reason unrelated to columns (e.g., filter state update, selection change)
+- **THEN** the `columns` array passed to DataTable SHALL be the same reference as the previous render
+- **THEN** TanStack Table's internal memoization SHALL NOT be invalidated
+
+#### Scenario: Translation language change
+
+- **WHEN** the translation function changes (e.g., language switch)
+- **THEN** the `columns` array SHALL be rebuilt with the new translations
+- **THEN** the new reference SHALL be passed to DataTable

--- a/openspec/changes/archive/2026-04-10-fix-search-input-freeze/tasks.md
+++ b/openspec/changes/archive/2026-04-10-fix-search-input-freeze/tasks.md
@@ -1,0 +1,35 @@
+## 1. Debounce the DataTable search input
+
+- [x] 1.1 Create `src/hooks/useDebouncedValue.ts` — a small generic hook `useDebouncedValue<T>(value: T, delay: number): T` backed by `useEffect` + `setTimeout`
+- [x] 1.2 Add a unit test for `useDebouncedValue` covering: immediate first value, delayed update, rapid changes coalesced, cleanup on unmount
+- [x] 1.3 In `src/components/data-table.tsx`, introduce a local `inputValue` state bound to the `<Input>`, pass `useDebouncedValue(inputValue, 250)` into `setGlobalFilter` via effect, so the visible input updates immediately while `globalFilter` only updates after the pause
+
+## 2. Memoize column definitions in all pages
+
+- [x] 2.1 Wrap the `columns` array in `src/pages/IndividualsPage.tsx` with `useMemo(() => [...], [t])`
+- [x] 2.2 Wrap the `columns` array in `src/pages/FamiliesPage.tsx` with `useMemo(() => [...], [t])`
+- [x] 2.3 Wrap the `columns` array in `src/pages/SourcesPage.tsx` with `useMemo(() => [...], [t])`
+- [x] 2.4 Wrap the `columns` array in `src/pages/RepositoriesPage.tsx` with `useMemo(() => [...], [t])`
+- [x] 2.5 Verify each page's columns closure only captures `t` (or adjust deps accordingly)
+
+## 3. Batch-fetch individuals for the list view
+
+- [x] 3.1 Add `getAllPrimaryNames(): Promise<Name[]>` in `src/db/trees/names.ts` — single query selecting all rows where `is_primary = 1`
+- [x] 3.2 Add `getAllNames(): Promise<Name[]>` in `src/db/trees/names.ts` — single query, ordered by `individual_id, is_primary DESC`
+- [x] 3.3 Add `getAllBirthDeathEvents(): Promise<EventWithDetails[]>` (or two targeted functions) in `src/db/trees/events.ts` — one query selecting BIRT/DEAT events joined with participants filtered by role `principal`
+- [x] 3.4 Rewrite `IndividualManager.getAll()` in `src/managers/IndividualManager.ts` to call the three batch functions above, build `Map<individualId, ...>` lookups in JS, then assemble `IndividualWithDetails[]` — no per-row awaits
+- [x] 3.5 Add/update manager tests covering: empty tree, individuals with/without primary name, with/without birth/death events, with multiple alternative names
+
+## 4. Batch-fetch families for the list view
+
+- [x] 4.1 Add `getAllFamilyMembers(): Promise<FamilyMember[]>` in `src/db/trees/families.ts` (or equivalent batch query)
+- [x] 4.2 Add `getAllMarriageEvents(): Promise<EventWithDetails[]>` in `src/db/trees/events.ts` for role `principal` on `MARR` events
+- [x] 4.3 Rewrite `FamilyManager.getAll()` in `src/managers/FamilyManager.ts` to compose the batch queries + the individual batch data, assemble `FamilyWithMembers[]` with JS maps
+- [x] 4.4 Add/update manager tests covering: empty tree, families with no spouses, families with children, families with no marriage event
+
+## 5. Verify and smoke-test
+
+- [x] 5.1 Run `pnpm test` and ensure all existing tests still pass
+- [x] 5.2 Manually test typing in search inputs on IndividualsPage, FamiliesPage, SourcesPage, RepositoriesPage — confirm no freeze, instant character display, filter applies after short pause
+- [x] 5.3 Test initial load time on the Individuals page with a reasonably sized tree — confirm it's significantly faster than before (constant queries vs N+1)
+- [x] 5.4 Verify column rendering, pagination, and sorting still work identically

--- a/openspec/specs/bulk-entity-fetch/spec.md
+++ b/openspec/specs/bulk-entity-fetch/spec.md
@@ -1,0 +1,41 @@
+### Requirement: Constant-query individual list fetch
+
+`IndividualManager.getAll()` SHALL load all enriched individuals using a fixed number of SQL queries, independent of the number of individuals.
+
+#### Scenario: Loading a tree with many individuals
+
+- **WHEN** `IndividualManager.getAll()` is called on a tree with N individuals
+- **THEN** the total number of SQL queries executed SHALL be a small constant (not proportional to N)
+- **THEN** the returned array SHALL contain one `IndividualWithDetails` entry per individual in the tree
+
+#### Scenario: Each row still exposes list-view fields
+
+- **WHEN** `IndividualManager.getAll()` returns
+- **THEN** each entry SHALL expose `primaryName`, `names`, `birthEvent`, and `deathEvent` as previously
+- **THEN** existing consumers of the list (columns in `IndividualsPage`) SHALL continue to work without code changes
+
+#### Scenario: Individual with no primary name
+
+- **WHEN** an individual has no name marked `is_primary`
+- **THEN** `primaryName` SHALL be `null` in the returned entry
+
+#### Scenario: Individual with no birth or death event
+
+- **WHEN** an individual has no birth or death event recorded
+- **THEN** `birthEvent` and/or `deathEvent` SHALL be `null` in the returned entry
+
+### Requirement: Constant-query family list fetch
+
+`FamilyManager.getAll()` SHALL load all enriched families using a fixed number of SQL queries, independent of the number of families.
+
+#### Scenario: Loading a tree with many families
+
+- **WHEN** `FamilyManager.getAll()` is called on a tree with N families
+- **THEN** the total number of SQL queries executed SHALL be a small constant (not proportional to N)
+- **THEN** the returned array SHALL contain one `FamilyWithMembers` entry per family in the tree
+
+#### Scenario: Each family exposes member summaries
+
+- **WHEN** `FamilyManager.getAll()` returns
+- **THEN** each entry SHALL expose `husband`, `wife`, `children`, and `marriageEvent` as previously
+- **THEN** existing consumers of the list (columns in `FamiliesPage`) SHALL continue to work without code changes

--- a/openspec/specs/data-table-search-performance/spec.md
+++ b/openspec/specs/data-table-search-performance/spec.md
@@ -1,0 +1,51 @@
+### Requirement: Responsive search input
+
+The DataTable search input SHALL reflect each keystroke visually within one frame, regardless of dataset size.
+
+#### Scenario: Typing in search input
+
+- **WHEN** the user types characters into the DataTable search input
+- **THEN** each typed character SHALL appear in the input immediately without perceptible delay
+- **THEN** the main thread SHALL NOT block long enough to drop keystrokes
+
+#### Scenario: Typing quickly on a large dataset
+
+- **WHEN** the dataset contains at least several hundred rows and the user types a 10-character query without pausing
+- **THEN** all 10 characters SHALL appear in the input
+- **THEN** the app SHALL remain responsive to other interactions (scrolling, clicking)
+
+### Requirement: Debounced filter computation
+
+The DataTable SHALL debounce the global filter so that row filtering only runs after the user pauses typing.
+
+#### Scenario: Continuous typing
+
+- **WHEN** the user is actively typing characters into the search input
+- **THEN** the filtered row model SHALL NOT be recomputed on every keystroke
+
+#### Scenario: Pause after typing
+
+- **WHEN** the user stops typing for the debounce interval
+- **THEN** the filtered row model SHALL be recomputed using the current input value
+- **THEN** the visible rows SHALL reflect the filter result
+
+#### Scenario: Clearing the input
+
+- **WHEN** the user clears the search input
+- **THEN** after the debounce interval, all rows SHALL be shown again
+
+### Requirement: Stable column references
+
+Pages using DataTable SHALL pass a stable `columns` reference that does not change between unrelated re-renders.
+
+#### Scenario: Re-render from unrelated state change
+
+- **WHEN** the parent page re-renders for a reason unrelated to columns (e.g., filter state update, selection change)
+- **THEN** the `columns` array passed to DataTable SHALL be the same reference as the previous render
+- **THEN** TanStack Table's internal memoization SHALL NOT be invalidated
+
+#### Scenario: Translation language change
+
+- **WHEN** the translation function changes (e.g., language switch)
+- **THEN** the `columns` array SHALL be rebuilt with the new translations
+- **THEN** the new reference SHALL be passed to DataTable

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -12,6 +12,7 @@ import {
 import { ArrowUpDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { useDebouncedValue } from '$hooks/useDebouncedValue';
 import { Button } from '$components/ui/button';
 import { Input } from '$components/ui/input';
 import {
@@ -43,7 +44,8 @@ export function DataTable<TData, TValue>({
 }: DataTableProps<TData, TValue>) {
   const { t } = useTranslation('common');
   const [sorting, setSorting] = useState<SortingState>([]);
-  const [globalFilter, setGlobalFilter] = useState('');
+  const [inputValue, setInputValue] = useState('');
+  const globalFilter = useDebouncedValue(inputValue, 250);
 
   const table = useReactTable({
     data,
@@ -76,8 +78,8 @@ export function DataTable<TData, TValue>({
     <div className="space-y-2">
       <Input
         placeholder={searchPlaceholder ?? t('actions.search')}
-        value={globalFilter}
-        onChange={(e) => setGlobalFilter(e.target.value)}
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
         className="h-8 max-w-sm text-sm"
       />
 

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   type ColumnDef,
   type SortingState,
@@ -47,14 +47,24 @@ export function DataTable<TData, TValue>({
   const [inputValue, setInputValue] = useState('');
   const globalFilter = useDebouncedValue(inputValue, 250);
 
+  const columnFilters = useMemo(
+    () => (searchColumnId ? [{ id: searchColumnId, value: globalFilter }] : []),
+    [searchColumnId, globalFilter]
+  );
+
+  const tableState = useMemo(
+    () => ({
+      sorting,
+      globalFilter: searchColumnId ? undefined : globalFilter,
+      columnFilters,
+    }),
+    [sorting, globalFilter, searchColumnId, columnFilters]
+  );
+
   const table = useReactTable({
     data,
     columns,
-    state: {
-      sorting,
-      globalFilter: searchColumnId ? undefined : globalFilter,
-      columnFilters: searchColumnId ? [{ id: searchColumnId, value: globalFilter }] : [],
-    },
+    state: tableState,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/src/db/sql-chunk.ts
+++ b/src/db/sql-chunk.ts
@@ -1,0 +1,29 @@
+/**
+ * SQLite defaults to 999 host parameters per statement
+ * (SQLITE_MAX_VARIABLE_NUMBER). Bulk `IN (...)` fetches must stay below this
+ * limit, so we chunk input arrays and run one statement per chunk.
+ */
+export const SQLITE_IN_CLAUSE_LIMIT = 900;
+
+/**
+ * Split an array into chunks of at most `size` items. Returns the input
+ * array unchanged when it already fits in one chunk so single-statement
+ * callers don't pay for an extra array allocation.
+ */
+export function chunkArray<T>(items: T[], size: number): T[][] {
+  if (items.length <= size) return [items];
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Build a comma-separated list of positional placeholders ($1, $2, …, $N)
+ * for an `IN (...)` clause whose parameters will be passed via the
+ * `plugin-sql` positional binding.
+ */
+export function buildInClausePlaceholders(count: number): string {
+  return Array.from({ length: count }, (_, i) => `$${i + 1}`).join(', ');
+}

--- a/src/db/trees/events.ts
+++ b/src/db/trees/events.ts
@@ -1,5 +1,6 @@
 import { getTreeDb } from '../connection';
 import { formatEntityId, parseEntityId } from '$/lib/entityId';
+import { SQLITE_IN_CLAUSE_LIMIT, buildInClausePlaceholders, chunkArray } from '../sql-chunk';
 import { mapToPlace, type RawPlace } from './places';
 import type {
   Event,
@@ -671,22 +672,6 @@ interface RawEventWithType extends RawEvent {
   et_sort_order: number;
 }
 
-/**
- * SQLite defaults to a maximum of 999 host parameters per query (the
- * SQLITE_MAX_VARIABLE_NUMBER compile-time limit). We stay below that so bulk
- * `IN (...)` fetches never fail on trees that exceed the default.
- */
-const SQLITE_IN_CLAUSE_LIMIT = 900;
-
-function chunkArray<T>(items: T[], size: number): T[][] {
-  if (items.length <= size) return [items];
-  const chunks: T[][] = [];
-  for (let i = 0; i < items.length; i += size) {
-    chunks.push(items.slice(i, i + size));
-  }
-  return chunks;
-}
-
 function mapToEventWithType(row: RawEventWithType): { event: Event; eventType: EventType } {
   const event = mapToEvent(row);
   const eventType = mapToEventType({
@@ -717,7 +702,7 @@ async function assembleEventsWithDetails(
   // SQLite host-parameter limit when the tree has many events.
   const participantsByEvent = new Map<number, EventParticipant[]>();
   for (const idsChunk of chunkArray(eventDbIds, SQLITE_IN_CLAUSE_LIMIT)) {
-    const placeholders = idsChunk.map((_, i) => `$${i + 1}`).join(', ');
+    const placeholders = buildInClausePlaceholders(idsChunk.length);
     const participantRows = await db.select<RawEventParticipant[]>(
       `SELECT id, event_id, individual_id, family_id, role, notes, created_at
        FROM event_participants
@@ -740,7 +725,7 @@ async function assembleEventsWithDetails(
   const placeMap = new Map<number, Place>();
   if (uniquePlaceIds.length > 0) {
     for (const idsChunk of chunkArray(uniquePlaceIds, SQLITE_IN_CLAUSE_LIMIT)) {
-      const placeholders = idsChunk.map((_, i) => `$${i + 1}`).join(', ');
+      const placeholders = buildInClausePlaceholders(idsChunk.length);
       const placeRows = await db.select<RawPlace[]>(
         `SELECT id, name, full_name, place_type_id, parent_id, latitude, longitude, notes, created_at, updated_at
          FROM places
@@ -779,6 +764,47 @@ export async function getAllBirthDeathEvents(): Promise<EventWithDetails[]> {
      WHERE et.tag IN ('BIRT', 'DEAT')
      ORDER BY e.id`
   );
+  return assembleEventsWithDetails(rows);
+}
+
+/**
+ * Get BIRT/DEAT events where any of the given individuals appears as a
+ * `principal` participant. Intended for batch loading enriched individual
+ * lists for a known subset of individuals (e.g. the people referenced by
+ * `family_members` rows in `FamilyManager.getAll`). The returned events
+ * are deduplicated — an event is returned once even if multiple requested
+ * individuals participate in it.
+ */
+export async function getBirthDeathEventsForIndividuals(
+  individualIds: string[]
+): Promise<EventWithDetails[]> {
+  if (individualIds.length === 0) return [];
+  const db = await getTreeDb();
+  const dbIds = individualIds.map(parseEntityId);
+
+  const seen = new Set<number>();
+  const rows: RawEventWithType[] = [];
+  for (const idsChunk of chunkArray(dbIds, SQLITE_IN_CLAUSE_LIMIT)) {
+    const placeholders = buildInClausePlaceholders(idsChunk.length);
+    const chunkRows = await db.select<RawEventWithType[]>(
+      `SELECT DISTINCT e.id, e.event_type_id, e.date_original, e.date_sort, e.place_id, e.description, e.notes, e.created_at, e.updated_at,
+              et.id AS et_id, et.tag AS et_tag, et.category AS et_category, et.is_system AS et_is_system, et.custom_name AS et_custom_name, et.sort_order AS et_sort_order
+       FROM events e
+       INNER JOIN event_types et ON et.id = e.event_type_id
+       INNER JOIN event_participants ep ON ep.event_id = e.id
+       WHERE et.tag IN ('BIRT', 'DEAT')
+         AND ep.role = 'principal'
+         AND ep.individual_id IN (${placeholders})
+       ORDER BY e.id`,
+      idsChunk
+    );
+    for (const row of chunkRows) {
+      if (seen.has(row.id)) continue;
+      seen.add(row.id);
+      rows.push(row);
+    }
+  }
+
   return assembleEventsWithDetails(rows);
 }
 

--- a/src/db/trees/events.ts
+++ b/src/db/trees/events.ts
@@ -658,6 +658,128 @@ export async function getIndividualEventByType(
   return getEventWithDetails(event.id);
 }
 
+// =============================================================================
+// Bulk Fetch Helpers (for list-view managers)
+// =============================================================================
+
+interface RawEventWithType extends RawEvent {
+  et_id: number;
+  et_tag: string | null;
+  et_category: string;
+  et_is_system: number;
+  et_custom_name: string | null;
+  et_sort_order: number;
+}
+
+function mapToEventWithType(row: RawEventWithType): { event: Event; eventType: EventType } {
+  const event = mapToEvent(row);
+  const eventType: EventType = {
+    id: String(row.et_id),
+    tag: row.et_tag,
+    category: row.et_category as EventCategory,
+    isSystem: row.et_is_system === 1,
+    customName: row.et_custom_name,
+    sortOrder: row.et_sort_order,
+  };
+  return { event, eventType };
+}
+
+/**
+ * Assemble EventWithDetails[] from a set of event rows.
+ * Loads participants and places for the given events in a constant number
+ * of queries (independent of event count).
+ */
+async function assembleEventsWithDetails(
+  eventRows: RawEventWithType[]
+): Promise<EventWithDetails[]> {
+  if (eventRows.length === 0) return [];
+
+  const db = await getTreeDb();
+  const eventDbIds = eventRows.map((r) => r.id);
+  const placeholders = eventDbIds.map((_, i) => `$${i + 1}`).join(', ');
+
+  // Fetch all participants for these events in a single query
+  const participantRows = await db.select<RawEventParticipant[]>(
+    `SELECT id, event_id, individual_id, family_id, role, notes, created_at
+     FROM event_participants
+     WHERE event_id IN (${placeholders})
+     ORDER BY role, id`,
+    eventDbIds
+  );
+
+  const participantsByEvent = new Map<number, EventParticipant[]>();
+  for (const row of participantRows) {
+    const list = participantsByEvent.get(row.event_id) ?? [];
+    list.push(mapToEventParticipant(row));
+    participantsByEvent.set(row.event_id, list);
+  }
+
+  // Fetch all places referenced by these events in a single query
+  const uniquePlaceIds = Array.from(
+    new Set(eventRows.map((r) => r.place_id).filter((id): id is number => id !== null))
+  );
+
+  const placeMap = new Map<number, Place>();
+  if (uniquePlaceIds.length > 0) {
+    const placeParams = uniquePlaceIds.map((_, i) => `$${i + 1}`).join(', ');
+    const placeRows = await db.select<RawPlace[]>(
+      `SELECT id, name, full_name, place_type_id, parent_id, latitude, longitude, notes, created_at, updated_at
+       FROM places
+       WHERE id IN (${placeParams})`,
+      uniquePlaceIds
+    );
+    for (const row of placeRows) {
+      placeMap.set(row.id, mapToPlace(row));
+    }
+  }
+
+  return eventRows.map((row) => {
+    const { event, eventType } = mapToEventWithType(row);
+    return {
+      ...event,
+      eventType,
+      place: row.place_id !== null ? (placeMap.get(row.place_id) ?? null) : null,
+      participants: participantsByEvent.get(row.id) ?? [],
+    };
+  });
+}
+
+/**
+ * Get every BIRT and DEAT event in the tree with full details.
+ * Uses a constant number of SQL queries regardless of event count.
+ * Intended for list-view batch loading (e.g. IndividualManager.getAll).
+ */
+export async function getAllBirthDeathEvents(): Promise<EventWithDetails[]> {
+  const db = await getTreeDb();
+  const rows = await db.select<RawEventWithType[]>(
+    `SELECT e.id, e.event_type_id, e.date_original, e.date_sort, e.place_id, e.description, e.notes, e.created_at, e.updated_at,
+            et.id AS et_id, et.tag AS et_tag, et.category AS et_category, et.is_system AS et_is_system, et.custom_name AS et_custom_name, et.sort_order AS et_sort_order
+     FROM events e
+     INNER JOIN event_types et ON et.id = e.event_type_id
+     WHERE et.tag IN ('BIRT', 'DEAT')
+     ORDER BY e.id`
+  );
+  return assembleEventsWithDetails(rows);
+}
+
+/**
+ * Get every MARR event in the tree with full details.
+ * Uses a constant number of SQL queries regardless of event count.
+ * Intended for list-view batch loading (e.g. FamilyManager.getAll).
+ */
+export async function getAllMarriageEvents(): Promise<EventWithDetails[]> {
+  const db = await getTreeDb();
+  const rows = await db.select<RawEventWithType[]>(
+    `SELECT e.id, e.event_type_id, e.date_original, e.date_sort, e.place_id, e.description, e.notes, e.created_at, e.updated_at,
+            et.id AS et_id, et.tag AS et_tag, et.category AS et_category, et.is_system AS et_is_system, et.custom_name AS et_custom_name, et.sort_order AS et_sort_order
+     FROM events e
+     INNER JOIN event_types et ON et.id = e.event_type_id
+     WHERE et.tag = 'MARR'
+     ORDER BY e.id`
+  );
+  return assembleEventsWithDetails(rows);
+}
+
 /**
  * Get the primary event of a specific type for a family
  * (e.g., get marriage event)

--- a/src/db/trees/events.ts
+++ b/src/db/trees/events.ts
@@ -671,16 +671,32 @@ interface RawEventWithType extends RawEvent {
   et_sort_order: number;
 }
 
+/**
+ * SQLite defaults to a maximum of 999 host parameters per query (the
+ * SQLITE_MAX_VARIABLE_NUMBER compile-time limit). We stay below that so bulk
+ * `IN (...)` fetches never fail on trees that exceed the default.
+ */
+const SQLITE_IN_CLAUSE_LIMIT = 900;
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  if (items.length <= size) return [items];
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
 function mapToEventWithType(row: RawEventWithType): { event: Event; eventType: EventType } {
   const event = mapToEvent(row);
-  const eventType: EventType = {
-    id: String(row.et_id),
+  const eventType = mapToEventType({
+    id: row.et_id,
     tag: row.et_tag,
-    category: row.et_category as EventCategory,
-    isSystem: row.et_is_system === 1,
-    customName: row.et_custom_name,
-    sortOrder: row.et_sort_order,
-  };
+    category: row.et_category,
+    is_system: row.et_is_system,
+    custom_name: row.et_custom_name,
+    sort_order: row.et_sort_order,
+  });
   return { event, eventType };
 }
 
@@ -696,40 +712,44 @@ async function assembleEventsWithDetails(
 
   const db = await getTreeDb();
   const eventDbIds = eventRows.map((r) => r.id);
-  const placeholders = eventDbIds.map((_, i) => `$${i + 1}`).join(', ');
 
-  // Fetch all participants for these events in a single query
-  const participantRows = await db.select<RawEventParticipant[]>(
-    `SELECT id, event_id, individual_id, family_id, role, notes, created_at
-     FROM event_participants
-     WHERE event_id IN (${placeholders})
-     ORDER BY role, id`,
-    eventDbIds
-  );
-
+  // Fetch all participants for these events, chunking to stay under the
+  // SQLite host-parameter limit when the tree has many events.
   const participantsByEvent = new Map<number, EventParticipant[]>();
-  for (const row of participantRows) {
-    const list = participantsByEvent.get(row.event_id) ?? [];
-    list.push(mapToEventParticipant(row));
-    participantsByEvent.set(row.event_id, list);
+  for (const idsChunk of chunkArray(eventDbIds, SQLITE_IN_CLAUSE_LIMIT)) {
+    const placeholders = idsChunk.map((_, i) => `$${i + 1}`).join(', ');
+    const participantRows = await db.select<RawEventParticipant[]>(
+      `SELECT id, event_id, individual_id, family_id, role, notes, created_at
+       FROM event_participants
+       WHERE event_id IN (${placeholders})
+       ORDER BY role, id`,
+      idsChunk
+    );
+    for (const row of participantRows) {
+      const list = participantsByEvent.get(row.event_id) ?? [];
+      list.push(mapToEventParticipant(row));
+      participantsByEvent.set(row.event_id, list);
+    }
   }
 
-  // Fetch all places referenced by these events in a single query
+  // Fetch all places referenced by these events, chunked for the same reason.
   const uniquePlaceIds = Array.from(
     new Set(eventRows.map((r) => r.place_id).filter((id): id is number => id !== null))
   );
 
   const placeMap = new Map<number, Place>();
   if (uniquePlaceIds.length > 0) {
-    const placeParams = uniquePlaceIds.map((_, i) => `$${i + 1}`).join(', ');
-    const placeRows = await db.select<RawPlace[]>(
-      `SELECT id, name, full_name, place_type_id, parent_id, latitude, longitude, notes, created_at, updated_at
-       FROM places
-       WHERE id IN (${placeParams})`,
-      uniquePlaceIds
-    );
-    for (const row of placeRows) {
-      placeMap.set(row.id, mapToPlace(row));
+    for (const idsChunk of chunkArray(uniquePlaceIds, SQLITE_IN_CLAUSE_LIMIT)) {
+      const placeholders = idsChunk.map((_, i) => `$${i + 1}`).join(', ');
+      const placeRows = await db.select<RawPlace[]>(
+        `SELECT id, name, full_name, place_type_id, parent_id, latitude, longitude, notes, created_at, updated_at
+         FROM places
+         WHERE id IN (${placeholders})`,
+        idsChunk
+      );
+      for (const row of placeRows) {
+        placeMap.set(row.id, mapToPlace(row));
+      }
     }
   }
 

--- a/src/db/trees/families.ts
+++ b/src/db/trees/families.ts
@@ -153,6 +153,29 @@ export async function countFamilies(): Promise<number> {
 // =============================================================================
 
 /**
+ * Get every family_member row in the tree.
+ * Single query — safe to use for batch loading list views.
+ * Results are ordered by family, then role (husband, wife, child), then sort_order.
+ */
+export async function getAllFamilyMembers(): Promise<FamilyMember[]> {
+  const db = await getTreeDb();
+  const rows = await db.select<RawFamilyMember[]>(
+    `SELECT id, family_id, individual_id, role, pedigree, sort_order, created_at
+     FROM family_members
+     ORDER BY
+       family_id,
+       CASE role
+         WHEN 'husband' THEN 1
+         WHEN 'wife' THEN 2
+         WHEN 'child' THEN 3
+       END,
+       sort_order,
+       id`
+  );
+  return rows.map(mapToFamilyMember);
+}
+
+/**
  * Get all members of a family
  */
 export async function getFamilyMembers(familyId: string): Promise<FamilyMember[]> {

--- a/src/db/trees/individuals.ts
+++ b/src/db/trees/individuals.ts
@@ -1,5 +1,6 @@
 import { getTreeDb } from '../connection';
 import { formatEntityId, parseEntityId } from '$/lib/entityId';
+import { SQLITE_IN_CLAUSE_LIMIT, buildInClausePlaceholders, chunkArray } from '../sql-chunk';
 import type {
   Individual,
   Gender,
@@ -47,6 +48,32 @@ export async function getAllIndividuals(): Promise<Individual[]> {
   const rows = await db.select<RawIndividual[]>(
     'SELECT id, gender, is_living, notes, created_at, updated_at FROM individuals ORDER BY id'
   );
+  return rows.map(mapToIndividual);
+}
+
+/**
+ * Get the individuals matching a set of IDs. Uses a chunked `IN (...)`
+ * clause so the number of SQL statements is constant regardless of the
+ * number of ids. The returned array is in `id` order and contains one
+ * entry per row found — missing ids are silently omitted.
+ */
+export async function getIndividualsByIds(ids: string[]): Promise<Individual[]> {
+  if (ids.length === 0) return [];
+  const db = await getTreeDb();
+  const dbIds = ids.map(parseEntityId);
+
+  const rows: RawIndividual[] = [];
+  for (const idsChunk of chunkArray(dbIds, SQLITE_IN_CLAUSE_LIMIT)) {
+    const placeholders = buildInClausePlaceholders(idsChunk.length);
+    const chunkRows = await db.select<RawIndividual[]>(
+      `SELECT id, gender, is_living, notes, created_at, updated_at
+       FROM individuals
+       WHERE id IN (${placeholders})
+       ORDER BY id`,
+      idsChunk
+    );
+    rows.push(...chunkRows);
+  }
   return rows.map(mapToIndividual);
 }
 

--- a/src/db/trees/names.ts
+++ b/src/db/trees/names.ts
@@ -67,6 +67,37 @@ export async function getNamesByIndividualId(individualId: string): Promise<Name
 }
 
 /**
+ * Get the primary name for every individual in the tree.
+ * Single query — safe to use for batch loading list views.
+ * Only returns rows where `is_primary = 1`. Individuals without a primary
+ * name are simply absent from the result set.
+ */
+export async function getAllPrimaryNames(): Promise<Name[]> {
+  const db = await getTreeDb();
+  const rows = await db.select<RawName[]>(
+    `SELECT id, individual_id, type, prefix, given_names, surname, suffix, nickname, is_primary, created_at, updated_at
+     FROM names
+     WHERE is_primary = 1
+     ORDER BY individual_id`
+  );
+  return rows.map(mapToName);
+}
+
+/**
+ * Get every name in the tree, ordered by individual and with primary names first.
+ * Single query — safe to use for batch loading list views.
+ */
+export async function getAllNames(): Promise<Name[]> {
+  const db = await getTreeDb();
+  const rows = await db.select<RawName[]>(
+    `SELECT id, individual_id, type, prefix, given_names, surname, suffix, nickname, is_primary, created_at, updated_at
+     FROM names
+     ORDER BY individual_id, is_primary DESC, id`
+  );
+  return rows.map(mapToName);
+}
+
+/**
  * Get the primary name for an individual
  */
 export async function getPrimaryName(individualId: string): Promise<Name | null> {

--- a/src/db/trees/names.ts
+++ b/src/db/trees/names.ts
@@ -1,5 +1,6 @@
 import { getTreeDb } from '../connection';
 import { formatEntityId, parseEntityId } from '$/lib/entityId';
+import { SQLITE_IN_CLAUSE_LIMIT, buildInClausePlaceholders, chunkArray } from '../sql-chunk';
 import type {
   Name,
   NameType,
@@ -94,6 +95,57 @@ export async function getAllNames(): Promise<Name[]> {
      FROM names
      ORDER BY individual_id, is_primary DESC, id`
   );
+  return rows.map(mapToName);
+}
+
+/**
+ * Get the `is_primary = 1` rows for a specific set of individuals.
+ * Intended for batch loading a sparse set of enriched individuals
+ * (e.g. the members referenced by `FamilyManager.getAll`). Chunks the
+ * `IN (...)` clause so callers never hit SQLite's parameter limit.
+ */
+export async function getPrimaryNamesForIndividuals(individualIds: string[]): Promise<Name[]> {
+  if (individualIds.length === 0) return [];
+  const db = await getTreeDb();
+  const dbIds = individualIds.map(parseEntityId);
+
+  const rows: RawName[] = [];
+  for (const idsChunk of chunkArray(dbIds, SQLITE_IN_CLAUSE_LIMIT)) {
+    const placeholders = buildInClausePlaceholders(idsChunk.length);
+    const chunkRows = await db.select<RawName[]>(
+      `SELECT id, individual_id, type, prefix, given_names, surname, suffix, nickname, is_primary, created_at, updated_at
+       FROM names
+       WHERE is_primary = 1 AND individual_id IN (${placeholders})
+       ORDER BY individual_id`,
+      idsChunk
+    );
+    rows.push(...chunkRows);
+  }
+  return rows.map(mapToName);
+}
+
+/**
+ * Get every name row for a specific set of individuals, with primary
+ * names first within each individual. Complements
+ * `getPrimaryNamesForIndividuals` when alternative names are needed.
+ */
+export async function getNamesForIndividuals(individualIds: string[]): Promise<Name[]> {
+  if (individualIds.length === 0) return [];
+  const db = await getTreeDb();
+  const dbIds = individualIds.map(parseEntityId);
+
+  const rows: RawName[] = [];
+  for (const idsChunk of chunkArray(dbIds, SQLITE_IN_CLAUSE_LIMIT)) {
+    const placeholders = buildInClausePlaceholders(idsChunk.length);
+    const chunkRows = await db.select<RawName[]>(
+      `SELECT id, individual_id, type, prefix, given_names, surname, suffix, nickname, is_primary, created_at, updated_at
+       FROM names
+       WHERE individual_id IN (${placeholders})
+       ORDER BY individual_id, is_primary DESC, id`,
+      idsChunk
+    );
+    rows.push(...chunkRows);
+  }
   return rows.map(mapToName);
 }
 

--- a/src/hooks/useDebouncedValue.test.ts
+++ b/src/hooks/useDebouncedValue.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebouncedValue } from './useDebouncedValue';
+
+describe('useDebouncedValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the initial value immediately on first render', () => {
+    const { result } = renderHook(() => useDebouncedValue('initial', 250));
+    expect(result.current).toBe('initial');
+  });
+
+  it('updates the value after the delay has elapsed', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 250), {
+      initialProps: { value: 'a' },
+    });
+
+    expect(result.current).toBe('a');
+
+    rerender({ value: 'b' });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(249);
+    });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe('b');
+  });
+
+  it('coalesces rapid changes into a single final update', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 250), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'b' });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    rerender({ value: 'c' });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    rerender({ value: 'd' });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(result.current).toBe('d');
+  });
+
+  it('cleans up the pending timer on unmount', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const { unmount, rerender } = renderHook(({ value }) => useDebouncedValue(value, 250), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'b' });
+    unmount();
+
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a debounced version of the given value that only updates after
+ * the value has been stable for `delay` milliseconds.
+ *
+ * Useful for decoupling a fast-updating input (e.g. a controlled text field)
+ * from an expensive downstream computation (e.g. filtering a large dataset).
+ */
+export function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/managers/FamilyManager.test.ts
+++ b/src/managers/FamilyManager.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTreeInMemoryDb } from '$/test/sqlite-memory';
+import { createIndividual } from '$db-tree/individuals';
+import { createName } from '$db-tree/names';
+import { createFamily, addFamilyMember } from '$db-tree/families';
+import { addEventParticipant, createEvent, getEventTypeByTag } from '$db-tree/events';
+import { FamilyManager } from './FamilyManager';
+
+const db = createTreeInMemoryDb();
+
+vi.mock('$/db/connection', () => ({
+  getTreeDb: vi.fn(),
+}));
+
+import('$/db/connection').then(({ getTreeDb }) => {
+  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+});
+
+beforeEach(async () => {
+  const { getTreeDb } = await import('$/db/connection');
+  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  db._raw.exec('DELETE FROM event_participants');
+  db._raw.exec('DELETE FROM events');
+  db._raw.exec('DELETE FROM family_members');
+  db._raw.exec('DELETE FROM families');
+  db._raw.exec('DELETE FROM names');
+  db._raw.exec('DELETE FROM individuals');
+});
+
+async function createNamedIndividual(
+  given: string,
+  surname: string,
+  gender: 'M' | 'F' | 'U' = 'U'
+): Promise<string> {
+  const id = await createIndividual({ gender });
+  await createName({
+    individualId: id,
+    givenNames: given,
+    surname,
+    isPrimary: true,
+  });
+  return id;
+}
+
+async function createMarriageEvent(familyId: string, date: string): Promise<string> {
+  const marrType = await getEventTypeByTag('MARR');
+  if (!marrType) throw new Error('MARR event type missing from test DB');
+  const eventId = await createEvent({
+    eventTypeId: marrType.id,
+    dateOriginal: date,
+  });
+  await addEventParticipant({
+    eventId,
+    familyId,
+    role: 'principal',
+  });
+  return eventId;
+}
+
+describe('FamilyManager.getAll', () => {
+  it('returns an empty array for an empty tree', async () => {
+    const result = await FamilyManager.getAll();
+    expect(result).toEqual([]);
+  });
+
+  it('returns families with no spouses and no children as empty shells', async () => {
+    const familyId = await createFamily({});
+
+    const result = await FamilyManager.getAll();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(familyId);
+    expect(result[0].husband).toBeNull();
+    expect(result[0].wife).toBeNull();
+    expect(result[0].children).toEqual([]);
+    expect(result[0].marriageEvent).toBeNull();
+  });
+
+  it('attaches husband and wife to the family', async () => {
+    const husbandId = await createNamedIndividual('John', 'Doe', 'M');
+    const wifeId = await createNamedIndividual('Jane', 'Smith', 'F');
+    const familyId = await createFamily({});
+    await addFamilyMember({ familyId, individualId: husbandId, role: 'husband' });
+    await addFamilyMember({ familyId, individualId: wifeId, role: 'wife' });
+
+    const result = await FamilyManager.getAll();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].husband?.id).toBe(husbandId);
+    expect(result[0].husband?.primaryName?.givenNames).toBe('John');
+    expect(result[0].wife?.id).toBe(wifeId);
+    expect(result[0].wife?.primaryName?.givenNames).toBe('Jane');
+  });
+
+  it('attaches children to the family', async () => {
+    const husbandId = await createNamedIndividual('Dad', 'Doe', 'M');
+    const wifeId = await createNamedIndividual('Mom', 'Doe', 'F');
+    const child1Id = await createNamedIndividual('Kid1', 'Doe');
+    const child2Id = await createNamedIndividual('Kid2', 'Doe');
+    const familyId = await createFamily({});
+    await addFamilyMember({ familyId, individualId: husbandId, role: 'husband' });
+    await addFamilyMember({ familyId, individualId: wifeId, role: 'wife' });
+    await addFamilyMember({ familyId, individualId: child1Id, role: 'child' });
+    await addFamilyMember({ familyId, individualId: child2Id, role: 'child' });
+
+    const result = await FamilyManager.getAll();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].children).toHaveLength(2);
+    const childIds = result[0].children.map((c) => c.id).sort();
+    expect(childIds).toEqual([child1Id, child2Id].sort());
+  });
+
+  it('returns null marriageEvent when the family has no marriage event recorded', async () => {
+    const husbandId = await createNamedIndividual('A', 'B', 'M');
+    const familyId = await createFamily({});
+    await addFamilyMember({ familyId, individualId: husbandId, role: 'husband' });
+
+    const result = await FamilyManager.getAll();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].marriageEvent).toBeNull();
+  });
+
+  it('populates marriageEvent when the family has a MARR event', async () => {
+    const husbandId = await createNamedIndividual('John', 'Doe', 'M');
+    const wifeId = await createNamedIndividual('Jane', 'Smith', 'F');
+    const familyId = await createFamily({});
+    await addFamilyMember({ familyId, individualId: husbandId, role: 'husband' });
+    await addFamilyMember({ familyId, individualId: wifeId, role: 'wife' });
+    await createMarriageEvent(familyId, '1950-06-15');
+
+    const result = await FamilyManager.getAll();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].marriageEvent).not.toBeNull();
+    expect(result[0].marriageEvent?.dateOriginal).toBe('1950-06-15');
+    expect(result[0].marriageEvent?.eventType.tag).toBe('MARR');
+  });
+
+  it('returns multiple families each with their own members and marriage events', async () => {
+    const h1 = await createNamedIndividual('H1', 'Fam1', 'M');
+    const w1 = await createNamedIndividual('W1', 'Fam1', 'F');
+    const h2 = await createNamedIndividual('H2', 'Fam2', 'M');
+
+    const family1 = await createFamily({});
+    const family2 = await createFamily({});
+    await addFamilyMember({ familyId: family1, individualId: h1, role: 'husband' });
+    await addFamilyMember({ familyId: family1, individualId: w1, role: 'wife' });
+    await addFamilyMember({ familyId: family2, individualId: h2, role: 'husband' });
+    await createMarriageEvent(family1, '1900-01-01');
+
+    const result = await FamilyManager.getAll();
+
+    expect(result).toHaveLength(2);
+    const f1 = result.find((f) => f.id === family1);
+    const f2 = result.find((f) => f.id === family2);
+    expect(f1?.husband?.id).toBe(h1);
+    expect(f1?.wife?.id).toBe(w1);
+    expect(f1?.marriageEvent?.dateOriginal).toBe('1900-01-01');
+    expect(f2?.husband?.id).toBe(h2);
+    expect(f2?.wife).toBeNull();
+    expect(f2?.marriageEvent).toBeNull();
+  });
+});

--- a/src/managers/FamilyManager.test.ts
+++ b/src/managers/FamilyManager.test.ts
@@ -12,10 +12,6 @@ vi.mock('$/db/connection', () => ({
   getTreeDb: vi.fn(),
 }));
 
-import('$/db/connection').then(({ getTreeDb }) => {
-  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
-});
-
 beforeEach(async () => {
   const { getTreeDb } = await import('$/db/connection');
   (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);

--- a/src/managers/FamilyManager.ts
+++ b/src/managers/FamilyManager.ts
@@ -1,6 +1,7 @@
 import { getTreeDb } from '$/db/connection';
 import {
   getAllFamilies,
+  getAllFamilyMembers,
   getFamilyById,
   createFamily,
   updateFamily,
@@ -9,10 +10,11 @@ import {
   addFamilyMember,
   removeFamilyMember,
 } from '$db-tree/families';
-import { getFamilyEventByType } from '$db-tree/events';
+import { getAllMarriageEvents, getFamilyEventByType } from '$db-tree/events';
 import { IndividualManager } from './IndividualManager';
 import type {
   CreateFamilyInput,
+  EventWithDetails,
   UpdateFamilyInput,
   FamilyWithMembers,
   IndividualWithDetails,
@@ -102,20 +104,79 @@ export class FamilyManager {
 
   /**
    * Get all families with full details.
-   * Note: Calls getById per family (N+1). Acceptable for local SQLite.
+   * Uses a constant number of SQL queries (families, family members, all
+   * individuals via IndividualManager.getAll, marriage events) and assembles
+   * the result in JS, so loading is independent of the number of families.
    */
   static async getAll(): Promise<FamilyWithMembers[]> {
-    const families = await getAllFamilies();
-    const results: FamilyWithMembers[] = [];
+    const [families, members, individuals, marriageEvents] = await Promise.all([
+      getAllFamilies(),
+      getAllFamilyMembers(),
+      IndividualManager.getAll(),
+      getAllMarriageEvents(),
+    ]);
 
-    for (const family of families) {
-      const enriched = await FamilyManager.getById(family.id);
-      if (enriched) {
-        results.push(enriched);
+    const individualById = new Map<string, IndividualWithDetails>();
+    for (const individual of individuals) {
+      individualById.set(individual.id, individual);
+    }
+
+    const marriageEventByFamily = new Map<string, EventWithDetails>();
+    for (const event of marriageEvents) {
+      if (event.eventType.tag !== 'MARR') continue;
+      for (const participant of event.participants) {
+        if (participant.role !== 'principal' || participant.familyId === null) continue;
+        if (!marriageEventByFamily.has(participant.familyId)) {
+          marriageEventByFamily.set(participant.familyId, event);
+        }
       }
     }
 
-    return results;
+    const membersByFamily = new Map<
+      string,
+      {
+        husband: IndividualWithDetails | null;
+        wife: IndividualWithDetails | null;
+        children: IndividualWithDetails[];
+      }
+    >();
+    for (const member of members) {
+      const entry = membersByFamily.get(member.familyId) ?? {
+        husband: null,
+        wife: null,
+        children: [] as IndividualWithDetails[],
+      };
+      const individual = individualById.get(member.individualId);
+      if (individual) {
+        switch (member.role) {
+          case 'husband':
+            entry.husband = individual;
+            break;
+          case 'wife':
+            entry.wife = individual;
+            break;
+          case 'child':
+            entry.children.push(individual);
+            break;
+        }
+      }
+      membersByFamily.set(member.familyId, entry);
+    }
+
+    return families.map((family) => {
+      const entry = membersByFamily.get(family.id) ?? {
+        husband: null,
+        wife: null,
+        children: [] as IndividualWithDetails[],
+      };
+      return {
+        ...family,
+        husband: entry.husband,
+        wife: entry.wife,
+        children: entry.children,
+        marriageEvent: marriageEventByFamily.get(family.id) ?? null,
+      };
+    });
   }
 
   /**

--- a/src/managers/FamilyManager.ts
+++ b/src/managers/FamilyManager.ts
@@ -104,17 +104,20 @@ export class FamilyManager {
 
   /**
    * Get all families with full details.
-   * Uses a constant number of SQL queries (families, family members, all
-   * individuals via IndividualManager.getAll, marriage events) and assembles
-   * the result in JS, so loading is independent of the number of families.
+   * Runs three parallel batch queries — families, family_members, marriage
+   * events — then fetches only the individuals actually referenced by
+   * `family_members` through `IndividualManager.getByIds`, so sparse trees
+   * don't pay the cost of loading people unrelated to any family.
    */
   static async getAll(): Promise<FamilyWithMembers[]> {
-    const [families, members, individuals, marriageEvents] = await Promise.all([
+    const [families, members, marriageEvents] = await Promise.all([
       getAllFamilies(),
       getAllFamilyMembers(),
-      IndividualManager.getAll(),
       getAllMarriageEvents(),
     ]);
+
+    const referencedIndividualIds = Array.from(new Set(members.map((m) => m.individualId)));
+    const individuals = await IndividualManager.getByIds(referencedIndividualIds);
 
     const individualById = new Map<string, IndividualWithDetails>();
     for (const individual of individuals) {

--- a/src/managers/IndividualManager.test.ts
+++ b/src/managers/IndividualManager.test.ts
@@ -11,10 +11,6 @@ vi.mock('$/db/connection', () => ({
   getTreeDb: vi.fn(),
 }));
 
-import('$/db/connection').then(({ getTreeDb }) => {
-  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
-});
-
 beforeEach(async () => {
   const { getTreeDb } = await import('$/db/connection');
   (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
@@ -174,6 +170,32 @@ describe('IndividualManager.getAll', () => {
 
     const principal = result.find((i) => i.id === principalId);
     const witness = result.find((i) => i.id === witnessId);
+    expect(principal?.birthEvent?.dateOriginal).toBe('1900-01-01');
+    expect(witness?.birthEvent).toBeNull();
+  });
+});
+
+describe('IndividualManager.getById', () => {
+  it('only attaches birth/death events where the individual is a principal participant', async () => {
+    // Shared rule with getAll: a witness at someone else's birth must not
+    // see that birth reported as their own.
+    const principalId = await createIndividual({ gender: 'M' });
+    const witnessId = await createIndividual({ gender: 'F' });
+    await createName({ individualId: principalId, givenNames: 'Principal', isPrimary: true });
+    await createName({ individualId: witnessId, givenNames: 'Witness', isPrimary: true });
+
+    const birtType = await getEventTypeByTag('BIRT');
+    if (!birtType) throw new Error('BIRT event type missing');
+    const eventId = await createEvent({
+      eventTypeId: birtType.id,
+      dateOriginal: '1900-01-01',
+    });
+    await addEventParticipant({ eventId, individualId: principalId, role: 'principal' });
+    await addEventParticipant({ eventId, individualId: witnessId, role: 'witness' });
+
+    const principal = await IndividualManager.getById(principalId);
+    const witness = await IndividualManager.getById(witnessId);
+
     expect(principal?.birthEvent?.dateOriginal).toBe('1900-01-01');
     expect(witness?.birthEvent).toBeNull();
   });

--- a/src/managers/IndividualManager.test.ts
+++ b/src/managers/IndividualManager.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTreeInMemoryDb } from '$/test/sqlite-memory';
+import { createIndividual } from '$db-tree/individuals';
+import { createName } from '$db-tree/names';
+import { createEvent, addEventParticipant, getEventTypeByTag } from '$db-tree/events';
+import { IndividualManager } from './IndividualManager';
+
+const db = createTreeInMemoryDb();
+
+vi.mock('$/db/connection', () => ({
+  getTreeDb: vi.fn(),
+}));
+
+import('$/db/connection').then(({ getTreeDb }) => {
+  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+});
+
+beforeEach(async () => {
+  const { getTreeDb } = await import('$/db/connection');
+  (getTreeDb as ReturnType<typeof vi.fn>).mockResolvedValue(db);
+  db._raw.exec('DELETE FROM event_participants');
+  db._raw.exec('DELETE FROM events');
+  db._raw.exec('DELETE FROM names');
+  db._raw.exec('DELETE FROM individuals');
+});
+
+async function createBirthEventFor(individualId: string, date: string): Promise<string> {
+  const birtType = await getEventTypeByTag('BIRT');
+  if (!birtType) throw new Error('BIRT event type missing from test DB');
+  const eventId = await createEvent({
+    eventTypeId: birtType.id,
+    dateOriginal: date,
+  });
+  await addEventParticipant({
+    eventId,
+    individualId,
+    role: 'principal',
+  });
+  return eventId;
+}
+
+async function createDeathEventFor(individualId: string, date: string): Promise<string> {
+  const deatType = await getEventTypeByTag('DEAT');
+  if (!deatType) throw new Error('DEAT event type missing from test DB');
+  const eventId = await createEvent({
+    eventTypeId: deatType.id,
+    dateOriginal: date,
+  });
+  await addEventParticipant({
+    eventId,
+    individualId,
+    role: 'principal',
+  });
+  return eventId;
+}
+
+describe('IndividualManager.getAll', () => {
+  it('returns an empty array for an empty tree', async () => {
+    const result = await IndividualManager.getAll();
+    expect(result).toEqual([]);
+  });
+
+  it('returns one entry per individual with primary names populated', async () => {
+    const id1 = await createIndividual({ gender: 'M' });
+    await createName({
+      individualId: id1,
+      givenNames: 'John',
+      surname: 'Doe',
+      isPrimary: true,
+    });
+
+    const id2 = await createIndividual({ gender: 'F' });
+    await createName({
+      individualId: id2,
+      givenNames: 'Jane',
+      surname: 'Smith',
+      isPrimary: true,
+    });
+
+    const result = await IndividualManager.getAll();
+
+    expect(result).toHaveLength(2);
+    const john = result.find((i) => i.id === id1);
+    const jane = result.find((i) => i.id === id2);
+    expect(john?.primaryName?.givenNames).toBe('John');
+    expect(john?.primaryName?.surname).toBe('Doe');
+    expect(jane?.primaryName?.givenNames).toBe('Jane');
+    expect(jane?.primaryName?.surname).toBe('Smith');
+  });
+
+  it('returns null primaryName for individuals with no primary name', async () => {
+    await createIndividual({ gender: 'U' });
+
+    const result = await IndividualManager.getAll();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].primaryName).toBeNull();
+    expect(result[0].names).toEqual([]);
+  });
+
+  it('includes alternative names alongside the primary name', async () => {
+    const id = await createIndividual({ gender: 'F' });
+    await createName({
+      individualId: id,
+      givenNames: 'Primary',
+      surname: 'Name',
+      isPrimary: true,
+    });
+    await createName({
+      individualId: id,
+      givenNames: 'Nickname',
+      type: 'aka',
+    });
+    await createName({
+      individualId: id,
+      givenNames: 'Married',
+      surname: 'Spouse',
+      type: 'married',
+    });
+
+    const result = await IndividualManager.getAll();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].names).toHaveLength(3);
+    expect(result[0].primaryName?.givenNames).toBe('Primary');
+    // Primary should come first in the names list
+    expect(result[0].names[0].isPrimary).toBe(true);
+  });
+
+  it('populates birth and death events when they exist', async () => {
+    const id = await createIndividual({ gender: 'M' });
+    await createName({ individualId: id, givenNames: 'Alive', isPrimary: true });
+    await createBirthEventFor(id, '1900-01-01');
+    await createDeathEventFor(id, '1980-12-31');
+
+    const result = await IndividualManager.getAll();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].birthEvent).not.toBeNull();
+    expect(result[0].birthEvent?.dateOriginal).toBe('1900-01-01');
+    expect(result[0].birthEvent?.eventType.tag).toBe('BIRT');
+    expect(result[0].deathEvent).not.toBeNull();
+    expect(result[0].deathEvent?.dateOriginal).toBe('1980-12-31');
+    expect(result[0].deathEvent?.eventType.tag).toBe('DEAT');
+  });
+
+  it('returns null birth/death events when an individual has none', async () => {
+    const id = await createIndividual({ gender: 'F' });
+    await createName({ individualId: id, givenNames: 'NoEvents', isPrimary: true });
+
+    const result = await IndividualManager.getAll();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].birthEvent).toBeNull();
+    expect(result[0].deathEvent).toBeNull();
+  });
+
+  it('only attaches events to individuals listed as principal participants', async () => {
+    const principalId = await createIndividual({ gender: 'M' });
+    const witnessId = await createIndividual({ gender: 'F' });
+    await createName({ individualId: principalId, givenNames: 'Principal', isPrimary: true });
+    await createName({ individualId: witnessId, givenNames: 'Witness', isPrimary: true });
+
+    const birtType = await getEventTypeByTag('BIRT');
+    if (!birtType) throw new Error('BIRT event type missing');
+    const eventId = await createEvent({
+      eventTypeId: birtType.id,
+      dateOriginal: '1900-01-01',
+    });
+    await addEventParticipant({ eventId, individualId: principalId, role: 'principal' });
+    await addEventParticipant({ eventId, individualId: witnessId, role: 'witness' });
+
+    const result = await IndividualManager.getAll();
+
+    const principal = result.find((i) => i.id === principalId);
+    const witness = result.find((i) => i.id === witnessId);
+    expect(principal?.birthEvent?.dateOriginal).toBe('1900-01-01');
+    expect(witness?.birthEvent).toBeNull();
+  });
+});

--- a/src/managers/IndividualManager.ts
+++ b/src/managers/IndividualManager.ts
@@ -6,11 +6,18 @@ import {
   updateIndividual,
   deleteIndividual,
 } from '$db-tree/individuals';
-import { createName, getNamesByIndividualId } from '$db-tree/names';
-import { getEventsByIndividualIdWithDetails } from '$db-tree/events';
-import { getPrimaryName } from '$db-tree/names';
+import {
+  createName,
+  getAllNames,
+  getAllPrimaryNames,
+  getNamesByIndividualId,
+  getPrimaryName,
+} from '$db-tree/names';
+import { getAllBirthDeathEvents, getEventsByIndividualIdWithDetails } from '$db-tree/events';
 import type {
   CreateIndividualInput,
+  EventWithDetails,
+  Name,
   UpdateIndividualInput,
   IndividualWithDetails,
 } from '$/types/database';
@@ -76,20 +83,53 @@ export class IndividualManager {
 
   /**
    * Get all individuals with full details.
-   * Note: Calls getById per individual (N+1). Acceptable for local SQLite.
+   * Uses a constant number of SQL queries (individuals, primary names, all
+   * names, birth/death events) and assembles the result in JS, so loading
+   * is independent of the number of individuals.
    */
   static async getAll(): Promise<IndividualWithDetails[]> {
-    const individuals = await getAllIndividuals();
-    const results: IndividualWithDetails[] = [];
+    const [individuals, primaryNames, allNames, birthDeathEvents] = await Promise.all([
+      getAllIndividuals(),
+      getAllPrimaryNames(),
+      getAllNames(),
+      getAllBirthDeathEvents(),
+    ]);
 
-    for (const individual of individuals) {
-      const enriched = await IndividualManager.getById(individual.id);
-      if (enriched) {
-        results.push(enriched);
+    const primaryNameByIndividual = new Map<string, Name>();
+    for (const name of primaryNames) {
+      primaryNameByIndividual.set(name.individualId, name);
+    }
+
+    const namesByIndividual = new Map<string, Name[]>();
+    for (const name of allNames) {
+      const list = namesByIndividual.get(name.individualId) ?? [];
+      list.push(name);
+      namesByIndividual.set(name.individualId, list);
+    }
+
+    const birthEventByIndividual = new Map<string, EventWithDetails>();
+    const deathEventByIndividual = new Map<string, EventWithDetails>();
+    for (const event of birthDeathEvents) {
+      const tag = event.eventType.tag;
+      if (tag !== 'BIRT' && tag !== 'DEAT') continue;
+
+      for (const participant of event.participants) {
+        if (participant.role !== 'principal' || participant.individualId === null) continue;
+        const target = tag === 'BIRT' ? birthEventByIndividual : deathEventByIndividual;
+        // Keep the first event encountered per individual, matching getById semantics
+        if (!target.has(participant.individualId)) {
+          target.set(participant.individualId, event);
+        }
       }
     }
 
-    return results;
+    return individuals.map((individual) => ({
+      ...individual,
+      primaryName: primaryNameByIndividual.get(individual.id) ?? null,
+      names: namesByIndividual.get(individual.id) ?? [],
+      birthEvent: birthEventByIndividual.get(individual.id) ?? null,
+      deathEvent: deathEventByIndividual.get(individual.id) ?? null,
+    }));
   }
 
   /**

--- a/src/managers/IndividualManager.ts
+++ b/src/managers/IndividualManager.ts
@@ -29,6 +29,27 @@ export interface CreateIndividualWithNameInput extends CreateIndividualInput {
   };
 }
 
+/**
+ * Select the first event whose type matches `tag` and where the given
+ * individual appears as a `principal` participant. Shared between `getAll`
+ * and `getById` so list and detail views stay consistent (see
+ * `bulk-entity-fetch` spec: Constant-query individual list fetch).
+ */
+function findPrincipalLifeEvent(
+  events: EventWithDetails[],
+  individualId: string,
+  tag: 'BIRT' | 'DEAT'
+): EventWithDetails | null {
+  for (const event of events) {
+    if (event.eventType.tag !== tag) continue;
+    const isPrincipal = event.participants.some(
+      (p) => p.role === 'principal' && p.individualId === individualId
+    );
+    if (isPrincipal) return event;
+  }
+  return null;
+}
+
 export class IndividualManager {
   /**
    * Create an individual with an optional primary name in a single transaction.
@@ -69,8 +90,8 @@ export class IndividualManager {
     const names = await getNamesByIndividualId(id);
     const events = await getEventsByIndividualIdWithDetails(id);
 
-    const birthEvent = events.find((e) => e.eventType.tag === 'BIRT') ?? null;
-    const deathEvent = events.find((e) => e.eventType.tag === 'DEAT') ?? null;
+    const birthEvent = findPrincipalLifeEvent(events, id, 'BIRT');
+    const deathEvent = findPrincipalLifeEvent(events, id, 'DEAT');
 
     return {
       ...individual,

--- a/src/managers/IndividualManager.ts
+++ b/src/managers/IndividualManager.ts
@@ -1,25 +1,33 @@
 import { getTreeDb } from '$/db/connection';
 import {
+  createIndividual,
+  deleteIndividual,
   getAllIndividuals,
   getIndividualById,
-  createIndividual,
+  getIndividualsByIds,
   updateIndividual,
-  deleteIndividual,
 } from '$db-tree/individuals';
 import {
   createName,
   getAllNames,
   getAllPrimaryNames,
   getNamesByIndividualId,
+  getNamesForIndividuals,
   getPrimaryName,
+  getPrimaryNamesForIndividuals,
 } from '$db-tree/names';
-import { getAllBirthDeathEvents, getEventsByIndividualIdWithDetails } from '$db-tree/events';
+import {
+  getAllBirthDeathEvents,
+  getBirthDeathEventsForIndividuals,
+  getEventsByIndividualIdWithDetails,
+} from '$db-tree/events';
 import type {
   CreateIndividualInput,
   EventWithDetails,
+  Individual,
+  IndividualWithDetails,
   Name,
   UpdateIndividualInput,
-  IndividualWithDetails,
 } from '$/types/database';
 
 export interface CreateIndividualWithNameInput extends CreateIndividualInput {
@@ -48,6 +56,55 @@ function findPrincipalLifeEvent(
     if (isPrincipal) return event;
   }
   return null;
+}
+
+/**
+ * Build `IndividualWithDetails[]` from batch-fetched name and birth/death
+ * event data. Shared between `getAll` and `getByIds` so both paths apply
+ * the same "first BIRT/DEAT with principal participant" selection rule.
+ */
+function assembleIndividualsWithDetails(
+  individuals: Individual[],
+  primaryNames: Name[],
+  allNames: Name[],
+  birthDeathEvents: EventWithDetails[]
+): IndividualWithDetails[] {
+  const primaryNameByIndividual = new Map<string, Name>();
+  for (const name of primaryNames) {
+    primaryNameByIndividual.set(name.individualId, name);
+  }
+
+  const namesByIndividual = new Map<string, Name[]>();
+  for (const name of allNames) {
+    const list = namesByIndividual.get(name.individualId) ?? [];
+    list.push(name);
+    namesByIndividual.set(name.individualId, list);
+  }
+
+  const birthEventByIndividual = new Map<string, EventWithDetails>();
+  const deathEventByIndividual = new Map<string, EventWithDetails>();
+  for (const event of birthDeathEvents) {
+    const tag = event.eventType.tag;
+    if (tag !== 'BIRT' && tag !== 'DEAT') continue;
+
+    for (const participant of event.participants) {
+      if (participant.role !== 'principal' || participant.individualId === null) continue;
+      const target = tag === 'BIRT' ? birthEventByIndividual : deathEventByIndividual;
+      // Keep the first event encountered per individual — matches the
+      // semantics of findPrincipalLifeEvent used by getById.
+      if (!target.has(participant.individualId)) {
+        target.set(participant.individualId, event);
+      }
+    }
+  }
+
+  return individuals.map((individual) => ({
+    ...individual,
+    primaryName: primaryNameByIndividual.get(individual.id) ?? null,
+    names: namesByIndividual.get(individual.id) ?? [],
+    birthEvent: birthEventByIndividual.get(individual.id) ?? null,
+    deathEvent: deathEventByIndividual.get(individual.id) ?? null,
+  }));
 }
 
 export class IndividualManager {
@@ -116,41 +173,32 @@ export class IndividualManager {
       getAllBirthDeathEvents(),
     ]);
 
-    const primaryNameByIndividual = new Map<string, Name>();
-    for (const name of primaryNames) {
-      primaryNameByIndividual.set(name.individualId, name);
-    }
+    return assembleIndividualsWithDetails(individuals, primaryNames, allNames, birthDeathEvents);
+  }
 
-    const namesByIndividual = new Map<string, Name[]>();
-    for (const name of allNames) {
-      const list = namesByIndividual.get(name.individualId) ?? [];
-      list.push(name);
-      namesByIndividual.set(name.individualId, list);
-    }
+  /**
+   * Get enriched details for a specific subset of individuals.
+   * Uses the same four-query batch pattern as `getAll` but filters every
+   * query to the given id list, so callers that already know which
+   * individuals they need (e.g. `FamilyManager.getAll` after resolving
+   * `family_members`) don't pay for loading the entire people graph.
+   *
+   * Duplicate ids are tolerated and the result array preserves the row
+   * order returned by the database; ids with no matching row are silently
+   * omitted.
+   */
+  static async getByIds(ids: string[]): Promise<IndividualWithDetails[]> {
+    if (ids.length === 0) return [];
+    const uniqueIds = Array.from(new Set(ids));
 
-    const birthEventByIndividual = new Map<string, EventWithDetails>();
-    const deathEventByIndividual = new Map<string, EventWithDetails>();
-    for (const event of birthDeathEvents) {
-      const tag = event.eventType.tag;
-      if (tag !== 'BIRT' && tag !== 'DEAT') continue;
+    const [individuals, primaryNames, allNames, birthDeathEvents] = await Promise.all([
+      getIndividualsByIds(uniqueIds),
+      getPrimaryNamesForIndividuals(uniqueIds),
+      getNamesForIndividuals(uniqueIds),
+      getBirthDeathEventsForIndividuals(uniqueIds),
+    ]);
 
-      for (const participant of event.participants) {
-        if (participant.role !== 'principal' || participant.individualId === null) continue;
-        const target = tag === 'BIRT' ? birthEventByIndividual : deathEventByIndividual;
-        // Keep the first event encountered per individual, matching getById semantics
-        if (!target.has(participant.individualId)) {
-          target.set(participant.individualId, event);
-        }
-      }
-    }
-
-    return individuals.map((individual) => ({
-      ...individual,
-      primaryName: primaryNameByIndividual.get(individual.id) ?? null,
-      names: namesByIndividual.get(individual.id) ?? [],
-      birthEvent: birthEventByIndividual.get(individual.id) ?? null,
-      deathEvent: deathEventByIndividual.get(individual.id) ?? null,
-    }));
+    return assembleIndividualsWithDetails(individuals, primaryNames, allNames, birthDeathEvents);
   }
 
   /**

--- a/src/pages/FamiliesPage.tsx
+++ b/src/pages/FamiliesPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -16,36 +17,39 @@ export function FamiliesPage({ treeId }: FamiliesPageProps): JSX.Element {
   const navigate = useNavigate();
   const { data: families, isLoading, isError } = useFamilies();
 
-  const columns: ColumnDef<FamilyWithMembers, string>[] = [
-    {
-      accessorKey: 'id',
-      header: t('columns.id'),
-      cell: ({ row }) => <span className="text-muted-foreground">{row.original.id}</span>,
-    },
-    {
-      id: 'husband',
-      header: t('columns.husband'),
-      accessorFn: (row) => formatName(row.husband?.primaryName ?? null).full,
-      cell: ({ getValue }) => <span className="font-medium">{getValue()}</span>,
-    },
-    {
-      id: 'wife',
-      header: t('columns.wife'),
-      accessorFn: (row) => formatName(row.wife?.primaryName ?? null).full,
-      cell: ({ getValue }) => <span className="font-medium">{getValue()}</span>,
-    },
-    {
-      id: 'children',
-      header: t('columns.children'),
-      accessorFn: (row) => String(row.children.length),
-      cell: ({ row }) => row.original.children.length,
-    },
-    {
-      id: 'marriage',
-      header: t('columns.marriage'),
-      accessorFn: (row) => row.marriageEvent?.dateOriginal ?? '',
-    },
-  ];
+  const columns = useMemo<ColumnDef<FamilyWithMembers, string>[]>(
+    () => [
+      {
+        accessorKey: 'id',
+        header: t('columns.id'),
+        cell: ({ row }) => <span className="text-muted-foreground">{row.original.id}</span>,
+      },
+      {
+        id: 'husband',
+        header: t('columns.husband'),
+        accessorFn: (row) => formatName(row.husband?.primaryName ?? null).full,
+        cell: ({ getValue }) => <span className="font-medium">{getValue()}</span>,
+      },
+      {
+        id: 'wife',
+        header: t('columns.wife'),
+        accessorFn: (row) => formatName(row.wife?.primaryName ?? null).full,
+        cell: ({ getValue }) => <span className="font-medium">{getValue()}</span>,
+      },
+      {
+        id: 'children',
+        header: t('columns.children'),
+        accessorFn: (row) => String(row.children.length),
+        cell: ({ row }) => row.original.children.length,
+      },
+      {
+        id: 'marriage',
+        header: t('columns.marriage'),
+        accessorFn: (row) => row.marriageEvent?.dateOriginal ?? '',
+      },
+    ],
+    [t]
+  );
 
   if (isLoading) {
     return <p className="p-6 text-sm text-muted-foreground">{tc('status.loading')}</p>;

--- a/src/pages/IndividualsPage.tsx
+++ b/src/pages/IndividualsPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -16,34 +17,37 @@ export function IndividualsPage({ treeId }: IndividualsPageProps): JSX.Element {
   const navigate = useNavigate();
   const { data: individuals, isLoading, isError } = useIndividuals();
 
-  const columns: ColumnDef<IndividualWithDetails, string>[] = [
-    {
-      accessorKey: 'id',
-      header: t('columns.id'),
-      cell: ({ row }) => <span className="text-muted-foreground">{row.original.id}</span>,
-    },
-    {
-      id: 'name',
-      header: t('columns.name'),
-      accessorFn: (row) => formatName(row.primaryName).full,
-      cell: ({ getValue }) => <span className="font-medium">{getValue()}</span>,
-    },
-    {
-      accessorKey: 'gender',
-      header: t('columns.gender'),
-      cell: ({ row }) => t(`gender.${row.original.gender}`),
-    },
-    {
-      id: 'birth',
-      header: t('columns.birth'),
-      accessorFn: (row) => row.birthEvent?.dateOriginal ?? '',
-    },
-    {
-      id: 'death',
-      header: t('columns.death'),
-      accessorFn: (row) => row.deathEvent?.dateOriginal ?? '',
-    },
-  ];
+  const columns = useMemo<ColumnDef<IndividualWithDetails, string>[]>(
+    () => [
+      {
+        accessorKey: 'id',
+        header: t('columns.id'),
+        cell: ({ row }) => <span className="text-muted-foreground">{row.original.id}</span>,
+      },
+      {
+        id: 'name',
+        header: t('columns.name'),
+        accessorFn: (row) => formatName(row.primaryName).full,
+        cell: ({ getValue }) => <span className="font-medium">{getValue()}</span>,
+      },
+      {
+        accessorKey: 'gender',
+        header: t('columns.gender'),
+        cell: ({ row }) => t(`gender.${row.original.gender}`),
+      },
+      {
+        id: 'birth',
+        header: t('columns.birth'),
+        accessorFn: (row) => row.birthEvent?.dateOriginal ?? '',
+      },
+      {
+        id: 'death',
+        header: t('columns.death'),
+        accessorFn: (row) => row.deathEvent?.dateOriginal ?? '',
+      },
+    ],
+    [t]
+  );
 
   if (isLoading) {
     return <p className="p-6 text-sm text-muted-foreground">{tc('status.loading')}</p>;

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -84,28 +84,31 @@ export function RepositoriesPage({ treeId }: RepositoriesPageProps): JSX.Element
     setForm((prev) => ({ ...prev, [name]: value }));
   }
 
-  const columns: ColumnDef<Repository, string>[] = [
-    {
-      accessorKey: 'id',
-      header: t('columns.id'),
-      cell: ({ row }) => <span className="text-muted-foreground">{row.original.id}</span>,
-    },
-    {
-      accessorKey: 'name',
-      header: t('columns.name'),
-      cell: ({ getValue }) => <span className="font-medium">{getValue()}</span>,
-    },
-    {
-      accessorKey: 'city',
-      header: t('columns.city'),
-      cell: ({ getValue }) => getValue() ?? '',
-    },
-    {
-      accessorKey: 'country',
-      header: t('columns.country'),
-      cell: ({ getValue }) => getValue() ?? '',
-    },
-  ];
+  const columns = useMemo<ColumnDef<Repository, string>[]>(
+    () => [
+      {
+        accessorKey: 'id',
+        header: t('columns.id'),
+        cell: ({ row }) => <span className="text-muted-foreground">{row.original.id}</span>,
+      },
+      {
+        accessorKey: 'name',
+        header: t('columns.name'),
+        cell: ({ getValue }) => <span className="font-medium">{getValue()}</span>,
+      },
+      {
+        accessorKey: 'city',
+        header: t('columns.city'),
+        cell: ({ getValue }) => getValue() ?? '',
+      },
+      {
+        accessorKey: 'country',
+        header: t('columns.country'),
+        cell: ({ getValue }) => getValue() ?? '',
+      },
+    ],
+    [t]
+  );
 
   if (isLoading) {
     return <p className="p-6 text-sm text-muted-foreground">{tc('status.loading')}</p>;

--- a/src/pages/SourcesPage.tsx
+++ b/src/pages/SourcesPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -88,28 +88,31 @@ export function SourcesPage({ treeId }: SourcesPageProps): JSX.Element {
     setForm((prev) => ({ ...prev, [name]: value }));
   }
 
-  const columns: ColumnDef<Source, string>[] = [
-    {
-      accessorKey: 'id',
-      header: t('columns.id'),
-      cell: ({ row }) => <span className="text-muted-foreground">{row.original.id}</span>,
-    },
-    {
-      accessorKey: 'title',
-      header: t('columns.title'),
-      cell: ({ getValue }) => <span className="font-medium">{getValue()}</span>,
-    },
-    {
-      accessorKey: 'author',
-      header: t('columns.author'),
-      cell: ({ getValue }) => getValue() ?? '',
-    },
-    {
-      id: 'repository',
-      header: t('columns.repository'),
-      accessorFn: (row) => row.repositoryId ?? '',
-    },
-  ];
+  const columns = useMemo<ColumnDef<Source, string>[]>(
+    () => [
+      {
+        accessorKey: 'id',
+        header: t('columns.id'),
+        cell: ({ row }) => <span className="text-muted-foreground">{row.original.id}</span>,
+      },
+      {
+        accessorKey: 'title',
+        header: t('columns.title'),
+        cell: ({ getValue }) => <span className="font-medium">{getValue()}</span>,
+      },
+      {
+        accessorKey: 'author',
+        header: t('columns.author'),
+        cell: ({ getValue }) => getValue() ?? '',
+      },
+      {
+        id: 'repository',
+        header: t('columns.repository'),
+        accessorFn: (row) => row.repositoryId ?? '',
+      },
+    ],
+    [t]
+  );
 
   if (isLoading) {
     return <p className="p-6 text-sm text-muted-foreground">{tc('status.loading')}</p>;


### PR DESCRIPTION
## Summary

- **Debounce** DataTable search input at 250ms via new `useDebouncedValue` hook — decouples immediate visual feedback from expensive filter recomputation
- **Memoize** columns in Individuals, Families, Sources, Repositories pages so `useReactTable` internal state isn't invalidated on every parent re-render
- **Batch queries** replace N+1 loops in `IndividualManager.getAll()` and `FamilyManager.getAll()` — constant number of SQL calls regardless of row count

## Why

Typing in any search input froze the UI: characters didn't appear, the main thread blocked, users had to restart. Three compounding causes:

1. Every keystroke synchronously updated `globalFilter`, triggering `getFilteredRowModel()` to re-scan the entire dataset
2. Column arrays were rebuilt on every render, invalidating TanStack Table's memoization
3. `IndividualManager.getAll()` loaded each individual via `getById()`, firing ~3 extra queries per row (~226 queries for 75 individuals)

## Changes

**Components / pages**
- `src/components/data-table.tsx` — split immediate `inputValue` from 250ms-debounced `globalFilter`
- `useMemo(…, [t])` applied to column arrays in all 4 pages

**DB layer (`src/db/trees/`)**
- `names.ts` — add `getAllPrimaryNames()` and `getAllNames()`
- `events.ts` — add `getAllBirthDeathEvents()` and `getAllMarriageEvents()` backed by a shared `assembleEventsWithDetails` helper that batches participants + places
- `families.ts` — add `getAllFamilyMembers()`

**Managers**
- `IndividualManager.getAll()` — 4 parallel batch queries + JS-map assembly, zero per-row awaits
- `FamilyManager.getAll()` — composes batch queries + `IndividualManager.getAll()` data with JS maps

**Hooks**
- `src/hooks/useDebouncedValue.ts` — generic `useDebouncedValue<T>(value, delay)` hook

## Test plan

- [x] `pnpm vitest run` — 550/550 passing (14 new tests: 4 hook + 7+7 manager)
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] Live smoke test in running Tauri app against GRAMPS-Bourgoin-Aubé tree (75 individuals, 19 families):
  - Typed "Bourgoin" (8 chars) in Individus search — all chars appeared, filter narrowed correctly, no freeze
  - Typed "Soucy" (5 chars) in Familles search — filter narrowed to 7 rows, pagination counter updated
  - Column sort triggered by header click — works unchanged
- [x] Direct timing of batch managers in the running app:
  - `IndividualManager.getAll()` — 35–39 ms (75 individuals, 3 runs)
  - `FamilyManager.getAll()` — 47–68 ms (19 families, includes nested individual batch, 3 runs)

## Spec / change tracking

Archived OpenSpec change under `openspec/changes/archive/2026-04-10-fix-search-input-freeze/` and synced two new capability specs:

- `openspec/specs/bulk-entity-fetch/spec.md`
- `openspec/specs/data-table-search-performance/spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)