### PR TITLE
chore(tauri): rename binary to Vata

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,6 +12,10 @@ edition = "2021"
 name = "vata_app_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[[bin]]
+name = "Vata"
+path = "src/main.rs"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 


### PR DESCRIPTION
## Summary
- Add explicit `[[bin]] name = "Vata"` in `src-tauri/Cargo.toml` so the macOS dock/process label shows **Vata** instead of `vata-app` during `tauri dev`.
- `productName` in `tauri.conf.json` was already "Vata" — only the binary name was lagging.

## Test plan
- [ ] Run `pnpm tauri:dev` and confirm the dock label reads "Vata".
- [ ] Verify `cargo check` / `pnpm build` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)