### PR TITLE
chore: add OpenSpec workflow tooling and initial proposals

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -41,7 +41,7 @@ Implement tasks from an OpenSpec change.
    - Dynamic instruction based on current state
 
    **Handle states:**
-   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "blocked"` (missing artifacts): show message listing what's missing, suggest using `/opsx:explore` (or create the missing artifacts manually)
    - If `state: "all_done"`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 
@@ -85,7 +85,7 @@ Implement tasks from an OpenSpec change.
 
 **Output During Implementation**
 
-```
+```text
 ## Implementing: <change-name> (schema: <schema-name>)
 
 Working on task 3/7: <task description>
@@ -99,7 +99,7 @@ Working on task 4/7: <task description>
 
 **Output On Completion**
 
-```
+```text
 ## Implementation Complete
 
 **Change:** <change-name>
@@ -116,7 +116,7 @@ All tasks complete! You can archive this change with `/opsx:archive`.
 
 **Output On Pause (Issue Encountered)**
 
-```
+```text
 ## Implementation Paused
 
 **Change:** <change-name>
@@ -146,7 +146,7 @@ What would you like to do?
 
 **Fluid Workflow Integration**
 
-This skill supports the "actions on a change" model:
+This command supports the "actions on a change" model:
 
 - **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
 - **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -89,7 +89,7 @@ Archive a completed change in the experimental workflow.
 
 **Output On Success**
 
-```
+```text
 ## Archive Complete
 
 **Change:** <change-name>
@@ -102,7 +102,7 @@ All artifacts complete. All tasks complete.
 
 **Output On Success (No Delta Specs)**
 
-```
+```text
 ## Archive Complete
 
 **Change:** <change-name>
@@ -115,7 +115,7 @@ All artifacts complete. All tasks complete.
 
 **Output On Success With Warnings**
 
-```
+```text
 ## Archive Complete (with warnings)
 
 **Change:** <change-name>
@@ -133,7 +133,7 @@ Review the archive if this was not intentional.
 
 **Output On Error (Archive Exists)**
 
-```
+```text
 ## Archive Failed
 
 **Change:** <change-name>

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -89,7 +89,7 @@ Implement tasks from an OpenSpec change.
 
 **Output During Implementation**
 
-```
+```text
 ## Implementing: <change-name> (schema: <schema-name>)
 
 Working on task 3/7: <task description>
@@ -103,7 +103,7 @@ Working on task 4/7: <task description>
 
 **Output On Completion**
 
-```
+```text
 ## Implementation Complete
 
 **Change:** <change-name>
@@ -120,7 +120,7 @@ All tasks complete! Ready to archive this change.
 
 **Output On Pause (Issue Encountered)**
 
-```
+```text
 ## Implementation Paused
 
 **Change:** <change-name>

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -45,7 +45,7 @@ Implement tasks from an OpenSpec change.
    - Dynamic instruction based on current state
 
    **Handle states:**
-   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "blocked"` (missing artifacts): show message listing what's missing, suggest using `/opsx:explore` (or create the missing artifacts manually)
    - If `state: "all_done"`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -93,7 +93,7 @@ Archive a completed change in the experimental workflow.
 
 **Output On Success**
 
-```
+```text
 ## Archive Complete
 
 **Change:** <change-name>

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │         CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -51,7 +51,7 @@ Depending on what the user brings, you might:
 - Recommend a path (if asked)
 
 **Visualize**
-```
+```text
 ┌─────────────────────────────────────────┐
 │     Use ASCII diagrams liberally        │
 ├─────────────────────────────────────────┤
@@ -146,7 +146,7 @@ If the user mentions a change or you detect one is relevant:
 ## Handling Different Entry Points
 
 **User brings a vague idea:**
-```
+```text
 User: I'm thinking about adding real-time collaboration
 
 You: Real-time collab is a big space. Let me think about this...
@@ -169,7 +169,7 @@ You: Real-time collab is a big space. Let me think about this...
 ```
 
 **User brings a specific problem:**
-```
+```text
 User: The auth system is a mess
 
 You: [reads codebase]
@@ -200,7 +200,7 @@ You: [reads codebase]
 ```
 
 **User is stuck mid-implementation:**
-```
+```text
 User: /opsx:explore add-auth-system
       The OAuth integration is more complex than expected
 
@@ -217,7 +217,7 @@ You: [reads change artifacts]
 ```
 
 **User wants to compare options:**
-```
+```text
 User: Should we use Postgres or SQLite?
 
 You: Generic answer is boring. What's the context?
@@ -258,7 +258,7 @@ There's no required ending. Discovery might:
 
 When it feels like things are crystallizing, you might summarize:
 
-```
+```text
 ## What We Figured Out
 
 **The problem**: [crystallized understanding]

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/openspec/changes/add-pedigree-chart/.openspec.yaml
+++ b/openspec/changes/add-pedigree-chart/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/add-pedigree-chart/design.md
+++ b/openspec/changes/add-pedigree-chart/design.md
@@ -1,0 +1,143 @@
+## Context
+
+Vata has no graphical representation of a family tree. The tree landing page (`src/pages/TreeView.tsx`) shows only the tree name, description, and counts of individuals and families. All genealogical browsing happens through tabular lists (Individuals, Families, Sources, Repositories). Users have asked for the iconic pedigree chart view — a visual "ancestor tree" centered on an active person that every genealogy app ships as the default view.
+
+Relevant current state:
+
+- No "active person" concept exists. `useAppStore` only tracks `currentTreeId`, theme, and language. The `tree_meta` table is a free key-value store already wired up for schema version and software info.
+- Family relationships are queryable via `getParentFamilies(individualId)` (`src/db/trees/families.ts`), but there's no function to walk N generations up the pedigree.
+- No visualization libraries are installed. The stack is React 18 + Tailwind + shadcn/ui, which pairs naturally with inline SVG.
+
+Constraints:
+
+- The pedigree fits in a small, bounded space (up to 5 generations = max 31 nodes). Layout and performance are trivial.
+- MVP4 is source-first; MVP5 is UI. This feature fits MVP5 (UI polish / default view).
+- No new routes — replace the content of the existing landing page to make this the default view on tree open.
+- Click-to-navigate only. No zoom/pan (user explicitly scoped this out).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Render a pedigree chart (subject + ancestors) as SVG on the tree landing page
+- Support click-to-navigate: clicking any ancestor re-roots the chart around them
+- Persist the active person per-tree so it survives navigation and app restart
+- Handle missing ancestors gracefully (empty slots keep the binary layout stable)
+- Show a default generation depth of 4 (1 subject + 3 ancestor generations = up to 15 people), with a simple control to switch to 3 or 5
+- Keep the implementation light: no heavy viz libraries if they don't pay for themselves
+
+**Non-Goals:**
+
+- Pan / zoom interactions (explicitly excluded)
+- Descendants view (children, grandchildren, etc.) — ancestors only
+- Printing or exporting the chart
+- Animations / smooth transitions when re-rooting
+- Inline editing of ancestors from the chart
+- Visual indicators for missing citations, consanguinity, or other advanced genealogy markers
+- Virtualization or performance work beyond the 5-generation cap
+
+## Decisions
+
+### D1: Render with plain SVG — no layout library
+
+**Decision**: Implement the pedigree chart as plain JSX rendering SVG elements (`<svg>`, `<g>`, `<rect>`, `<text>`, `<path>`). Compute node positions with a small pure function. Do not install d3-hierarchy, @visx/hierarchy, react-d3-tree, react-flow, or any other viz dependency.
+
+**Rationale**: A pedigree is a _balanced binary tree of bounded depth_ (max 5 levels = 31 slots). Unlike general trees where variable-width subtrees demand the Reingold–Tilford algorithm, every slot has a fixed, deterministic position based only on its path from the root: `x = slotIndex * slotWidth`, `y = level * levelHeight`. The layout function fits in ~20 lines. React + SVG gives full control over node cards (we can embed Tailwind-styled HTML via `<foreignObject>` if needed) and integrates cleanly with the existing shadcn/ui / lucide-react stack.
+
+**Alternatives considered:**
+
+- **d3-hierarchy** (~8 KB): Industry standard for tree layouts, but it solves a harder problem than we have. It expects an arbitrary tree and computes balanced positions; for a fixed binary pedigree it adds no value. Data model mismatch too — a pedigree root has "parents" not "children", requiring an inversion.
+- **@visx/hierarchy**: Nicer React API around d3-hierarchy, but inherits the data model mismatch and adds dependency weight.
+- **react-d3-tree**: Full-featured with zoom/pan/collapse out of the box, but opinionated rendering, less control over node design, and brings features (zoom/pan) that are explicit non-goals.
+- **react-flow / xyflow**: General-purpose diagram library, overkill for a fixed-layout pedigree. Would require custom layout code anyway, defeating the point.
+- **family-chart**: Genealogy-specific but thin on React support and maintenance.
+
+**Revisit if**: we later want descendants view with variable branching, then d3-hierarchy becomes the right tool.
+
+### D2: Store `home_person_id` in `tree_meta` as a key-value row
+
+**Decision**: Use the existing `tree_meta` key-value table. Add a `home_person_id` key whose value is the integer individual ID (stringified). No schema migration — `tree_meta` is already a free-form key-value store.
+
+**Rationale**: `tree_meta` already exists for exactly this kind of lightweight per-tree configuration. Adding a new key is a pure data operation: no ALTER TABLE, no migration, no versioning concerns.
+
+**Alternative considered**: Store in `useAppStore` (Zustand + localStorage). Rejected because it couples per-tree state to global UI state and doesn't survive if the user opens the tree on another machine (a likely future scenario with sync).
+
+### D3: Active-person selection hook reads and writes `tree_meta`
+
+**Decision**: Add `getHomePersonId()` / `setHomePersonId(id)` functions in a new file `src/db/trees/tree-meta.ts` (or extend whatever tree-meta code exists). Expose a TanStack Query hook `useActivePerson()` that reads the home person and auto-falls-back to the first individual in the tree if unset, and a mutation `useSetActivePerson()` that writes the value and invalidates the chart query.
+
+**Rationale**: Matches the project's existing pattern (DB layer → hook → component). Falling back to the first individual gives a sensible first-run experience for newly imported trees.
+
+**Alternative considered**: Show a first-run modal asking the user to pick a home person. Rejected as friction — a silent default is good enough, and the user can change it by clicking any ancestor.
+
+### D4: Ancestor loading via an iterative IN query
+
+**Decision**: Add `getAncestors(rootId, generations)` that loads the pedigree iteratively:
+
+1. Start with `currentLevel = [rootId]`
+2. For each level up to `generations`:
+   a. Query `SELECT id, gender, is_living FROM individuals WHERE id IN (currentLevel)`
+   b. Query parent relationships: `SELECT individual_id, family_id FROM family_members WHERE individual_id IN (currentLevel) AND role = 'child'` → get parent family IDs
+   c. Query husband/wife from those families: `SELECT family_id, individual_id, role FROM family_members WHERE family_id IN (parentFamilyIds) AND role IN ('husband','wife')`
+   d. Build `currentLevel = [all parent IDs]` for next iteration
+3. After all levels, do one batch call to load primary names and birth/death events for every unique individual ID collected (reusing the batch functions introduced by `fix-search-input-freeze`)
+4. Return a structured pedigree: `{ [slotIndex]: Person | null }` mapped onto binary-tree positions
+
+**Rationale**: Each iteration is one small SQL query; total is ~`2 * generations + 1` queries regardless of tree size. With `generations = 4`, that's 9 queries — trivial on SQLite. Using IN clauses batches lookups across an entire generation at once, avoiding N+1.
+
+**Alternative considered**: Recursive CTE (`WITH RECURSIVE ancestors AS ...`). Rejected because the `@tauri-apps/plugin-sql` API is fine with multiple small queries, and iterative JS code is easier to reason about, test, and debug than a recursive CTE that walks three join tables.
+
+### D5: Data shape uses binary-tree slot indices
+
+**Decision**: Represent the pedigree as a flat array indexed by "ancestor number" (Ahnentafel / Sosa–Stradonitz numbering):
+
+- Slot 1 = subject (root)
+- Slot 2 = father, Slot 3 = mother
+- Slot 4 = paternal grandfather, 5 = paternal grandmother, 6 = maternal grandfather, 7 = maternal grandmother
+- In general: for slot _n_, father = 2n, mother = 2n + 1
+
+A single sparse array `Pedigree = Record<number, PedigreeNode | null>` covers all generations.
+
+**Rationale**: Ahnentafel numbering is the standard genealogy convention for pedigree charts. It gives O(1) lookup for any ancestor, trivially maps to (level, positionInLevel) coordinates for layout, and null entries represent unknown ancestors without breaking the structure.
+
+**Alternative considered**: Nested object tree (`{ self, father: {...}, mother: {...} }`). Rejected because recursive traversal is more awkward and the flat representation is what the renderer actually wants.
+
+### D6: Layout — left-to-right, subject on the left
+
+**Decision**: Orient the chart left-to-right: subject on the far left, each ancestor generation extending rightward. Fixed slot dimensions (~180×60 px card with ~40 px vertical gap and ~80 px horizontal gap).
+
+- Level _L_ occupies column _L_ at `x = L * (cardWidth + hGap)`
+- Within level _L_, slot _p_ (0-indexed) is at `y = (p + 0.5) * (totalHeight / 2^L)`
+- Connectors are right-angle paths: from the right edge of a child node to the left edges of its two parents
+
+**Rationale**: Left-to-right is the most common pedigree orientation in desktop genealogy software (RootsMagic, Gramps, Family Tree Maker all default to it). It matches reading order, accommodates wider name labels, and keeps the subject anchored on the left where the eye lands first.
+
+**Alternative considered**: Top-down (subject at bottom, ancestors above). Rejected as less space-efficient for desktop aspect ratios.
+
+### D7: Person card shows minimal fields
+
+**Decision**: Each non-empty node card displays:
+
+- Primary name (formatted, truncated with ellipsis if too long)
+- Birth–death years range (e.g., `1842–1910`, or `1842–` for living, or `?` if unknown)
+- Gender indicator (icon or colored left border)
+
+No photos, no IDs, no places, no event lists. Empty slots show a muted dashed outline with a "+" or "?" placeholder.
+
+**Rationale**: The pedigree chart is a navigational overview, not a detail view. Minimal data keeps cards small and the whole chart scannable at a glance. For more detail the user clicks through to the individual detail page (via the existing individual route).
+
+### D8: Click behavior — re-root the chart
+
+**Decision**: Clicking any ancestor card calls `setHomePersonId(clickedId)`, which updates `tree_meta` and invalidates the `useActivePerson` and `useAncestors` queries, causing the chart to re-render centered on the new subject. No route change, no modal.
+
+**Rationale**: Re-rooting is the standard interaction for pedigree charts and keeps the user in a single view. Because TanStack Query handles the invalidation, the transition is automatic.
+
+**Alternative considered**: Open the individual detail page. Rejected because the user explicitly chose "click to navigate" within the chart itself, not away from it. A separate link or button on the card can still navigate to the detail page later if desired.
+
+## Risks / Trade-offs
+
+- **No zoom/pan** → If 5 generations doesn't fit at common window sizes, the chart might overflow or look cramped. → Mitigation: Default to 4 generations (15 nodes) which fits comfortably. Overflow scrolls natively within the SVG container. User can reduce depth if needed.
+- **Manual layout code is our responsibility** → No library to fall back on for edge cases. → Mitigation: Layout is simple enough that the code fits in one file with unit tests covering all positions up to 5 generations.
+- **Default active person heuristic** → "First individual in the tree" is arbitrary and may surprise users with a disconnected individual who has no ancestors. → Mitigation: When `getAncestors` returns only the root (no parents), the chart still renders meaningfully and the user can navigate to a better starting point via the individuals list. A future improvement can suggest the individual with the most ancestors.
+- **Performance with missing ancestors** → Not a real concern — the layout renders empty slots at the same cost as filled ones.
+- **Accessibility of clickable SVG** → SVG elements need explicit `role="button"`, `tabIndex`, keyboard handlers. → Mitigation: Wrap each person card in a `<g>` with proper ARIA attributes and handle `Enter`/`Space` keys; testing-standards skill will flag any gaps.

--- a/openspec/changes/add-pedigree-chart/proposal.md
+++ b/openspec/changes/add-pedigree-chart/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+A graphical pedigree chart (an ancestor tree showing the active person with their parents, grandparents, and beyond) is the iconic, expected visualization for any genealogy application — usually the default view when opening a tree. Vata currently has no graphical representation at all: the tree landing page only shows summary stats (individual count, family count) and all browsing happens through tabular lists. Researchers lose their bearings when navigating across hundreds of individuals without a visual "map" of how people relate.
+
+## What Changes
+
+- **Add a pedigree chart view** that displays the active person and their ancestors up to 5 generations (configurable), rendered as SVG
+- **Make the pedigree chart the default tree landing page** at `/tree/$treeId/`, replacing the current stats-only view
+- **Introduce an "active person" concept** (the subject/proband of the pedigree chart), persisted per-tree so it survives navigation and app restart
+- **Support click-to-navigate** on any ancestor node: clicking a person makes them the new active person and re-roots the chart around them
+- **Show a minimal node card per ancestor**: primary name, birth–death years, gender indicator
+- **Handle missing ancestors** as empty/placeholder slots so the binary structure stays visually stable
+- **Auto-select a default active person** on first load if none is set (first individual in the tree, or null state with a picker if the tree is empty)
+
+## Capabilities
+
+### New Capabilities
+
+- `pedigree-chart`: SVG pedigree visualization showing the active person and their ancestors, with click-to-navigate and generation depth configuration
+- `active-person`: Per-tree "active person" (subject of the pedigree chart) stored in tree metadata, persisted across sessions, with hooks for reading/updating
+- `ancestor-fetch`: DB/query layer to efficiently load an individual's ancestors up to N generations in a bounded number of queries
+
+### Modified Capabilities
+
+_None — the current tree landing page has no spec-level requirements; it's being replaced._
+
+## Impact
+
+- **New route content**: `/tree/$treeId/` (via `src/pages/TreeView.tsx`) becomes the pedigree chart. The summary stats (individual/family counts) move into a header or small sidebar.
+- **New components**: `PedigreeChart` (SVG root), `PedigreeNode` (person card), `PedigreeConnector` (parent–child lines), `PedigreeEmptySlot` (missing ancestor placeholder), optional `ActivePersonPicker` (first-time selection).
+- **New hook**: `useAncestors(individualId, generations)` — fetches the ancestor tree via a bounded SQL strategy.
+- **New DB function**: `getAncestors(rootId, generations)` in `src/db/trees/individuals.ts` (or a new file) that loads ancestors using a CTE or iterative queries with IN clauses.
+- **Schema change**: Add `home_person_id` key to the `tree_meta` table (already exists as a key-value store, so no migration — just a new row when set).
+- **Store change**: The active person is stored in `tree_meta`, but we cache it in TanStack Query for reads.
+- **No new dependencies required**. The design doc will evaluate library options (d3-hierarchy, @visx/hierarchy, react-d3-tree, manual layout) and justify the choice.
+- **No breaking changes** — the existing individuals list and detail routes are unchanged.

--- a/openspec/changes/add-pedigree-chart/specs/active-person/spec.md
+++ b/openspec/changes/add-pedigree-chart/specs/active-person/spec.md
@@ -29,6 +29,11 @@ The system SHALL provide a hook that returns the effective active person, fallin
 - **WHEN** the tree has a `home_person_id` set and the hook is called
 - **THEN** the hook SHALL return the individual with that ID
 
+#### Scenario: Stale `home_person_id`
+
+- **WHEN** the tree has a `home_person_id` that does not match any individual in the tree and the hook is called
+- **THEN** the hook SHALL treat the stale value as if unset and fall through to the auto-fallback behavior (return the first individual in the tree, or `null` if the tree is empty)
+
 #### Scenario: Unset with individuals available
 
 - **WHEN** the tree has no `home_person_id` but has at least one individual

--- a/openspec/changes/add-pedigree-chart/specs/active-person/spec.md
+++ b/openspec/changes/add-pedigree-chart/specs/active-person/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Per-tree active person stored in tree_meta
+
+Each tree SHALL have an optional "active person" (home person) stored in the `tree_meta` key-value table under the key `home_person_id`.
+
+#### Scenario: Setting the active person
+
+- **WHEN** the system calls `setHomePersonId(individualId)` for an open tree
+- **THEN** the value SHALL be written to `tree_meta` under the key `home_person_id`
+- **THEN** subsequent reads SHALL return the newly set ID
+
+#### Scenario: Reading an unset active person
+
+- **WHEN** the system calls `getHomePersonId()` on a tree that has no `home_person_id` row
+- **THEN** the function SHALL return `null`
+
+#### Scenario: Persistence across sessions
+
+- **WHEN** the user sets an active person, closes the tree, and reopens it later
+- **THEN** reading `home_person_id` SHALL return the same value that was set
+
+### Requirement: Active person query with auto-fallback
+
+The system SHALL provide a hook that returns the effective active person, falling back to the first individual in the tree if none is explicitly set.
+
+#### Scenario: Explicit active person
+
+- **WHEN** the tree has a `home_person_id` set and the hook is called
+- **THEN** the hook SHALL return the individual with that ID
+
+#### Scenario: Unset with individuals available
+
+- **WHEN** the tree has no `home_person_id` but has at least one individual
+- **THEN** the hook SHALL return the first individual in the tree (ordered by ID)
+
+#### Scenario: Unset with no individuals
+
+- **WHEN** the tree has no `home_person_id` and no individuals at all
+- **THEN** the hook SHALL return `null`
+
+### Requirement: Mutation invalidates pedigree queries
+
+Setting a new active person SHALL invalidate any cached pedigree data for the affected tree.
+
+#### Scenario: Switching active person refreshes the chart
+
+- **WHEN** the user sets a new active person via the mutation hook
+- **THEN** the mutation SHALL invalidate the active-person query and the ancestor-fetch query
+- **THEN** the pedigree chart component SHALL re-render with the new data without a manual refresh

--- a/openspec/changes/add-pedigree-chart/specs/ancestor-fetch/spec.md
+++ b/openspec/changes/add-pedigree-chart/specs/ancestor-fetch/spec.md
@@ -24,8 +24,8 @@ The system SHALL provide a DB function `getAncestors(rootId, generations)` that 
 
 #### Scenario: Generations parameter bounds
 
-- **WHEN** `getAncestors(rootId, N)` is called
-- **THEN** the function SHALL reject or clamp values where N is less than 1 or greater than 5
+- **WHEN** `getAncestors(rootId, N)` is called with N outside the inclusive range `1..5`
+- **THEN** the function SHALL clamp N to that range: values less than 1 SHALL be treated as 1, and values greater than 5 SHALL be treated as 5
 
 ### Requirement: Ancestor results structured as Ahnentafel numbering
 
@@ -44,8 +44,8 @@ The ancestor fetch result SHALL be indexed by Ahnentafel (Sosa–Stradonitz) num
 #### Scenario: Missing ancestor slots
 
 - **WHEN** an ancestor at slot `n` is unknown
-- **THEN** the result SHALL have no entry (or a null entry) at slot `n`
-- **THEN** descendants of that missing slot SHALL also be absent from the result
+- **THEN** the result SHALL have a `null` entry at slot `n`
+- **THEN** descendants of that missing slot SHALL also be `null` entries in the result
 
 ### Requirement: Each ancestor node exposes display fields
 

--- a/openspec/changes/add-pedigree-chart/specs/ancestor-fetch/spec.md
+++ b/openspec/changes/add-pedigree-chart/specs/ancestor-fetch/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Load ancestors up to N generations in bounded queries
+
+The system SHALL provide a DB function `getAncestors(rootId, generations)` that loads an individual and their ancestors up to the specified number of generations using a bounded number of SQL queries (independent of total tree size).
+
+#### Scenario: Loading a full pedigree
+
+- **WHEN** `getAncestors(rootId, 4)` is called and all 15 ancestor slots are filled in the DB
+- **THEN** the function SHALL return 15 individuals (the root plus 14 ancestors)
+- **THEN** the total number of SQL queries SHALL be bounded by a constant multiple of the number of generations, not the number of individuals in the tree
+
+#### Scenario: Partial pedigree
+
+- **WHEN** `getAncestors(rootId, 4)` is called and some ancestors are unknown
+- **THEN** the function SHALL return only the known individuals
+- **THEN** the caller SHALL be able to identify which ancestor slots are missing from the result
+
+#### Scenario: Root with no parents
+
+- **WHEN** `getAncestors(rootId, 4)` is called on an individual with no parent family
+- **THEN** the function SHALL return only the root individual
+- **THEN** no error SHALL be thrown
+
+#### Scenario: Generations parameter bounds
+
+- **WHEN** `getAncestors(rootId, N)` is called
+- **THEN** the function SHALL reject or clamp values where N is less than 1 or greater than 5
+
+### Requirement: Ancestor results structured as Ahnentafel numbering
+
+The ancestor fetch result SHALL be indexed by Ahnentafel (Sosa–Stradonitz) numbers so that each slot has a stable, well-known position.
+
+#### Scenario: Root position
+
+- **WHEN** ancestors are returned
+- **THEN** the root individual SHALL be at slot 1
+
+#### Scenario: Parents' positions
+
+- **WHEN** a child is at slot `n`
+- **THEN** their father SHALL be at slot `2n` and their mother at slot `2n + 1`
+
+#### Scenario: Missing ancestor slots
+
+- **WHEN** an ancestor at slot `n` is unknown
+- **THEN** the result SHALL have no entry (or a null entry) at slot `n`
+- **THEN** descendants of that missing slot SHALL also be absent from the result
+
+### Requirement: Each ancestor node exposes display fields
+
+Each individual returned from `getAncestors` SHALL include the fields needed to render a pedigree person card without additional queries.
+
+#### Scenario: Display fields available
+
+- **WHEN** `getAncestors` returns a slot's individual
+- **THEN** that individual SHALL expose the formatted primary name, birth year (if known), death year (if known), living status, and gender
+
+#### Scenario: Missing primary name
+
+- **WHEN** an individual has no primary name
+- **THEN** the primary name field SHALL be `null`
+- **THEN** the card SHALL still be renderable (the component handles the null)

--- a/openspec/changes/add-pedigree-chart/specs/pedigree-chart/spec.md
+++ b/openspec/changes/add-pedigree-chart/specs/pedigree-chart/spec.md
@@ -99,7 +99,9 @@ Clicking a filled ancestor node SHALL re-root the pedigree chart around that per
 
 #### Scenario: Keyboard activation
 
-- **WHEN** a person card is focused and the user presses Enter or Space
+- **WHEN** a filled person card is rendered
+- **THEN** the card SHALL be keyboard focusable and expose interactive semantics (e.g., `role="button"` or a semantic `<button>`)
+- **WHEN** a filled person card is focused and the user presses Enter or Space
 - **THEN** the chart SHALL re-root on that person as if it were clicked
 
 ### Requirement: Connector lines between generations

--- a/openspec/changes/add-pedigree-chart/specs/pedigree-chart/spec.md
+++ b/openspec/changes/add-pedigree-chart/specs/pedigree-chart/spec.md
@@ -1,0 +1,118 @@
+## ADDED Requirements
+
+### Requirement: Pedigree chart on tree landing page
+
+The tree landing page at `/tree/$treeId/` SHALL display a pedigree chart showing the active person and their ancestors.
+
+#### Scenario: Opening a tree with an active person set
+
+- **WHEN** the user navigates to `/tree/$treeId/` and the tree has an active person
+- **THEN** the page SHALL render a pedigree chart rooted on that active person
+- **THEN** the active person SHALL appear on the left side of the chart
+- **THEN** ancestors SHALL be laid out to the right of the active person, one column per generation
+
+#### Scenario: Opening a tree with no active person set
+
+- **WHEN** the user opens a tree that has no active person stored
+- **THEN** the app SHALL automatically select the first individual in the tree as the active person
+- **THEN** the chart SHALL render rooted on that auto-selected person
+
+#### Scenario: Opening an empty tree
+
+- **WHEN** the user opens a tree that has no individuals
+- **THEN** the page SHALL display an empty state instead of the chart
+- **THEN** the empty state SHALL guide the user toward adding or importing individuals
+
+### Requirement: Ancestor rendering up to configured depth
+
+The pedigree chart SHALL display ancestors up to a configurable generation depth, with a default of 4 generations (subject + 3 ancestor levels, up to 15 people).
+
+#### Scenario: Default depth
+
+- **WHEN** the chart first renders
+- **THEN** it SHALL display 4 generations: the subject, parents, grandparents, and great-grandparents
+
+#### Scenario: Changing depth
+
+- **WHEN** the user changes the generation depth control to a supported value (3, 4, or 5)
+- **THEN** the chart SHALL re-render with the selected number of generations
+
+#### Scenario: Maximum depth enforced
+
+- **WHEN** the user attempts to set a depth greater than 5
+- **THEN** the chart SHALL cap the depth at 5 generations
+
+### Requirement: Person card content
+
+Each filled pedigree node SHALL display the individual's primary name, birth–death years, and a gender indicator.
+
+#### Scenario: Individual with full data
+
+- **WHEN** an ancestor has a primary name, a birth event with a year, and a death event with a year
+- **THEN** the card SHALL show the formatted primary name, the birth year, and the death year separated by an en dash (e.g., `1842–1910`)
+- **THEN** the card SHALL show a gender indicator corresponding to the individual's gender
+
+#### Scenario: Living individual
+
+- **WHEN** an ancestor is marked as living
+- **THEN** the card SHALL show the birth year followed by an en dash and no death year (e.g., `1960–`)
+
+#### Scenario: Individual with no dates
+
+- **WHEN** an ancestor has no birth or death year
+- **THEN** the card SHALL display a placeholder in place of the year range (e.g., `?`)
+
+#### Scenario: Long name truncation
+
+- **WHEN** a primary name is longer than fits in the card
+- **THEN** the name SHALL be truncated with an ellipsis and the full name SHALL remain available as the element's accessible name (e.g., `aria-label` or `<title>`)
+
+### Requirement: Empty ancestor slots
+
+Missing ancestors SHALL be rendered as visually distinct empty slots that preserve the binary layout.
+
+#### Scenario: Unknown parent
+
+- **WHEN** an individual at any level has no recorded parent
+- **THEN** the corresponding slot SHALL render as an empty placeholder card (e.g., dashed outline)
+- **THEN** the slot SHALL occupy the same position it would have if filled
+
+#### Scenario: Empty slot is not clickable
+
+- **WHEN** a slot is an empty placeholder
+- **THEN** clicking it SHALL have no effect on the active person
+
+### Requirement: Click to re-root
+
+Clicking a filled ancestor node SHALL re-root the pedigree chart around that person.
+
+#### Scenario: Click on an ancestor
+
+- **WHEN** the user clicks any filled person card in the chart
+- **THEN** the clicked person SHALL become the new active person
+- **THEN** the chart SHALL re-render showing the clicked person on the left with their ancestors extending to the right
+
+#### Scenario: Active person persists across navigation
+
+- **WHEN** the user re-roots the chart and then navigates away and back to the landing page
+- **THEN** the chart SHALL still be rooted on the previously selected active person
+
+#### Scenario: Keyboard activation
+
+- **WHEN** a person card is focused and the user presses Enter or Space
+- **THEN** the chart SHALL re-root on that person as if it were clicked
+
+### Requirement: Connector lines between generations
+
+Parent–child relationships in the chart SHALL be drawn as connector lines between cards.
+
+#### Scenario: Child connected to both parents
+
+- **WHEN** a child node has both parents recorded
+- **THEN** a line SHALL connect the right edge of the child card to the left edges of both parent cards
+- **THEN** the line SHALL visually disambiguate the two parents
+
+#### Scenario: Child with one missing parent
+
+- **WHEN** a child node has only one parent recorded and the other is an empty slot
+- **THEN** a line SHALL still be drawn to the empty slot so the binary layout stays readable

--- a/openspec/changes/add-pedigree-chart/tasks.md
+++ b/openspec/changes/add-pedigree-chart/tasks.md
@@ -1,0 +1,45 @@
+## 1. Active person — DB and hooks
+
+- [ ] 1.1 Create `src/db/trees/tree-meta.ts` (or extend existing) with `getHomePersonId()` and `setHomePersonId(individualId)` reading/writing the `home_person_id` key in `tree_meta`
+- [ ] 1.2 Add integration tests for `getHomePersonId` / `setHomePersonId` covering unset → null, set → read back, overwrite, persistence
+- [ ] 1.3 Create `src/hooks/useActivePerson.ts` — TanStack Query hook that returns the effective active person, falling back to the first individual if unset, or null if the tree is empty
+- [ ] 1.4 Create `useSetActivePerson` mutation that writes the home person ID and invalidates `useActivePerson` and `useAncestors` queries
+- [ ] 1.5 Add unit tests for the hook's fallback logic (explicit set, unset with individuals, unset with no individuals)
+
+## 2. Ancestor fetch — DB function
+
+- [ ] 2.1 Add `getAncestors(rootId: string, generations: number)` in `src/db/trees/individuals.ts` (or a new `src/db/trees/ancestors.ts`) implementing the iterative IN-query strategy from design D4
+- [ ] 2.2 Clamp `generations` to the 1..5 range
+- [ ] 2.3 Return results keyed by Ahnentafel slot number (root = 1, father = 2, mother = 3, etc.) with the shape `Record<number, PedigreeNode>` where missing ancestors have no entry
+- [ ] 2.4 Include primary name, birth year, death year, living status, and gender on each `PedigreeNode` (reuse batch query helpers from `fix-search-input-freeze` if already landed; otherwise fetch them in the same iterative pass)
+- [ ] 2.5 Add integration tests: full 4-generation pedigree, partial pedigree with missing grandparents, root with no parents, depth clamping, depth = 1 returns only the root
+- [ ] 2.6 Create `src/hooks/useAncestors.ts` — TanStack Query hook wrapping the DB function, keyed by `(treeId, rootId, generations)`
+
+## 3. Pedigree chart — layout
+
+- [ ] 3.1 Create `src/lib/pedigree-layout.ts` with a pure function `computePedigreeLayout({ generations, cardWidth, cardHeight, hGap, vGap }): { slots: Record<number, { x: number; y: number }>; width: number; height: number }`
+- [ ] 3.2 Layout rule: for slot `n` at level `L = floor(log2(n))`, place it at `x = L * (cardWidth + hGap)` and `y = ((slotInLevel + 0.5) * (totalHeight / 2^L))` where `slotInLevel = n - 2^L`
+- [ ] 3.3 Unit test the layout function exhaustively for depths 1 through 5, verifying each slot's position and the total width/height
+
+## 4. Pedigree chart — components
+
+- [ ] 4.1 Create `src/components/pedigree/PedigreeNode.tsx` — renders one person card as an SVG group; props: position, person data (or null for empty slot), onClick; shows primary name (truncated), year range, gender indicator; handles Enter/Space for keyboard activation; sets `role="button"`, `tabIndex={0}`, `aria-label`
+- [ ] 4.2 Create `src/components/pedigree/PedigreeConnector.tsx` — draws an SVG path connecting a child card's right edge to a parent card's left edge (right-angle path)
+- [ ] 4.3 Create `src/components/pedigree/PedigreeChart.tsx` — top-level SVG component; props: `rootId`, `generations`; uses `useAncestors` + `computePedigreeLayout`; renders connectors first (below), then nodes (above); handles click to call `useSetActivePerson`
+- [ ] 4.4 Create `src/components/pedigree/PedigreeEmptyState.tsx` — empty state for when the tree has no individuals
+- [ ] 4.5 Add a small depth selector (3 / 4 / 5) as a local UI control above the chart; default 4
+- [ ] 4.6 Add component tests: renders with full data, renders with missing ancestors (empty slots), click re-roots, keyboard activation works, correct number of nodes for each depth
+
+## 5. Landing page integration
+
+- [ ] 5.1 Update `src/pages/TreeView.tsx` to render the `PedigreeChart` as the main content
+- [ ] 5.2 Keep the existing tree name/description and counts in a compact header above the chart
+- [ ] 5.3 Handle the empty-tree case by rendering `PedigreeEmptyState` instead of the chart
+- [ ] 5.4 Verify the route at `/tree/$treeId/` displays the chart after opening a populated tree
+
+## 6. Verify and polish
+
+- [ ] 6.1 Run `pnpm test` — all tests pass
+- [ ] 6.2 Run `pnpm lint` and `pnpm format:check`
+- [ ] 6.3 Manually test with `pnpm tauri:dev`: open a tree, verify chart renders, click an ancestor, verify re-rooting, refresh app, verify active person persisted, switch depth, verify re-layout
+- [ ] 6.4 Verify the tree landing page still works for empty trees and single-person trees

--- a/openspec/changes/improve-individual-detail-page/.openspec.yaml
+++ b/openspec/changes/improve-individual-detail-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/improve-individual-detail-page/design.md
+++ b/openspec/changes/improve-individual-detail-page/design.md
@@ -65,4 +65,4 @@ The Figma mockup shows a three-panel layout: individual list (left), structured 
 
 - **Performance with large trees**: The left panel loads all individuals via `useIndividuals()`. For trees with thousands of entries, this could be slow. → Mitigation: The existing pagination from IndividualsPage is already implemented; we can reuse the search/filter logic. Virtual scrolling can be added later if needed.
 - **Multiple concurrent queries**: Rendering the detail view triggers `useIndividual` + `useIndividualRelationships` + `useEventTimeline`. → Mitigation: TanStack Query handles deduplication and caching. These are lightweight SQLite queries.
-- **Route consolidation**: Merging two routes into one changes existing URLs. → Mitigation: The old `/individual/$individualId` route can redirect to `/individuals?id=$individualId` for any bookmarks.
+- **Route consolidation**: Merging two routes into one changes existing URLs. → Mitigation: The old `/tree/$treeId/individual/$individualId` route can redirect to `/tree/$treeId/individuals?id=$individualId` for any bookmarks, preserving the tree context.

--- a/openspec/changes/improve-individual-detail-page/design.md
+++ b/openspec/changes/improve-individual-detail-page/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The current `IndividualViewPage` is a single-column layout: a back link, a header with name/gender/status/ID, a "Names" card, and an "Events" card. The `IndividualsPage` is a separate route showing a searchable table. There is no way to browse between individuals without leaving the detail view.
+
+The Figma mockup shows a three-panel layout: individual list (left), structured summary (center), contextual sidebar (right). All relationship data (parents, siblings, half-siblings, spouse, children) is already queryable via the families/family_members DB layer — it just isn't surfaced on the individual page.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Redesign the individual detail page into a three-panel master-detail layout matching the Figma mockup
+- Surface family relationships (parents, siblings, half-siblings) directly on the individual page
+- Enable quick navigation between related individuals without route changes
+- Keep the layout responsive and performant with existing data queries
+
+**Non-Goals:**
+
+- Inline editing of individual fields (buttons shown as disabled/placeholder)
+- Creating new individuals from the detail page (the "New" button in the list is already available on IndividualsPage)
+- Modifying the database schema or adding new DB tables
+- Mobile/tablet responsive layout (desktop-first for Tauri app)
+- CRUD operations for family relationships ("Add Brother"/"Add Sister"/"Add" event are shown in the mockup but will be non-functional placeholders initially)
+
+## Decisions
+
+### D1: Merge list and detail into a single route
+
+**Decision**: Replace the separate `/individuals` list page and `/individual/$individualId` detail page with a unified master-detail view at `/tree/$treeId/individuals` that shows the list on the left and the selected individual on the right.
+
+**Rationale**: The Figma mockup shows them as one screen. This avoids full page transitions when browsing individuals and keeps context. The list route already exists; we add an optional selected individual state.
+
+**Alternative considered**: Keep separate routes and use a layout route to render the list alongside. Rejected because it adds routing complexity for a feature that's fundamentally a single view with selection state.
+
+### D2: Use URL search params for selected individual
+
+**Decision**: The selected individual ID is stored in a URL search param (`?id=I-0001`) on the `/individuals` route, not as a route param.
+
+**Rationale**: This keeps the list always visible, allows deep-linking to a specific individual, and avoids needing a new nested route. Back/forward browser behavior works naturally.
+
+**Alternative considered**: Zustand state for selection. Rejected because it breaks deep-linking and browser history.
+
+### D3: New `useIndividualRelationships` hook
+
+**Decision**: Create a dedicated hook that composes existing DB functions (`getParentFamilies`, `getSpouseFamilies`, `getChildrenInFamily`, family member lookups) to return a structured relationships object: `{ father, mother, siblings, halfSiblings, spouseFamilies }`.
+
+**Rationale**: The data exists but requires multiple queries to assemble. Encapsulating this in a TanStack Query hook with proper cache keys keeps the component layer clean. The hook depends on `useFamily` internals but not on new DB functions.
+
+**Alternative considered**: Extend `IndividualWithDetails` type to include relationships. Rejected because it would require changing the existing `getIndividualById` query to do expensive joins for every fetch, even when relationships aren't needed.
+
+### D4: Three-panel layout with CSS Grid
+
+**Decision**: Use a CSS Grid layout with three columns: `280px 1fr 320px`. The left panel scrolls independently, center panel scrolls independently, right sidebar scrolls independently.
+
+**Rationale**: Grid provides stable column sizing without flex-based hacks. Independent scroll regions match the mockup's UX where each panel is its own viewport.
+
+**Alternative considered**: Flexbox with fixed widths. Grid is more semantic for this layout pattern.
+
+### D5: Reuse existing components where possible
+
+**Decision**: The left panel reuses the existing individuals list data/query (`useIndividuals`) with a simplified display (no table, just a card-per-row list). The center panel is a new component. The right sidebar is a new component. EventTimeline is reused as-is in the sidebar.
+
+**Rationale**: Avoids duplicating data-fetching logic while allowing visual customization per panel.
+
+## Risks / Trade-offs
+
+- **Performance with large trees**: The left panel loads all individuals via `useIndividuals()`. For trees with thousands of entries, this could be slow. → Mitigation: The existing pagination from IndividualsPage is already implemented; we can reuse the search/filter logic. Virtual scrolling can be added later if needed.
+- **Multiple concurrent queries**: Rendering the detail view triggers `useIndividual` + `useIndividualRelationships` + `useEventTimeline`. → Mitigation: TanStack Query handles deduplication and caching. These are lightweight SQLite queries.
+- **Route consolidation**: Merging two routes into one changes existing URLs. → Mitigation: The old `/individual/$individualId` route can redirect to `/individuals?id=$individualId` for any bookmarks.

--- a/openspec/changes/improve-individual-detail-page/proposal.md
+++ b/openspec/changes/improve-individual-detail-page/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The current individual detail page is a basic vertical layout (header + names card + events card) that doesn't surface key genealogical context at a glance. A researcher viewing an individual needs to immediately see vital dates, family relationships (parents, siblings, spouse, children), and events — all in a structured, information-dense layout. The current page requires navigating away to understand family context, breaking the research flow.
+
+## What Changes
+
+- **Redesign the individual detail page** into a three-panel master-detail layout:
+  - **Left panel**: Scrollable individual list with search, allowing quick switching between individuals without leaving the page
+  - **Center panel**: Individual summary as a structured key-value table (ID, gender, alternative names, birth/death dates and places, father, mother, siblings, half-siblings) with clickable links to related individuals and places
+  - **Right panel**: Contextual sidebar showing Parents (with "Add Brother"/"Add Sister" actions), Families (spouse + children), and Events (timeline with "Add" action)
+- **Replace the current card-based layout** with a denser, more informative presentation inspired by professional genealogy software
+- **Add relationship display** directly on the individual page (father, mother, siblings, half-siblings) — data exists via families DB but is not currently surfaced on this page
+- **Add quick navigation** between related individuals via clickable links (parent, sibling, spouse names navigate to their detail pages)
+
+## Capabilities
+
+### New Capabilities
+
+- `individual-detail-layout`: Three-panel master-detail layout for individual browsing (list + detail + sidebar)
+- `individual-relationships`: Display and navigate family relationships (parents, siblings, half-siblings, spouse, children) on the individual detail page
+- `individual-summary-panel`: Structured key-value summary of an individual's vital information (dates, places, names, family links)
+- `individual-sidebar`: Right sidebar showing parents, families, and events with quick-add actions
+
+### Modified Capabilities
+
+_None — no existing spec-level requirements are changing._
+
+## Impact
+
+- **Pages**: `IndividualViewPage.tsx` — full rewrite into multi-panel layout; `IndividualsPage.tsx` — the list may be extracted into a reusable panel component
+- **Components**: New components for the three panels, relationship display, and summary table
+- **Hooks/Data**: New hook or query to fetch an individual's relationships (parents, siblings, half-siblings) by composing existing `getParentFamilies`, `getSpouseFamilies`, `getChildrenInFamily` DB functions
+- **Routes**: The `/tree/$treeId/individual/$individualId` route will need to accommodate the new layout; the `/tree/$treeId/individuals` list route may merge into the detail page as the left panel
+- **No database changes** — all relationship data is already available through the families/family_members tables

--- a/openspec/changes/improve-individual-detail-page/specs/individual-detail-layout/spec.md
+++ b/openspec/changes/improve-individual-detail-page/specs/individual-detail-layout/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Three-panel master-detail layout
+
+The individuals view SHALL display a three-panel layout: a left panel with the individual list, a center panel with the selected individual's summary, and a right panel with contextual sidebar information.
+
+#### Scenario: Default state with no selection
+
+- **WHEN** the user navigates to the individuals page without a selected individual
+- **THEN** the left panel SHALL display the searchable list of individuals
+- **THEN** the center and right panels SHALL display an empty state message
+
+#### Scenario: Individual selected
+
+- **WHEN** the user clicks on an individual in the left panel list
+- **THEN** the URL SHALL update with the selected individual's ID as a search param
+- **THEN** the center panel SHALL display that individual's summary
+- **THEN** the right panel SHALL display that individual's sidebar information
+
+### Requirement: Left panel individual list with search
+
+The left panel SHALL display a scrollable, searchable list of all individuals in the tree.
+
+#### Scenario: List display
+
+- **WHEN** the individuals page loads
+- **THEN** each list item SHALL show the individual's formatted name, ID, gender, birth/death years, and living status
+- **THEN** the currently selected individual SHALL be visually highlighted
+
+#### Scenario: Search filtering
+
+- **WHEN** the user types in the search input
+- **THEN** the list SHALL filter individuals whose name matches the search term
+
+### Requirement: Deep-linking to selected individual
+
+The selected individual SHALL be encoded in the URL so it can be bookmarked and shared.
+
+#### Scenario: Direct URL navigation
+
+- **WHEN** the user navigates to `/tree/$treeId/individuals?id=I-0001`
+- **THEN** the individual with ID `I-0001` SHALL be selected and displayed in the center and right panels
+
+#### Scenario: Browser history navigation
+
+- **WHEN** the user selects different individuals and uses the browser back button
+- **THEN** the previously selected individual SHALL be restored
+
+### Requirement: Independent panel scrolling
+
+Each of the three panels SHALL scroll independently.
+
+#### Scenario: Long list does not affect detail scroll
+
+- **WHEN** the individual list is longer than the viewport
+- **THEN** the left panel SHALL scroll independently without affecting the center or right panel scroll positions

--- a/openspec/changes/improve-individual-detail-page/specs/individual-detail-layout/spec.md
+++ b/openspec/changes/improve-individual-detail-page/specs/individual-detail-layout/spec.md
@@ -46,6 +46,13 @@ The selected individual SHALL be encoded in the URL so it can be bookmarked and 
 - **WHEN** the user selects different individuals and uses the browser back button
 - **THEN** the previously selected individual SHALL be restored
 
+#### Scenario: Invalid `id` search param
+
+- **WHEN** the user navigates to `/tree/$treeId/individuals?id=<value>` where `<value>` does not match any individual in the tree (e.g., a stale bookmark)
+- **THEN** no individual SHALL be selected
+- **THEN** the center and right panels SHALL display a "not found" empty state
+- **THEN** the left panel SHALL remain fully usable for selecting another individual
+
 ### Requirement: Independent panel scrolling
 
 Each of the three panels SHALL scroll independently.

--- a/openspec/changes/improve-individual-detail-page/specs/individual-relationships/spec.md
+++ b/openspec/changes/improve-individual-detail-page/specs/individual-relationships/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Fetch individual relationships
+
+The system SHALL provide a hook that returns an individual's family relationships: father, mother, siblings, and half-siblings.
+
+#### Scenario: Individual with both parents
+
+- **WHEN** an individual belongs to a parent family with a husband and wife
+- **THEN** the father SHALL be the family's husband
+- **THEN** the mother SHALL be the family's wife
+
+#### Scenario: Individual with siblings
+
+- **WHEN** an individual's parent family has other children
+- **THEN** siblings SHALL include all other children in that family (excluding the individual)
+
+#### Scenario: Individual with half-siblings
+
+- **WHEN** either parent belongs to another family with children
+- **THEN** half-siblings SHALL include children from those other families who are not already listed as full siblings
+
+#### Scenario: Individual with no parent family
+
+- **WHEN** an individual does not belong to any family as a child
+- **THEN** father, mother, siblings, and half-siblings SHALL all be null/empty
+
+### Requirement: Display relationships as navigable links
+
+Family relationship values (father, mother, siblings, half-siblings) SHALL be displayed as clickable links that navigate to that individual's detail view.
+
+#### Scenario: Click on father link
+
+- **WHEN** the user clicks on the father's name in the center summary
+- **THEN** the view SHALL navigate to display that father's detail (updating the URL search param)
+
+#### Scenario: No related individual
+
+- **WHEN** a relationship field has no value (e.g., no father recorded)
+- **THEN** the field SHALL display "None" or equivalent placeholder text

--- a/openspec/changes/improve-individual-detail-page/specs/individual-sidebar/spec.md
+++ b/openspec/changes/improve-individual-detail-page/specs/individual-sidebar/spec.md
@@ -14,7 +14,7 @@ The right sidebar SHALL display a "Parents" section showing the individual's fat
 #### Scenario: No parents recorded
 
 - **WHEN** an individual has no parent family
-- **THEN** the Parents section SHALL display an empty state
+- **THEN** the Parents section SHALL display an empty state with the literal text "No parents"
 
 ### Requirement: Siblings in parents section
 
@@ -61,4 +61,4 @@ The right sidebar SHALL display an "Events" section with the individual's event 
 #### Scenario: No events
 
 - **WHEN** an individual has no events
-- **THEN** the Events section SHALL display an empty state with the "Add" button still visible
+- **THEN** the Events section SHALL display an empty state with the literal text "No events" and the "Add" button still visible

--- a/openspec/changes/improve-individual-detail-page/specs/individual-sidebar/spec.md
+++ b/openspec/changes/improve-individual-detail-page/specs/individual-sidebar/spec.md
@@ -8,7 +8,7 @@ The right sidebar SHALL display a "Parents" section showing the individual's fat
 
 - **WHEN** an individual has parents recorded
 - **THEN** each parent SHALL be displayed as a card/row showing their name, ID, birth/death years, gender, and living status
-- **THEN** each parent card SHALL be clickable to navigate to that parent's detail
+- **THEN** clicking a parent card SHALL update the selection by navigating to `/tree/$treeId/individuals?id=<parentId>` (updating the `id` search param) rather than performing a full page navigation
 
 #### Scenario: No parents recorded
 
@@ -23,7 +23,7 @@ The Parents section SHALL also list siblings below the parents, with "Add Brothe
 
 - **WHEN** the individual has siblings in the parent family
 - **THEN** each sibling SHALL be displayed as a card/row with name, ID, birth/death years, gender, and living status
-- **THEN** each sibling card SHALL be clickable to navigate to that sibling's detail
+- **THEN** clicking a sibling card SHALL update the selection by navigating to `/tree/$treeId/individuals?id=<siblingId>` (updating the `id` search param) rather than performing a full page navigation
 
 #### Scenario: Add sibling buttons
 

--- a/openspec/changes/improve-individual-detail-page/specs/individual-sidebar/spec.md
+++ b/openspec/changes/improve-individual-detail-page/specs/individual-sidebar/spec.md
@@ -8,7 +8,8 @@ The right sidebar SHALL display a "Parents" section showing the individual's fat
 
 - **WHEN** an individual has parents recorded
 - **THEN** each parent SHALL be displayed as a card/row showing their name, ID, birth/death years, gender, and living status
-- **THEN** clicking a parent card SHALL update the selection by navigating to `/tree/$treeId/individuals?id=<parentId>` (updating the `id` search param) rather than performing a full page navigation
+- **THEN** a missing birth or death year SHALL be rendered as the literal placeholder `—` (em dash)
+- **THEN** clicking a parent card SHALL update the selection by navigating to `/tree/$treeId/individuals?id=<parentId>` (updating the `id` search param) rather than performing a full-page navigation
 
 #### Scenario: No parents recorded
 
@@ -23,7 +24,8 @@ The Parents section SHALL also list siblings below the parents, with "Add Brothe
 
 - **WHEN** the individual has siblings in the parent family
 - **THEN** each sibling SHALL be displayed as a card/row with name, ID, birth/death years, gender, and living status
-- **THEN** clicking a sibling card SHALL update the selection by navigating to `/tree/$treeId/individuals?id=<siblingId>` (updating the `id` search param) rather than performing a full page navigation
+- **THEN** a missing birth or death year SHALL be rendered as the literal placeholder `—` (em dash)
+- **THEN** clicking a sibling card SHALL update the selection by navigating to `/tree/$treeId/individuals?id=<siblingId>` (updating the `id` search param) rather than performing a full-page navigation
 
 #### Scenario: Add sibling buttons
 
@@ -39,7 +41,7 @@ The right sidebar SHALL display a "Families" section showing families where the 
 
 - **WHEN** an individual is a husband or wife in one or more families
 - **THEN** each family SHALL be displayed showing the spouse's name and children
-- **THEN** clicking a spouse or child name SHALL update the selection by navigating to `/tree/$treeId/individuals?id=<personId>` (updating the `id` search param) rather than performing a full page navigation, preserving browser history for back/forward and deep-linking
+- **THEN** clicking a spouse or child name SHALL update the selection by navigating to `/tree/$treeId/individuals?id=<personId>` (updating the `id` search param) rather than performing a full-page navigation, preserving browser history for back/forward and deep-linking
 
 #### Scenario: No spouse families
 

--- a/openspec/changes/improve-individual-detail-page/specs/individual-sidebar/spec.md
+++ b/openspec/changes/improve-individual-detail-page/specs/individual-sidebar/spec.md
@@ -39,12 +39,12 @@ The right sidebar SHALL display a "Families" section showing families where the 
 
 - **WHEN** an individual is a husband or wife in one or more families
 - **THEN** each family SHALL be displayed showing the spouse's name and children
-- **THEN** spouse and children names SHALL be clickable links
+- **THEN** clicking a spouse or child name SHALL update the selection by navigating to `/tree/$treeId/individuals?id=<personId>` (updating the `id` search param) rather than performing a full page navigation, preserving browser history for back/forward and deep-linking
 
 #### Scenario: No spouse families
 
 - **WHEN** an individual has no spouse families
-- **THEN** the Families section SHALL be collapsed or show an empty state
+- **THEN** the Families section SHALL display an empty state with the literal text "No families"
 
 ### Requirement: Events section
 

--- a/openspec/changes/improve-individual-detail-page/specs/individual-sidebar/spec.md
+++ b/openspec/changes/improve-individual-detail-page/specs/individual-sidebar/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Parents section
+
+The right sidebar SHALL display a "Parents" section showing the individual's father and mother with summary details.
+
+#### Scenario: Parents with details
+
+- **WHEN** an individual has parents recorded
+- **THEN** each parent SHALL be displayed as a card/row showing their name, ID, birth/death years, gender, and living status
+- **THEN** each parent card SHALL be clickable to navigate to that parent's detail
+
+#### Scenario: No parents recorded
+
+- **WHEN** an individual has no parent family
+- **THEN** the Parents section SHALL display an empty state
+
+### Requirement: Siblings in parents section
+
+The Parents section SHALL also list siblings below the parents, with "Add Brother" and "Add Sister" action buttons.
+
+#### Scenario: Siblings displayed
+
+- **WHEN** the individual has siblings in the parent family
+- **THEN** each sibling SHALL be displayed as a card/row with name, ID, birth/death years, gender, and living status
+- **THEN** each sibling card SHALL be clickable to navigate to that sibling's detail
+
+#### Scenario: Add sibling buttons
+
+- **WHEN** the Parents section is displayed
+- **THEN** "Add Brother" and "Add Sister" buttons SHALL be visible
+- **THEN** these buttons SHALL be non-functional placeholders initially
+
+### Requirement: Families section
+
+The right sidebar SHALL display a "Families" section showing families where the individual is a spouse.
+
+#### Scenario: Individual with spouse families
+
+- **WHEN** an individual is a husband or wife in one or more families
+- **THEN** each family SHALL be displayed showing the spouse's name and children
+- **THEN** spouse and children names SHALL be clickable links
+
+#### Scenario: No spouse families
+
+- **WHEN** an individual has no spouse families
+- **THEN** the Families section SHALL be collapsed or show an empty state
+
+### Requirement: Events section
+
+The right sidebar SHALL display an "Events" section with the individual's event timeline and an "Add" button.
+
+#### Scenario: Events displayed
+
+- **WHEN** an individual has events
+- **THEN** the Events section SHALL display the event timeline (reusing EventTimeline component)
+- **THEN** an "Add" button SHALL be visible (non-functional placeholder)
+
+#### Scenario: No events
+
+- **WHEN** an individual has no events
+- **THEN** the Events section SHALL display an empty state with the "Add" button still visible

--- a/openspec/changes/improve-individual-detail-page/specs/individual-summary-panel/spec.md
+++ b/openspec/changes/improve-individual-detail-page/specs/individual-summary-panel/spec.md
@@ -33,7 +33,7 @@ The summary SHALL display all non-primary names as alternative names.
 #### Scenario: No alternative names
 
 - **WHEN** an individual has only a primary name
-- **THEN** the Alternative names row SHALL display "None" or be omitted
+- **THEN** the Alternative names row SHALL be displayed and SHALL show the literal text "None"
 
 ### Requirement: Place links
 

--- a/openspec/changes/improve-individual-detail-page/specs/individual-summary-panel/spec.md
+++ b/openspec/changes/improve-individual-detail-page/specs/individual-summary-panel/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Structured key-value summary
+
+The center panel SHALL display the individual's information as a structured key-value table with the following rows: ID, Gender, Alternative names, Birth date, Birth place, Death date, Death place, Father, Mother, Siblings, Half-siblings.
+
+#### Scenario: Full individual data
+
+- **WHEN** an individual has complete data (all fields populated)
+- **THEN** each row SHALL display the label on the left and the value on the right
+- **THEN** the individual's formatted name SHALL appear as a large heading above the table
+
+#### Scenario: Missing optional fields
+
+- **WHEN** an individual has no birth date, death date, or place recorded
+- **THEN** those fields SHALL display a placeholder (empty or dash)
+
+#### Scenario: Living individual
+
+- **WHEN** the individual is marked as living
+- **THEN** the Death date and Death place rows SHALL display "Alive"
+
+### Requirement: Alternative names display
+
+The summary SHALL display all non-primary names as alternative names.
+
+#### Scenario: Multiple alternative names
+
+- **WHEN** an individual has names beyond the primary name
+- **THEN** the Alternative names row SHALL list them comma-separated
+- **THEN** an edit icon SHALL be displayed (non-functional placeholder)
+
+#### Scenario: No alternative names
+
+- **WHEN** an individual has only a primary name
+- **THEN** the Alternative names row SHALL display "None" or be omitted
+
+### Requirement: Place links
+
+Place values in the summary SHALL be displayed as styled links.
+
+#### Scenario: Birth place displayed as link
+
+- **WHEN** an individual has a birth event with a place
+- **THEN** the Birth place value SHALL be displayed as a colored link with the place's full name
+
+### Requirement: Edit button placeholder
+
+The center panel header SHALL include an "Edit" button that is currently disabled or non-functional.
+
+#### Scenario: Edit button visible
+
+- **WHEN** the individual summary is displayed
+- **THEN** an "Edit" button SHALL appear in the header area next to the individual's name
+- **THEN** the button SHALL be non-functional (placeholder for future CRUD)

--- a/openspec/changes/improve-individual-detail-page/tasks.md
+++ b/openspec/changes/improve-individual-detail-page/tasks.md
@@ -8,6 +8,9 @@
 - [ ] 2.1 Create `IndividualsMasterDetail` layout component with CSS Grid three-column layout (`280px 1fr 320px`) and independent scroll regions per panel
 - [ ] 2.2 Update the `/tree/$treeId/individuals` route to use the new master-detail layout with `id` search param for selected individual
 - [ ] 2.3 Add redirect from old `/tree/$treeId/individual/$individualId` route to `/tree/$treeId/individuals?id=$individualId`
+- [ ] 2.4 Add integration test: selecting an individual via `?id=` restores the selection after navigation / back / refresh
+- [ ] 2.5 Add integration test: the old `/tree/$treeId/individual/$individualId` route redirects to `/tree/$treeId/individuals?id=$individualId` while preserving browser history
+- [ ] 2.6 Add integration test: an invalid `?id=` value renders the "not found" empty state without selecting any individual
 
 ## 3. Left Panel — Individual List
 

--- a/openspec/changes/improve-individual-detail-page/tasks.md
+++ b/openspec/changes/improve-individual-detail-page/tasks.md
@@ -1,0 +1,38 @@
+## 1. Data Layer — Relationships Hook
+
+- [ ] 1.1 Create `useIndividualRelationships(individualId)` hook in `src/hooks/` that composes existing DB functions (`getParentFamilies`, `getSpouseFamilies`, `getChildrenInFamily`) to return `{ father, mother, siblings, halfSiblings, spouseFamilies }` as a TanStack Query hook
+- [ ] 1.2 Add tests for `useIndividualRelationships` covering: both parents, siblings, half-siblings, no parent family
+
+## 2. Layout — Three-Panel Structure
+
+- [ ] 2.1 Create `IndividualsMasterDetail` layout component with CSS Grid three-column layout (`280px 1fr 320px`) and independent scroll regions per panel
+- [ ] 2.2 Update the `/tree/$treeId/individuals` route to use the new master-detail layout with `id` search param for selected individual
+- [ ] 2.3 Add redirect from old `/tree/$treeId/individual/$individualId` route to `/tree/$treeId/individuals?id=$individualId`
+
+## 3. Left Panel — Individual List
+
+- [ ] 3.1 Create `IndividualListPanel` component: scrollable list of individuals with name, ID, gender, birth/death years, and living status per row
+- [ ] 3.2 Add search input filtering individuals by name
+- [ ] 3.3 Highlight the currently selected individual in the list
+- [ ] 3.4 On click, update the URL search param to navigate to the selected individual
+
+## 4. Center Panel — Individual Summary
+
+- [ ] 4.1 Create `IndividualSummaryPanel` component with individual name heading and "Edit" button placeholder
+- [ ] 4.2 Build the key-value table rows: ID, Gender, Alternative names, Birth date, Birth place, Death date, Death place
+- [ ] 4.3 Add Father, Mother, Siblings, Half-siblings rows using data from `useIndividualRelationships`, with clickable links to navigate to related individuals
+- [ ] 4.4 Display places as styled accent-colored links
+
+## 5. Right Panel — Sidebar
+
+- [ ] 5.1 Create `IndividualSidebar` component with collapsible sections: Parents, Families, Events
+- [ ] 5.2 Build Parents section: parent cards (name, ID, dates, gender, status) + sibling cards + "Add Brother"/"Add Sister" placeholder buttons
+- [ ] 5.3 Build Families section: spouse families with spouse and children as clickable links
+- [ ] 5.4 Build Events section: reuse `EventTimeline` component + "Add" placeholder button
+- [ ] 5.5 Handle empty states for each sidebar section
+
+## 6. Cleanup & Polish
+
+- [ ] 6.1 Remove or deprecate the old `IndividualViewPage` component
+- [ ] 6.2 Ensure all clickable individual/place links navigate correctly within the master-detail layout
+- [ ] 6.3 Verify empty state when no individual is selected (center + right panels)

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
## Summary
- Add OpenSpec commands (`/opsx:{propose,explore,apply,archive}`), skills, and `openspec/config.yaml` for the experimental change-proposal workflow.
- Seed `openspec/changes/` with two in-progress proposals: `add-pedigree-chart` and `improve-individual-detail-page`.

## Test plan
- [ ] Confirm `/opsx:propose` and siblings are discoverable as slash commands.
- [ ] Confirm `openspec/changes/*` proposals render correctly and don't affect app build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)