### PR TITLE
feat: GitHub Issues backlog with templates, project, and capture/link skills

### DIFF
--- a/.claude/skills/capture-idea/SKILL.md
+++ b/.claude/skills/capture-idea/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: capture-idea
+description: Capture a product idea or insight as a GitHub issue. Use when the user signals an idea should be saved for later rather than acted on now — phrases like "faire plus tard", "à faire plus tard", "note pour plus tard", "ne pas oublier", "garder pour plus tard", "to do later", "remember this for later", "save this for later", "save this as an insight", "add this to the backlog", or any other phrasing indicating a non-actionable idea worth recording. Reads existing repo labels via `gh label list` and applies 0–2 that match.
+---
+
+# Capture Idea
+
+Files a product idea as a GitHub issue in the repo of the current working directory. Backed by the `gh` CLI — no MCP, no API key, no setup beyond `gh auth login` (already done if `gh` works).
+
+## When to activate
+
+Activate as soon as the user expresses one of these intents in either French or English:
+
+- "faire plus tard", "à faire plus tard", "note pour plus tard", "garder pour plus tard", "ne pas oublier"
+- "to do later", "remember this for later", "save this for later"
+- "save this as an insight", "add this to the backlog", "capture this idea"
+- Any equivalent phrasing where the user is parking an idea, not asking for immediate work
+
+If the user is asking for the work to be done **now**, this skill does not apply — proceed with the task instead.
+
+## Capture flow
+
+Follow these steps in order. Do **not** ask the user for confirmation before creating — the trigger phrase is itself the explicit signal.
+
+### 1. Compose the issue
+
+From the recent conversation context, build:
+
+- **Title** — concise, ≤80 chars, imperative form, English (project rule). Example: _"Detect duplicate individuals on GEDCOM import"_.
+- **Body** — optional. Include only if it adds context beyond the title (motivating example, constraint, related file path). Skip it if the title alone is self-explanatory. Markdown is supported.
+
+Translate the user's idea to English even if they expressed it in French (project rule: all artifacts are English-only; only conversation with the user is in French).
+
+### 2. Fetch existing labels
+
+```bash
+gh label list --json name,description,color --limit 100
+```
+
+Don't pass `--repo` — `gh` infers it from the current working directory's git remote. This keeps the skill portable across repos.
+
+### 3. Pick labels
+
+Select **0 to 2** labels whose name or description clearly matches the idea. Examples:
+
+- Idea about GEDCOM import → `gedcom`
+- Idea about UI copy or layout → `ui` or `area:ui`
+- Idea about query/migration/schema → `db`
+- Idea about Rust shell or Tauri permissions → `tauri`
+
+If nothing fits cleanly, **pass no labels**. Do not invent or stretch a match. Steve can label later in GitHub.
+
+Do not create new labels from this skill.
+
+### 4. Create the issue
+
+```bash
+gh issue create \
+  --title "<title>" \
+  --body "<body>" \
+  --label "<label1>" \
+  --label "<label2>"
+```
+
+Omit `--body` if there's no body. Omit each `--label` flag whose label wasn't picked. Pipe the body via a heredoc if it spans multiple lines so escaping doesn't bite.
+
+### 5. Report back
+
+Reply to the user with one short sentence in the same language they used. Include the issue number, the URL, and which labels were applied (or "no labels"). Example:
+
+> Captured as **#42** (label: `gedcom`) — https://github.com/vata-apps/vata-app/issues/42
+
+That's it. Do not summarize the idea back to the user; they just told you what it was.
+
+## Failure handling
+
+- **`gh` not authenticated**: tell the user to run `gh auth login`. Do not fall back to a manual API call.
+- **Not in a git repo**: surface the `gh` error verbatim — this skill assumes the cwd is a repo with a GitHub remote.
+- **`gh issue create` returns non-zero**: surface the error message.
+
+## What this skill must not do
+
+- Ask for a confirmation before creating
+- Force a label when no existing label fits
+- Create new labels
+- Hardcode the repo — always rely on `gh` inferring from cwd
+- Modify or close existing issues — capture only

--- a/.claude/skills/capture-idea/SKILL.md
+++ b/.claude/skills/capture-idea/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: capture-idea
-description: Capture a product idea or insight as a GitHub issue. Use when the user signals an idea should be saved for later rather than acted on now — phrases like "faire plus tard", "à faire plus tard", "note pour plus tard", "ne pas oublier", "garder pour plus tard", "to do later", "remember this for later", "save this for later", "save this as an insight", "add this to the backlog", or any other phrasing indicating a non-actionable idea worth recording. Reads existing repo labels via `gh label list` and applies 0–2 that match.
+description: Capture a product idea, bug, or task as a GitHub issue. Use when the user signals something should be saved for later rather than acted on now — phrases like "faire plus tard", "à faire plus tard", "note pour plus tard", "ne pas oublier", "garder pour plus tard", "to do later", "remember this for later", "save this for later", "save this as an insight", "add this to the backlog", or any other phrasing indicating a non-actionable item worth recording. Reads existing repo labels via `gh label list` and applies 0–2 that match. Sets the org-level Issue Type (Task/Bug/Feature) via GraphQL after creation, defaulting to Feature for ideas.
 ---
 
 # Capture Idea
 
-Files a product idea as a GitHub issue in the repo of the current working directory. Backed by the `gh` CLI — no MCP, no API key, no setup beyond `gh auth login` (already done if `gh` works).
+Files an item as a GitHub issue in the repo of the current working directory, then sets the org-level Issue Type via GraphQL so the issue is consistent with web-UI submissions. Backed by the `gh` CLI — no MCP, no API key, no setup beyond `gh auth login` plus `read:org` scope.
 
 ## When to activate
 
@@ -14,7 +14,7 @@ Activate as soon as the user expresses one of these intents in either French or 
 - "faire plus tard", "à faire plus tard", "note pour plus tard", "garder pour plus tard", "ne pas oublier"
 - "to do later", "remember this for later", "save this for later"
 - "save this as an insight", "add this to the backlog", "capture this idea"
-- Any equivalent phrasing where the user is parking an idea, not asking for immediate work
+- Any equivalent phrasing where the user is parking an item, not asking for immediate work
 
 If the user is asking for the work to be done **now**, this skill does not apply — proceed with the task instead.
 
@@ -29,9 +29,19 @@ From the recent conversation context, build:
 - **Title** — concise, ≤80 chars, imperative form, English (project rule). Example: _"Detect duplicate individuals on GEDCOM import"_.
 - **Body** — optional. Include only if it adds context beyond the title (motivating example, constraint, related file path). Skip it if the title alone is self-explanatory. Markdown is supported.
 
-Translate the user's idea to English even if they expressed it in French (project rule: all artifacts are English-only; only conversation with the user is in French).
+Translate the user's content to English even if they expressed it in French (project rule: all artifacts are English-only; only conversation with the user is in French).
 
-### 2. Fetch existing labels
+### 2. Decide the Issue Type
+
+Pick one of the org's three types:
+
+- **Feature** (default for ideas/insights) — a new capability, improvement, or open-ended idea
+- **Bug** — only if the captured item explicitly describes a defect ("X is broken", "Y crashes", "Z gives wrong result")
+- **Task** — only if the user's wording is operational and concrete ("rename X", "bump Y dep", "extract Z helper")
+
+When in doubt, choose **Feature**. The user can reclassify in the GitHub UI if needed.
+
+### 3. Fetch existing labels
 
 ```bash
 gh label list --json name,description,color --limit 100
@@ -39,20 +49,19 @@ gh label list --json name,description,color --limit 100
 
 Don't pass `--repo` — `gh` infers it from the current working directory's git remote. This keeps the skill portable across repos.
 
-### 3. Pick labels
+### 4. Pick labels
 
-Select **0 to 2** labels whose name or description clearly matches the idea. Examples:
+Select **0 to 2** labels whose name or description clearly matches the item. Examples (current Vata taxonomy):
 
-- Idea about GEDCOM import → `gedcom`
-- Idea about UI copy or layout → `ui` or `area:ui`
-- Idea about query/migration/schema → `db`
-- Idea about Rust shell or Tauri permissions → `tauri`
+- GEDCOM import/export → `gedcom`
+- UI copy or layout → `ui`
+- Query / migration / schema → `db`
+- Rust shell or Tauri permissions → `tauri`
+- Documentation → `docs`
 
-If nothing fits cleanly, **pass no labels**. Do not invent or stretch a match. Steve can label later in GitHub.
+If nothing fits cleanly, **pass no labels**. Do not invent or stretch a match. Do not create new labels from this skill.
 
-Do not create new labels from this skill.
-
-### 4. Create the issue
+### 5. Create the issue
 
 ```bash
 gh issue create \
@@ -62,26 +71,64 @@ gh issue create \
   --label "<label2>"
 ```
 
-Omit `--body` if there's no body. Omit each `--label` flag whose label wasn't picked. Pipe the body via a heredoc if it spans multiple lines so escaping doesn't bite.
+Omit `--body` if there's no body. Omit each `--label` flag whose label wasn't picked. Use a heredoc for multi-line bodies so escaping doesn't bite.
 
-### 5. Report back
+Capture the issue URL printed by `gh`. Parse the issue number from it.
 
-Reply to the user with one short sentence in the same language they used. Include the issue number, the URL, and which labels were applied (or "no labels"). Example:
+### 6. Set the Issue Type via GraphQL
 
-> Captured as **#42** (label: `gedcom`) — https://github.com/vata-apps/vata-app/issues/42
+`gh issue create` does not support setting the org-level Issue Type. Apply it after creation:
+
+```bash
+# Resolve the type ID (cache in a shell var per session if you create multiple issues)
+TYPE_ID=$(gh api graphql -f query='
+  query {
+    organization(login: "vata-apps") {
+      issueTypes(first: 25) { nodes { id name } }
+    }
+  }
+' --jq ".data.organization.issueTypes.nodes[] | select(.name == \"<TYPE>\") | .id")
+
+# Get the new issue's node ID
+ISSUE_NODE_ID=$(gh api "repos/vata-apps/vata-app/issues/<NUMBER>" --jq .node_id)
+
+# Apply the type
+gh api graphql -f query='
+  mutation($issueId: ID!, $typeId: ID!) {
+    updateIssueIssueType(input: { issueId: $issueId, issueTypeId: $typeId }) {
+      issue { id }
+    }
+  }
+' -f issueId="$ISSUE_NODE_ID" -f typeId="$TYPE_ID" >/dev/null
+```
+
+Substitute `<TYPE>` with `Feature`, `Bug`, or `Task` from step 2. Substitute `<NUMBER>` with the parsed issue number.
+
+If the GraphQL mutation fails with an auth error, surface it and tell the user to run `gh auth refresh -s read:org`.
+
+The owner/repo (`vata-apps/vata-app`) can be hardcoded for this project; it's not portable, and that's fine — this skill lives in the Vata repo.
+
+### 7. Report back
+
+Reply to the user with one short sentence in the same language they used. Include the issue number, the URL, the type, and any labels. Example:
+
+> Captured as **#42** (Feature, label: `gedcom`) — https://github.com/vata-apps/vata-app/issues/42
 
 That's it. Do not summarize the idea back to the user; they just told you what it was.
 
 ## Failure handling
 
-- **`gh` not authenticated**: tell the user to run `gh auth login`. Do not fall back to a manual API call.
-- **Not in a git repo**: surface the `gh` error verbatim — this skill assumes the cwd is a repo with a GitHub remote.
-- **`gh issue create` returns non-zero**: surface the error message.
+- **`gh` not authenticated**: tell the user to run `gh auth login`.
+- **Missing `read:org` scope** (GraphQL step fails with auth error): tell the user to run `gh auth refresh -s read:org`.
+- **`gh issue create` returns non-zero**: surface the error verbatim.
+- **GraphQL `updateIssueIssueType` fails after issue creation**: the issue exists but lacks a type. Tell the user the issue number/URL and that the type must be set manually in the GitHub UI; do not delete the issue.
+- **Not in a git repo**: surface `gh`'s error.
 
 ## What this skill must not do
 
-- Ask for a confirmation before creating
+- Ask for confirmation before creating
 - Force a label when no existing label fits
 - Create new labels
-- Hardcode the repo — always rely on `gh` inferring from cwd
+- Pick more than one Issue Type (each issue gets exactly one)
 - Modify or close existing issues — capture only
+- Skip step 6 — the type must be set for consistency with web-UI issues

--- a/.claude/skills/capture-idea/SKILL.md
+++ b/.claude/skills/capture-idea/SKILL.md
@@ -77,32 +77,31 @@ Capture the issue URL printed by `gh`. Parse the issue number from it.
 
 ### 6. Set the Issue Type via GraphQL
 
-`gh issue create` does not support setting the org-level Issue Type. Apply it after creation:
+`gh issue create` does not support setting the org-level Issue Type. Apply it after creation. Type IDs are stable for the `vata-apps` org and hardcoded here to save a round-trip:
+
+| Type    | ID                    |
+| ------- | --------------------- |
+| Task    | `IT_kwDODVrl8M4BrCV1` |
+| Bug     | `IT_kwDODVrl8M4BrCV2` |
+| Feature | `IT_kwDODVrl8M4BrCV3` |
 
 ```bash
-# Resolve the type ID
-TYPE_ID=$(gh api graphql -f query='
-  query {
-    organization(login: "vata-apps") {
-      issueTypes(first: 25) { nodes { id name } }
-    }
-  }
-' --jq ".data.organization.issueTypes.nodes[] | select(.name == \"<TYPE>\") | .id")
-
 # Get the new issue's node ID
 ISSUE_NODE_ID=$(gh api "repos/vata-apps/vata-app/issues/<NUMBER>" --jq .node_id)
 
-# Apply the type
+# Apply the type (substitute the right ID from the table above based on step 2)
 gh api graphql -f query='
   mutation($issueId: ID!, $typeId: ID!) {
     updateIssueIssueType(input: { issueId: $issueId, issueTypeId: $typeId }) {
       issue { id }
     }
   }
-' -f issueId="$ISSUE_NODE_ID" -f typeId="$TYPE_ID" >/dev/null
+' -f issueId="$ISSUE_NODE_ID" -f typeId="<TYPE_ID>" >/dev/null
 ```
 
-Substitute `<TYPE>` with `Feature`, `Bug`, or `Task` from step 2. Substitute `<NUMBER>` with the parsed issue number.
+Substitute `<NUMBER>` with the parsed issue number and `<TYPE_ID>` with the value from the table for the type chosen in step 2.
+
+If the type IDs ever change (Steve renamed/recreated a type at the org level), the mutation will return a Not-Found error. In that case, re-resolve via `gh api graphql -f query='{ organization(login:"vata-apps") { issueTypes(first:25) { nodes { id name } } } }'` and update this skill.
 
 ### 7. Add to the Project and set Status to Icebox
 

--- a/.claude/skills/capture-idea/SKILL.md
+++ b/.claude/skills/capture-idea/SKILL.md
@@ -80,7 +80,7 @@ Capture the issue URL printed by `gh`. Parse the issue number from it.
 `gh issue create` does not support setting the org-level Issue Type. Apply it after creation:
 
 ```bash
-# Resolve the type ID (cache in a shell var per session if you create multiple issues)
+# Resolve the type ID
 TYPE_ID=$(gh api graphql -f query='
   query {
     organization(login: "vata-apps") {
@@ -104,24 +104,63 @@ gh api graphql -f query='
 
 Substitute `<TYPE>` with `Feature`, `Bug`, or `Task` from step 2. Substitute `<NUMBER>` with the parsed issue number.
 
-If the GraphQL mutation fails with an auth error, surface it and tell the user to run `gh auth refresh -s read:org`.
+### 7. Add to the Project and set Status to Icebox
 
-The owner/repo (`vata-apps/vata-app`) can be hardcoded for this project; it's not portable, and that's fine — this skill lives in the Vata repo.
+Captured ideas go to the **Icebox** column of the Vata Roadmap project — they're parked, not queued. The web-UI auto-add workflow will already place new issues in `Todo`; we override to `Icebox` explicitly so capture-idea outputs are clearly distinguishable.
 
-### 7. Report back
+Hardcoded IDs (stable for this project):
+
+| Variable           | Value                            |
+| ------------------ | -------------------------------- |
+| `PROJECT_ID`       | `PVT_kwDODVrl8M4BWWni`           |
+| `STATUS_FIELD_ID`  | `PVTSSF_lADODVrl8M4BWWnizhRrpbs` |
+| `ICEBOX_OPTION_ID` | `cdad492c`                       |
+
+```bash
+# Add to project (idempotent — if auto-add already fired, returns the existing item)
+ITEM_ID=$(gh api graphql -f query='
+  mutation($projectId: ID!, $contentId: ID!) {
+    addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+      item { id }
+    }
+  }
+' -f projectId="PVT_kwDODVrl8M4BWWni" \
+  -f contentId="$ISSUE_NODE_ID" \
+  --jq '.data.addProjectV2ItemById.item.id')
+
+# Set Status to Icebox
+gh api graphql -f query='
+  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
+      value: { singleSelectOptionId: $optionId }
+    }) { projectV2Item { id } }
+  }
+' -f projectId="PVT_kwDODVrl8M4BWWni" \
+  -f itemId="$ITEM_ID" \
+  -f fieldId="PVTSSF_lADODVrl8M4BWWnizhRrpbs" \
+  -f optionId="cdad492c" >/dev/null
+```
+
+If any GraphQL call fails with an auth error, surface it and tell the user to run `gh auth refresh -s read:org,project`.
+
+The owner/repo (`vata-apps/vata-app`) and the IDs above are hardcoded for this project; that's fine — this skill lives in the Vata repo.
+
+### 8. Report back
 
 Reply to the user with one short sentence in the same language they used. Include the issue number, the URL, the type, and any labels. Example:
 
-> Captured as **#42** (Feature, label: `gedcom`) — https://github.com/vata-apps/vata-app/issues/42
+> Captured in Icebox as **#42** (Feature, label: `gedcom`) — https://github.com/vata-apps/vata-app/issues/42
 
-That's it. Do not summarize the idea back to the user; they just told you what it was.
+Mentioning "Icebox" reinforces that the item is parked, not queued. Do not summarize the idea back to the user; they just told you what it was.
 
 ## Failure handling
 
 - **`gh` not authenticated**: tell the user to run `gh auth login`.
-- **Missing `read:org` scope** (GraphQL step fails with auth error): tell the user to run `gh auth refresh -s read:org`.
+- **Missing `read:org` or `project` scope** (GraphQL step fails with auth error): tell the user to run `gh auth refresh -s read:org,project`.
 - **`gh issue create` returns non-zero**: surface the error verbatim.
 - **GraphQL `updateIssueIssueType` fails after issue creation**: the issue exists but lacks a type. Tell the user the issue number/URL and that the type must be set manually in the GitHub UI; do not delete the issue.
+- **GraphQL `addProjectV2ItemById` or `updateProjectV2ItemFieldValue` fails**: the issue exists (and probably has its type set) but isn't in the project or isn't at Icebox. Surface the error and the issue URL — the user can drag it into Icebox manually. Do not delete the issue.
 - **Not in a git repo**: surface `gh`'s error.
 
 ## What this skill must not do
@@ -132,3 +171,4 @@ That's it. Do not summarize the idea back to the user; they just told you what i
 - Pick more than one Issue Type (each issue gets exactly one)
 - Modify or close existing issues — capture only
 - Skip step 6 — the type must be set for consistency with web-UI issues
+- Skip step 7 — captured ideas must land in Icebox, not Todo, to preserve the "parked vs queued" distinction

--- a/.claude/skills/link-task/SKILL.md
+++ b/.claude/skills/link-task/SKILL.md
@@ -124,4 +124,3 @@ Don't ask the user to confirm the magic word — Phase A was the explicit-consen
 - Amend or rewrite existing commit messages
 - Create an issue itself — delegate to `capture-idea` if the user wants a new one
 - Change the issue's state from this skill — let the `Closes` magic word handle it at merge time
-- Hardcode the repo — always rely on `gh` inferring from cwd

--- a/.claude/skills/link-task/SKILL.md
+++ b/.claude/skills/link-task/SKILL.md
@@ -29,16 +29,16 @@ For each query, run:
 
 ```bash
 gh issue list --search "<query> in:title,body" --state open --limit 10 \
-  --json number,title,state,labels,updatedAt
+  --json number,title,state,labels,issueType,updatedAt
 ```
 
-Don't pass `--repo` — `gh` infers it from the cwd's git remote.
+Don't pass `--repo` — `gh` infers it from the cwd's git remote. The `issueType` field returns the org-level type (`{ name: "Bug" }`, etc.) when set, otherwise an empty value.
 
 Stop once you have 5–10 candidate issues across all queries — don't enumerate the entire backlog.
 
 ### 3. Present candidates
 
-If 1+ candidates found: show up to 5, sorted by `updatedAt` desc, with `#<number> · <state> · <title>` (and labels in parens if any). Ask the user **one** of:
+If 1+ candidates found: show up to 5, sorted by `updatedAt` desc, with `#<number> · <type> · <state> · <title>` (use `—` for the type column when `issueType` is empty; include labels in parens if any). Ask the user **one** of:
 
 > "Which issue is this work for? **#12**, **#34**, **none of these (create new)**, or **no link**?"
 

--- a/.claude/skills/link-task/SKILL.md
+++ b/.claude/skills/link-task/SKILL.md
@@ -25,16 +25,30 @@ From the user's task description, build 1–3 short search queries. Examples:
 
 ### 2. Search GitHub Issues
 
-For each query, run:
+`gh issue list --json ...` does **not** expose `issueType` in the current CLI version. Use a GraphQL search instead so the type column is populated:
 
 ```bash
-gh issue list --search "<query> in:title,body" --state open --limit 10 \
-  --json number,title,state,labels,issueType,updatedAt
+gh api graphql -f query='
+  query($q: String!) {
+    search(query: $q, type: ISSUE, first: 10) {
+      nodes {
+        ... on Issue {
+          number
+          title
+          state
+          issueType { name }
+          labels(first: 5) { nodes { name } }
+          updatedAt
+        }
+      }
+    }
+  }
+' -f q="repo:vata-apps/vata-app <query> in:title,body is:issue is:open"
 ```
 
-Don't pass `--repo` — `gh` infers it from the cwd's git remote. The `issueType` field returns the org-level type (`{ name: "Bug" }`, etc.) when set, otherwise an empty value.
+Substitute `<query>` with each search term. Stop once you have 5–10 candidates across all queries — don't enumerate the entire backlog. Repo (`vata-apps/vata-app`) is hardcoded for this project; that's fine because this skill lives in the Vata repo.
 
-Stop once you have 5–10 candidate issues across all queries — don't enumerate the entire backlog.
+If the GraphQL call fails with an auth error, surface it and tell the user to run `gh auth refresh -s read:org`.
 
 ### 3. Present candidates
 

--- a/.claude/skills/link-task/SKILL.md
+++ b/.claude/skills/link-task/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: link-task
+description: Search GitHub for an existing issue matching the current dev task and link it so the resulting PR auto-closes it at merge. Use at the START of a new development task — typically right after the user answers "simple branch or worktree?" and before any code changes begin (triggers like "let's implement X", "on travaille sur Y", "add a feature for Z", "fix bug W", "commençons sur X"). Also use just before creating a PR to inject the magic word `Closes #N` into the description.
+---
+
+# Link Task
+
+Bridges a Vata development task with a GitHub issue so the PR auto-closes the right issue at merge. Backed by the `gh` CLI — no MCP, no API key.
+
+There are two phases. Run **Phase A** when starting a task. Run **Phase B** when creating a PR. They share state via `git config branch.<branch>.ghIssue`.
+
+---
+
+## Phase A — Find and link an issue (task start)
+
+Run this immediately after the worktree/branch is decided and named, **before** any code changes.
+
+### 1. Compose search queries
+
+From the user's task description, build 1–3 short search queries. Examples:
+
+- _"add a CSV export of the individuals list"_ → queries: `csv export`, `export individuals`
+- _"fix duplicate import bug"_ → queries: `duplicate import`, `gedcom duplicates`
+- _"refactor the places query"_ → queries: `places query`, `place performance`
+
+### 2. Search GitHub Issues
+
+For each query, run:
+
+```bash
+gh issue list --search "<query> in:title,body" --state open --limit 10 \
+  --json number,title,state,labels,updatedAt
+```
+
+Don't pass `--repo` — `gh` infers it from the cwd's git remote.
+
+Stop once you have 5–10 candidate issues across all queries — don't enumerate the entire backlog.
+
+### 3. Present candidates
+
+If 1+ candidates found: show up to 5, sorted by `updatedAt` desc, with `#<number> · <state> · <title>` (and labels in parens if any). Ask the user **one** of:
+
+> "Which issue is this work for? **#12**, **#34**, **none of these (create new)**, or **no link**?"
+
+Keep the message short. Don't paraphrase or comment.
+
+If 0 candidates found: ask once:
+
+> "No matching open issue found. Want me to create a new one (delegates to `capture-idea`), or skip the link for this task?"
+
+### 4. Persist the link
+
+Once the user picks an issue (or you create one via `capture-idea`):
+
+```bash
+git config branch."$(git branch --show-current)".ghIssue <number>
+```
+
+If the user picks "no link", do nothing — silent skip. Don't ask again later in the same session.
+
+### 5. Confirm
+
+Tell the user in one sentence which issue is linked, e.g. _"Linked to #42 — will auto-close at PR merge."_ Then proceed to the actual task.
+
+---
+
+## Phase B — Inject the magic word (PR creation)
+
+Run this whenever you're about to call `gh pr create` (directly, via `/commit-push-pr`, or any other path).
+
+### 1. Read the link
+
+```bash
+git config branch."$(git branch --show-current)".ghIssue 2>/dev/null
+```
+
+If the value is empty, no link exists for this branch. **Do not search GitHub at PR time** — Phase A is the only entry point for that. Just create the PR without a magic word.
+
+### 2. Inject the magic word
+
+If the value is `<N>`, ensure the PR description body ends with a footer line:
+
+```
+Closes #N
+```
+
+Use `Closes` as the default — it auto-closes the issue at merge. Use `Refs #N` instead only if the user explicitly says "this only partially addresses the issue" or "don't close it yet".
+
+If the PR description was authored by another skill (e.g., `commit-push-pr`), append the footer; don't rewrite the rest.
+
+### 3. No prompt
+
+Don't ask the user to confirm the magic word — Phase A was the explicit-consent step.
+
+---
+
+## Edge cases
+
+- **Branch already has commits before Phase A runs.** Still proceed — the ID lives in git config, not in commit messages, so existing commits don't need rewriting.
+- **User changes the linked issue mid-task.** Re-run Phase A — `git config` overwrites cleanly.
+- **Worktree on a detached HEAD.** Skip silently — `git branch --show-current` returns empty.
+- **`gh` not authenticated.** Tell the user once to run `gh auth login`, then skip Phase A. Phase B becomes a no-op.
+- **No open issues at all in the repo.** Phase A still runs — the agent jumps to "no candidates" and offers to create.
+
+## What this skill must not do
+
+- Auto-pick an issue without user confirmation (Phase A always asks)
+- Search GitHub at PR time (Phase A is the only search entry point)
+- Modify branch names to include the issue number — that's a separate stylistic choice the user hasn't requested
+- Amend or rewrite existing commit messages
+- Create an issue itself — delegate to `capture-idea` if the user wants a new one
+- Change the issue's state from this skill — let the `Closes` magic word handle it at merge time
+- Hardcode the repo — always rely on `gh` inferring from cwd

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,4 +1,4 @@
-name: 🐞 Bug report
+name: Bug report
 description: An unexpected problem or behavior
 type: bug
 labels: []
@@ -31,6 +31,8 @@ body:
       placeholder: |
         Expected: ...
         Actual: ...
+    validations:
+      required: true
   - type: textarea
     id: env
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,43 @@
+name: 🐞 Bug report
+description: An unexpected problem or behavior
+type: bug
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Fill in what you can — only fields marked required must be answered.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What's wrong?
+      placeholder: One or two sentences describing the bug
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+      placeholder: |
+        Expected: ...
+        Actual: ...
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      placeholder: OS / Vata version / data sample size / GEDCOM source
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      placeholder: Logs, screenshots, related issues

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,1 @@
 blank_issues_enabled: false
-contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,4 +1,4 @@
-name: 💡 Idea / feature request
+name: Idea / feature request
 description: A new capability, improvement, or insight to explore later
 type: feature
 labels: []
@@ -11,16 +11,16 @@ body:
     id: idea
     attributes:
       label: The idea
-      placeholder: What should Vata do (or stop doing)?
+      description: What should Vata do (or stop doing)?
     validations:
       required: true
   - type: textarea
     id: why
     attributes:
       label: Why does this matter?
-      placeholder: Use case, pain point, or constraint motivating the idea
+      description: Use case, pain point, or constraint motivating the idea
   - type: textarea
     id: sketch
     attributes:
       label: Sketch / examples (optional)
-      placeholder: UI mockup, sample data, related code paths
+      description: UI mockup, sample data, related code paths

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,26 @@
+name: 💡 Idea / feature request
+description: A new capability, improvement, or insight to explore later
+type: feature
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Capture the idea — analysis can wait until prioritization.
+  - type: textarea
+    id: idea
+    attributes:
+      label: The idea
+      placeholder: What should Vata do (or stop doing)?
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why does this matter?
+      placeholder: Use case, pain point, or constraint motivating the idea
+  - type: textarea
+    id: sketch
+    attributes:
+      label: Sketch / examples (optional)
+      placeholder: UI mockup, sample data, related code paths

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,27 @@
+name: 🛠 Task
+description: A specific piece of dev work with a clear deliverable
+type: task
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when scope is already concrete (refactor, dep bump, internal cleanup).
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      placeholder: What needs to be done, in one or two sentences
+    validations:
+      required: true
+  - type: textarea
+    id: criteria
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+  - type: textarea
+    id: notes
+    attributes:
+      label: Implementation notes (optional)

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -22,6 +22,8 @@ body:
       placeholder: |
         - [ ] ...
         - [ ] ...
+    validations:
+      required: true
   - type: textarea
     id: notes
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,4 +1,4 @@
-name: 🛠 Task
+name: Task
 description: A specific piece of dev work with a clear deliverable
 type: task
 labels: []
@@ -11,13 +11,14 @@ body:
     id: goal
     attributes:
       label: Goal
-      placeholder: What needs to be done, in one or two sentences
+      description: What needs to be done, in one or two sentences
     validations:
       required: true
   - type: textarea
     id: criteria
     attributes:
       label: Acceptance criteria
+      description: Use a markdown task list, e.g. `- [ ] step one`
       placeholder: |
         - [ ] ...
         - [ ] ...
@@ -25,3 +26,4 @@ body:
     id: notes
     attributes:
       label: Implementation notes (optional)
+      description: Constraints, related code paths, prior art

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ Desktop application for managing genealogical trees. Local-first, GEDCOM 5.5.1 c
 
 ## Dev Tools
 
-- [Issue Tracking](./dev-tools/issue-tracking.md) — Skills wrapping the `gh` CLI for capturing ideas (`capture-idea`) and linking dev tasks to issues with PR auto-close (`link-task`)
+- [Issue Tracking](./dev-tools/issue-tracking.md) — Org-level Issue Types, YAML templates, the Vata Roadmap Project, and the `capture-idea` / `link-task` skills
 
 ## GEDCOM logic (in-app)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,10 @@ Desktop application for managing genealogical trees. Local-first, GEDCOM 5.5.1 c
 - [GEDCOM 5.5.1 Mapping](./references/gedcom-551-mapping.md) — GEDCOM tag to Vata model correspondences
 - [Date Formats](./references/date-formats.md) — Supported genealogical date formats
 
+## Dev Tools
+
+- [Issue Tracking](./dev-tools/issue-tracking.md) — Skills wrapping the `gh` CLI for capturing ideas (`capture-idea`) and linking dev tasks to issues with PR auto-close (`link-task`)
+
 ## GEDCOM logic (in-app)
 
 GEDCOM parsing and genealogical date handling are implemented as in-app modules (see [ADR-004](./decisions/adr-004-gedcom-libraries.md)): `src/gedcom-date/` and `src/gedcom-parser/`, consumed via `@vata-apps/gedcom-date` and `@vata-apps/gedcom-parser`. They are structured for possible future extraction as separate packages.

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -64,25 +64,66 @@ Org-level: **Vata Roadmap** at `https://github.com/orgs/vata-apps/projects/<num>
 | ------------ | ------------- | ------------------------------------------------------ |
 | **Title**    | (built-in)    | Issue title                                            |
 | **Type**     | (built-in)    | Maps to org Issue Type (Task / Bug / Feature)          |
-| **Status**   | (built-in)    | Default 3-stage pipeline: Todo → In Progress → Done    |
+| **Status**   | (built-in)    | 4-stage pipeline: Icebox → Todo → In Progress → Done   |
 | **Priority** | single-select | P0 (drop everything) / P1 (this cycle) / P2 (whenever) |
+
+The Status pipeline separates two horizons:
+
+- **Icebox** — vague ideas captured for "maybe someday". Not committed to. `capture-idea` lands here.
+- **Todo** — queued work for the near future. Web-UI submissions via templates land here.
+- **In Progress** — actively being worked on.
+- **Done** — closed or merged.
+
+The transition from `Icebox` → `Todo` is the explicit promotion moment ("yes, I'm going to do this").
 
 ### Auto-add
 
-A workflow on the Project adds every new issue from `vata-apps/vata-app` automatically. New items land with **Status: Todo**.
+A workflow on the Project adds every new issue from `vata-apps/vata-app` automatically. New items land with **Status: Todo** by default. The `capture-idea` skill explicitly overrides the Status to **Icebox** after creation, so skill-captured ideas are clearly distinguishable from deliberate web-UI submissions.
 
 ### Auto-status (built-in workflows)
 
-- Item added to project → Status = **Todo**
+- Item added to project → Status = **Todo** (overridden to **Icebox** by `capture-idea`)
 - Pull request opened on a linked issue → Status = **In Progress**
 - Pull request merged → Status = **Done**
 - Issue closed → Status = **Done**
 
 ### Recommended views
 
-- **Board**: grouped by Status (kanban — current work)
-- **Table**: grouped by Type (everything by category)
-- **Roadmap**: only useful once dates / iterations are in use
+Four views cover the day-to-day. Configure in the Project UI; saved filter syntax shown.
+
+#### View 1 — **Now** (board, default)
+
+Active work. Hides Icebox and Done so only what's queued or in flight shows up.
+
+- **Layout**: Board, grouped by Status
+- **Filter**: `is:open -status:Icebox -status:Done`
+- **Sort**: Priority asc, then updated desc
+
+#### View 2 — **Icebox** (table)
+
+Triage ideas. Open weekly to promote or prune.
+
+- **Layout**: Table, grouped by Type
+- **Filter**: `is:open status:Icebox`
+- **Sort**: updated desc
+- **Visible columns**: Title, Type, Labels, Priority, updated
+
+#### View 3 — **Bugs** (board)
+
+Bug-only board, full pipeline visible (including unreviewed bug reports in Icebox).
+
+- **Layout**: Board, grouped by Status
+- **Filter**: `is:open type:Bug`
+- **Sort**: Priority asc, then updated desc
+
+#### View 4 — **Backlog by Priority** (table)
+
+When you ask "what's truly the most important thing right now?".
+
+- **Layout**: Table, grouped by Priority
+- **Filter**: `is:open -status:Icebox -status:Done`
+- **Sort**: updated desc
+- **Visible columns**: Title, Type, Status, Labels
 
 ## Skills
 
@@ -97,7 +138,7 @@ Activates on phrases like:
 - "to do later", "remember this for later", "save this for later"
 - "save this as an insight", "add this to the backlog"
 
-The agent composes a concise English title (and optional body), reads the repo's existing labels, picks 0–2 that match, creates the issue with `gh issue create`, then sets the org-level Issue Type (Feature by default; Bug or Task if context suggests) via the `updateIssueIssueType` GraphQL mutation. Replies with the issue number, type, labels, and URL.
+The agent composes a concise English title (and optional body), reads the repo's existing labels, picks 0–2 that match, creates the issue with `gh issue create`, then via GraphQL sets the org-level Issue Type (Feature by default; Bug or Task if context suggests) and pins the Project Status to **Icebox**. Replies with the issue number, type, labels, "Icebox", and URL.
 
 ### `link-task`
 
@@ -128,21 +169,26 @@ For first-time setup or when wiring a new dev environment:
 
    It reconciles labels (drops obsolete ones, adds missing), creates the **Vata Roadmap** Project if missing, and adds the custom **Priority** field. The built-in **Status** field already provides the Todo / In Progress / Done pipeline. Idempotent.
 
-3. **Configure the Auto-add workflow** in the Project UI (one-time, not scriptable):
+3. **Add `Icebox` to Status** (Project UI):
+   - Project → ⚙ **Settings** → **Fields** → **Status** → "Add option" → name it `Icebox`
+   - Drag `Icebox` to the **first** position so it sits before `Todo` in the pipeline
+
+4. **Configure the Auto-add workflow** in the Project UI (one-time, not scriptable):
    - Project → **Workflows** → enable **Auto-add to project**
    - Repository: `vata-apps/vata-app`
    - Filter: `is:issue,open`
 
-4. **Configure auto-status workflows** (built-ins, also UI-only). Status uses GitHub's default 3-stage pipeline (`Todo / In Progress / Done`):
-   - **Item added to project** → set Status: `Todo`
+5. **Configure auto-status workflows** (built-ins, also UI-only). Status pipeline is `Icebox / Todo / In Progress / Done`:
+   - **Item added to project** → set Status: `Todo` (the `capture-idea` skill overrides to `Icebox` after the fact)
    - **Pull request opened** → set Status: `In Progress`
    - **Pull request merged** → set Status: `Done`
    - **Issue closed** → set Status: `Done`
 
-5. **Set up views**:
-   - Board grouped by Status
-   - Table grouped by Type
-   - (optional) Roadmap if you start using dates / iterations
+6. **Set up the four recommended views** (see "Recommended views" above for queries):
+   - **Now** — board, hides Icebox + Done
+   - **Icebox** — table of parked ideas
+   - **Bugs** — board filtered to `type:Bug`
+   - **Backlog by Priority** — table grouped by P0/P1/P2
 
 The bootstrap script prints these manual steps after running.
 

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -107,7 +107,7 @@ Activates at the **start** of a dev task, on phrases like:
 - "add a feature for Z" / "fix bug W"
 - "commençons sur X" / "on s'attaque à X"
 
-Phase A: searches the repo's open issues with `gh issue list --search ...`, lists up to 5 candidates as `#<number> · <type> · <state> · <title>`, lets the user pick or create. Stores the choice in `git config branch.<branch>.ghIssue`.
+Phase A: searches the repo's open issues via the GraphQL `search` API (returns `issueType` alongside title and state — `gh issue list --json` doesn't expose the type field), lists up to 5 candidates as `#<number> · <type> · <state> · <title>`, lets the user pick or create. Stores the choice in `git config branch.<branch>.ghIssue`.
 
 Phase B: at PR creation, reads that git config and appends `Closes #N` to the description. GitHub auto-closes the linked issue on merge, and the Project's auto-status workflow moves it to **Done**.
 

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -4,13 +4,13 @@ Single backlog for everything — bugs, ideas, tasks. GitHub Issues + one org-le
 
 ## Quick start
 
-| Where      | What                                                                                |
-| ---------- | ----------------------------------------------------------------------------------- |
-| Issue Type | One of `Task` / `Bug` / `Feature`, set at the org level (max 25 across all repos)   |
-| Templates  | `.github/ISSUE_TEMPLATE/{bug,feature,task}.yml` — auto-set the type on web UI       |
-| Labels     | 6 labels covering area: `db`, `ui`, `gedcom`, `tauri`, `docs`, `good-first-issue`   |
-| Project    | Org-level "Vata Roadmap" — Status / Priority / Type fields, auto-add for new issues |
-| Skills     | `capture-idea` (file an idea), `link-task` (bind PR to existing issue)              |
+| Where      | What                                                                                      |
+| ---------- | ----------------------------------------------------------------------------------------- |
+| Issue Type | One of `Task` / `Bug` / `Feature`, set at the org level (max 25 across all repos)         |
+| Templates  | `.github/ISSUE_TEMPLATE/{bug,feature,task}.yml` — auto-set the type on web UI             |
+| Labels     | 5 area labels (`db`, `ui`, `gedcom`, `tauri`, `docs`) + 1 meta label (`good-first-issue`) |
+| Project    | Org-level "Vata Roadmap" — Status / Priority / Type fields, auto-add for new issues       |
+| Skills     | `capture-idea` (file an idea), `link-task` (bind PR to existing issue)                    |
 
 ## Issue Types
 
@@ -30,29 +30,28 @@ For ideas/insights captured via `capture-idea`, the default is **Feature** unles
 
 Three YAML issue forms live in `.github/ISSUE_TEMPLATE/`. Each preset its `type:` so issues created via the GitHub web UI ("New issue" → pick a template) are auto-classified.
 
-| File          | Type      | Required fields                         |
-| ------------- | --------- | --------------------------------------- |
-| `bug.yml`     | `bug`     | What's wrong, Steps to reproduce        |
-| `feature.yml` | `feature` | The idea                                |
-| `task.yml`    | `task`    | Goal                                    |
-| `config.yml`  | —         | Disables blank issues, no contact links |
+| File          | Type      | Required fields                  |
+| ------------- | --------- | -------------------------------- |
+| `bug.yml`     | `bug`     | What's wrong, Steps to reproduce |
+| `feature.yml` | `feature` | The idea                         |
+| `task.yml`    | `task`    | Goal                             |
 
-Blank issues are disabled — every new issue must go through one of the three templates. The skills (`capture-idea`) bypass templates because they create issues programmatically; they set the type explicitly via GraphQL after creation, keeping parity with web-UI submissions.
+`config.yml` (no `type`) disables blank issues so new submissions always go through one of the three templates. The skills (`capture-idea`) bypass templates because they create issues programmatically; they set the type via GraphQL after creation, keeping parity with web-UI submissions.
 
 ## Labels
 
-Labels track the **area** of the codebase only. Issue Type is not a label. Priority and Status live on the Project, not as labels.
+Labels split into two groups: **area** (which part of the codebase) and **meta** (how an issue should be triaged). Issue Type, Priority, and Status are not labels — they live on the issue itself or on the Project.
 
-| Label              | Meaning                               | Color     |
-| ------------------ | ------------------------------------- | --------- |
-| `db`               | Schema, queries, migrations           | `#0E8A16` |
-| `ui`               | Components, pages, routing            | `#1D76DB` |
-| `gedcom`           | Import/export GEDCOM                  | `#D93F0B` |
-| `tauri`            | Rust shell, permissions, capabilities | `#5319E7` |
-| `docs`             | Documentation work                    | `#0075CA` |
-| `good-first-issue` | Good for newcomers / small surface    | `#7057FF` |
+| Label              | Group | Meaning                               | Color     |
+| ------------------ | ----- | ------------------------------------- | --------- |
+| `db`               | area  | Schema, queries, migrations           | `#0E8A16` |
+| `ui`               | area  | Components, pages, routing            | `#1D76DB` |
+| `gedcom`           | area  | Import/export GEDCOM                  | `#D93F0B` |
+| `tauri`            | area  | Rust shell, permissions, capabilities | `#5319E7` |
+| `docs`             | area  | Documentation work                    | `#0075CA` |
+| `good-first-issue` | meta  | Good for newcomers / small surface    | `#7057FF` |
 
-An issue can have **0–2 area labels**. Most have one or none.
+An issue can have **0–2 area labels** plus optional meta labels. Most have one area label or none.
 
 ## The Project
 

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -196,7 +196,7 @@ The bootstrap script prints these manual steps after running.
 - **`gh` not authenticated**: `gh auth login`.
 - **Skill fails on the type-setting GraphQL step**: missing `read:org` scope. `gh auth refresh -s read:org`.
 - **`setup-gh-project.sh` fails to create a Project field**: confirm the `project` scope is present (`gh auth status`). The script prints manual instructions for any field it couldn't create.
-- **Auto-add isn't picking up new issues**: the workflow on the Project must be enabled (UI step 3 above).
+- **Auto-add isn't picking up new issues**: the workflow on the Project must be enabled (UI step 4 above).
 - **Forgot to link at task start**: trigger `link-task` mid-task — _"link this task to a GitHub issue"_ — Phase A runs again and overwrites `git config`.
 - **Wrong issue linked**: re-run Phase A; `git config` overwrites cleanly.
 - **PR already opened without `Closes #N`**: edit the PR description manually or via `gh pr edit --body "..."`.

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -147,7 +147,9 @@ Activates at the **start** of a dev task, on phrases like:
 - "add a feature for Z" / "fix bug W"
 - "commençons sur X" / "on s'attaque à X"
 
-Phase A: searches the repo's open issues via the GraphQL `search` API (returns `issueType` alongside title and state — `gh issue list --json` doesn't expose the type field), lists up to 5 candidates as `#<number> · <type> · <state> · <title>`, lets the user pick or create. Stores the choice in `git config branch.<branch>.ghIssue`.
+Phase A: searches the repo's open issues via the GraphQL `search` API (returns `issueType` alongside title and state — `gh issue list --json` doesn't expose the type field), lists up to 5 candidates as `#<number> · <type> · <state> · <title>`, lets the user pick from existing open issues. Stores the choice in `git config branch.<branch>.ghIssue`.
+
+**Note**: `link-task` does NOT create new issues — it only links to existing ones. If no matching issue exists, run `capture-idea` to create one first, then run `link-task` to link it.
 
 Phase B: at PR creation, reads that git config and appends `Closes #N` to the description. GitHub auto-closes the linked issue on merge, and the Project's auto-status workflow moves it to **Done**.
 

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -1,0 +1,93 @@
+# Issue Tracking with GitHub Issues
+
+Single backlog for everything — bugs, ideas, tasks. Two skills wrap the `gh` CLI so capture and linking stay near-zero-friction from a Claude Code session.
+
+- **`capture-idea`** — file a future idea as a GitHub issue with appropriate label(s)
+- **`link-task`** — connect the current dev task to an existing issue so the PR auto-closes it at merge
+
+No MCP, no API key, no extra setup — `gh auth login` is the only requirement, and you've already done it if `gh` works.
+
+---
+
+## Capturing ideas — `capture-idea`
+
+Just say it in chat. The skill (defined at `.claude/skills/capture-idea/SKILL.md`) activates on phrases like:
+
+- "à faire plus tard", "faire plus tard", "note pour plus tard"
+- "ne pas oublier", "garder pour plus tard"
+- "to do later", "remember this for later", "save this for later"
+- "save this as an insight", "add this to the backlog"
+
+Examples:
+
+> _"On devrait détecter les doublons à l'import GEDCOM, à faire plus tard."_
+
+> _"Note pour plus tard: revoir le wording de la home page."_
+
+> _"Save this as an insight — query perf on individuals list is mediocre."_
+
+The agent composes a concise English title (and optional body), reads the repo's existing labels, picks 0–2 that match, and creates the issue. It replies with the issue number and URL.
+
+### What gets created
+
+- A regular GitHub issue (open state, no assignee, no milestone)
+- Title and body in English (project rule)
+- 0–2 labels picked from existing repo labels (no labels are auto-created)
+- Created via `gh issue create` in whatever repo the current cwd resolves to
+
+Refine in GitHub afterward.
+
+---
+
+## Linking a task to an issue — `link-task`
+
+Activates at the **start** of a dev task, right after you decide "simple branch or worktree?" and before code changes. Triggers on phrases like:
+
+- "let's implement X" / "on travaille sur Y"
+- "add a feature for Z" / "fix bug W"
+- "commençons sur X" / "on s'attaque à X"
+
+Flow:
+
+1. Agent searches the repo's issues with `gh issue list --search ...` for queries derived from the task description
+2. Lists up to 5 candidates with `#<number> · <state> · <title>`
+3. You pick one, ask for a new one (delegates to `capture-idea`), or skip
+4. The picked number is stored in `git config branch.<branch>.ghIssue`
+
+When you later open the PR, the agent reads that git config and appends `Closes #N` to the description automatically. GitHub natively closes the linked issue when the PR merges — no external integration needed.
+
+The link is per-branch and survives across sessions.
+
+### Example session
+
+```
+You: simple branch or worktree?
+Agent: <recommends, you choose>
+You: let's add a CSV export of the individuals list
+Agent: I found these:
+       #12 · open · CSV export of individuals (label: ui)
+       #31 · open · Bulk export options
+       Which one — #12, #31, create new, or no link?
+You: #12
+Agent: Linked to #12. Proceeding.
+... work happens ...
+You: open the PR
+Agent: <opens PR; description includes "Closes #12">
+```
+
+### What does _not_ happen
+
+- The agent doesn't auto-pick — Phase A always asks
+- The agent doesn't search GitHub at PR time — only at task start
+- Branch names are not modified to include the issue number
+- Existing commits are not amended
+
+---
+
+## Troubleshooting
+
+- **`gh` not authenticated**: run `gh auth login`, then retry.
+- **No labels applied when you expected one** (capture flow): the agent only applies labels when the match is unambiguous. Add the label in the repo and the next capture will see it.
+- **Forgot to link at task start**: re-trigger the skill mid-task — _"link this task to a GitHub issue"_ — Phase A runs again and updates `git config`.
+- **Wrong issue linked**: re-run Phase A; `git config` overwrites cleanly.
+- **PR already opened without `Closes #N`**: edit the PR description in GitHub and add the footer manually, or run `gh pr edit --body "..."`. Future PRs on this branch will pick up the link from `git config` automatically if you re-run Phase B.

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -64,16 +64,17 @@ Org-level: **Vata Roadmap** at `https://github.com/orgs/vata-apps/projects/<num>
 | ------------ | ------------- | ------------------------------------------------------ |
 | **Title**    | (built-in)    | Issue title                                            |
 | **Type**     | (built-in)    | Maps to org Issue Type (Task / Bug / Feature)          |
-| **Status**   | single-select | Backlog → Todo → In Progress → In Review → Done        |
+| **Status**   | (built-in)    | Default 3-stage pipeline: Todo → In Progress → Done    |
 | **Priority** | single-select | P0 (drop everything) / P1 (this cycle) / P2 (whenever) |
 
 ### Auto-add
 
-A workflow on the Project adds every new issue from `vata-apps/vata-app` automatically. New items land with no Status — set it manually when picked up.
+A workflow on the Project adds every new issue from `vata-apps/vata-app` automatically. New items land with **Status: Todo**.
 
 ### Auto-status (built-in workflows)
 
-- Pull request opened on a linked issue → Status = **In Review**
+- Item added to project → Status = **Todo**
+- Pull request opened on a linked issue → Status = **In Progress**
 - Pull request merged → Status = **Done**
 - Issue closed → Status = **Done**
 
@@ -125,16 +126,16 @@ For first-time setup or when wiring a new dev environment:
    bash scripts/setup-gh-project.sh
    ```
 
-   It reconciles labels (drops obsolete ones, adds missing) and creates the **Vata Roadmap** Project + Status + Priority fields if missing. Idempotent.
+   It reconciles labels (drops obsolete ones, adds missing), creates the **Vata Roadmap** Project if missing, and adds the custom **Priority** field. The built-in **Status** field already provides the Todo / In Progress / Done pipeline. Idempotent.
 
 3. **Configure the Auto-add workflow** in the Project UI (one-time, not scriptable):
    - Project → **Workflows** → enable **Auto-add to project**
    - Repository: `vata-apps/vata-app`
    - Filter: `is:issue,open`
 
-4. **Configure auto-status workflows** (built-ins, also UI-only):
-   - **Item added to project** → set Status: `Backlog`
-   - **Pull request opened** → set Status: `In Review`
+4. **Configure auto-status workflows** (built-ins, also UI-only). Status uses GitHub's default 3-stage pipeline (`Todo / In Progress / Done`):
+   - **Item added to project** → set Status: `Todo`
+   - **Pull request opened** → set Status: `In Progress`
    - **Pull request merged** → set Status: `Done`
    - **Issue closed** → set Status: `Done`
 

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -1,93 +1,157 @@
-# Issue Tracking with GitHub Issues
+# Issue Tracking
 
-Single backlog for everything — bugs, ideas, tasks. Two skills wrap the `gh` CLI so capture and linking stay near-zero-friction from a Claude Code session.
+Single backlog for everything — bugs, ideas, tasks. GitHub Issues + one org-level GH Project replace what Linear used to do, with zero external service to keep authenticated.
 
-- **`capture-idea`** — file a future idea as a GitHub issue with appropriate label(s)
-- **`link-task`** — connect the current dev task to an existing issue so the PR auto-closes it at merge
+## Quick start
 
-No MCP, no API key, no extra setup — `gh auth login` is the only requirement, and you've already done it if `gh` works.
+| Where      | What                                                                                |
+| ---------- | ----------------------------------------------------------------------------------- |
+| Issue Type | One of `Task` / `Bug` / `Feature`, set at the org level (max 25 across all repos)   |
+| Templates  | `.github/ISSUE_TEMPLATE/{bug,feature,task}.yml` — auto-set the type on web UI       |
+| Labels     | 6 labels covering area: `db`, `ui`, `gedcom`, `tauri`, `docs`, `good-first-issue`   |
+| Project    | Org-level "Vata Roadmap" — Status / Priority / Type fields, auto-add for new issues |
+| Skills     | `capture-idea` (file an idea), `link-task` (bind PR to existing issue)              |
 
----
+## Issue Types
 
-## Capturing ideas — `capture-idea`
+`vata-apps` has three Issue Types defined at the organization level:
 
-Just say it in chat. The skill (defined at `.claude/skills/capture-idea/SKILL.md`) activates on phrases like:
+| Type        | When to use                                                                         |
+| ----------- | ----------------------------------------------------------------------------------- |
+| **Bug**     | An unexpected problem or behavior — something is broken or wrong                    |
+| **Feature** | A new capability, improvement, or insight — anything that's not a defect or a task  |
+| **Task**    | A concrete piece of dev work with a clear deliverable (refactor, dep bump, cleanup) |
+
+Each issue has exactly one Type (single value). Types are visible in the issue header, in search (`type:"Bug"`), and as a built-in field in the Project. Only org owners can create/edit/disable types in `vata-apps` settings.
+
+For ideas/insights captured via `capture-idea`, the default is **Feature** unless the wording clearly indicates a defect (Bug) or operational task (Task).
+
+## Templates
+
+Three YAML issue forms live in `.github/ISSUE_TEMPLATE/`. Each preset its `type:` so issues created via the GitHub web UI ("New issue" → pick a template) are auto-classified.
+
+| File          | Type      | Required fields                         |
+| ------------- | --------- | --------------------------------------- |
+| `bug.yml`     | `bug`     | What's wrong, Steps to reproduce        |
+| `feature.yml` | `feature` | The idea                                |
+| `task.yml`    | `task`    | Goal                                    |
+| `config.yml`  | —         | Disables blank issues, no contact links |
+
+Blank issues are disabled — every new issue must go through one of the three templates. The skills (`capture-idea`) bypass templates because they create issues programmatically; they set the type explicitly via GraphQL after creation, keeping parity with web-UI submissions.
+
+## Labels
+
+Labels track the **area** of the codebase only. Issue Type is not a label. Priority and Status live on the Project, not as labels.
+
+| Label              | Meaning                               | Color     |
+| ------------------ | ------------------------------------- | --------- |
+| `db`               | Schema, queries, migrations           | `#0E8A16` |
+| `ui`               | Components, pages, routing            | `#1D76DB` |
+| `gedcom`           | Import/export GEDCOM                  | `#D93F0B` |
+| `tauri`            | Rust shell, permissions, capabilities | `#5319E7` |
+| `docs`             | Documentation work                    | `#0075CA` |
+| `good-first-issue` | Good for newcomers / small surface    | `#7057FF` |
+
+An issue can have **0–2 area labels**. Most have one or none.
+
+## The Project
+
+Org-level: **Vata Roadmap** at `https://github.com/orgs/vata-apps/projects/<num>`.
+
+### Fields
+
+| Field        | Type          | Values / behavior                                      |
+| ------------ | ------------- | ------------------------------------------------------ |
+| **Title**    | (built-in)    | Issue title                                            |
+| **Type**     | (built-in)    | Maps to org Issue Type (Task / Bug / Feature)          |
+| **Status**   | single-select | Backlog → Todo → In Progress → In Review → Done        |
+| **Priority** | single-select | P0 (drop everything) / P1 (this cycle) / P2 (whenever) |
+
+### Auto-add
+
+A workflow on the Project adds every new issue from `vata-apps/vata-app` automatically. New items land with no Status — set it manually when picked up.
+
+### Auto-status (built-in workflows)
+
+- Pull request opened on a linked issue → Status = **In Review**
+- Pull request merged → Status = **Done**
+- Issue closed → Status = **Done**
+
+### Recommended views
+
+- **Board**: grouped by Status (kanban — current work)
+- **Table**: grouped by Type (everything by category)
+- **Roadmap**: only useful once dates / iterations are in use
+
+## Skills
+
+Two Claude Code skills, used from any session in the repo.
+
+### `capture-idea`
+
+Activates on phrases like:
 
 - "à faire plus tard", "faire plus tard", "note pour plus tard"
 - "ne pas oublier", "garder pour plus tard"
 - "to do later", "remember this for later", "save this for later"
 - "save this as an insight", "add this to the backlog"
 
-Examples:
+The agent composes a concise English title (and optional body), reads the repo's existing labels, picks 0–2 that match, creates the issue with `gh issue create`, then sets the org-level Issue Type (Feature by default; Bug or Task if context suggests) via the `updateIssueIssueType` GraphQL mutation. Replies with the issue number, type, labels, and URL.
 
-> _"On devrait détecter les doublons à l'import GEDCOM, à faire plus tard."_
+### `link-task`
 
-> _"Note pour plus tard: revoir le wording de la home page."_
-
-> _"Save this as an insight — query perf on individuals list is mediocre."_
-
-The agent composes a concise English title (and optional body), reads the repo's existing labels, picks 0–2 that match, and creates the issue. It replies with the issue number and URL.
-
-### What gets created
-
-- A regular GitHub issue (open state, no assignee, no milestone)
-- Title and body in English (project rule)
-- 0–2 labels picked from existing repo labels (no labels are auto-created)
-- Created via `gh issue create` in whatever repo the current cwd resolves to
-
-Refine in GitHub afterward.
-
----
-
-## Linking a task to an issue — `link-task`
-
-Activates at the **start** of a dev task, right after you decide "simple branch or worktree?" and before code changes. Triggers on phrases like:
+Activates at the **start** of a dev task, on phrases like:
 
 - "let's implement X" / "on travaille sur Y"
 - "add a feature for Z" / "fix bug W"
 - "commençons sur X" / "on s'attaque à X"
 
-Flow:
+Phase A: searches the repo's open issues with `gh issue list --search ...`, lists up to 5 candidates as `#<number> · <type> · <state> · <title>`, lets the user pick or create. Stores the choice in `git config branch.<branch>.ghIssue`.
 
-1. Agent searches the repo's issues with `gh issue list --search ...` for queries derived from the task description
-2. Lists up to 5 candidates with `#<number> · <state> · <title>`
-3. You pick one, ask for a new one (delegates to `capture-idea`), or skip
-4. The picked number is stored in `git config branch.<branch>.ghIssue`
+Phase B: at PR creation, reads that git config and appends `Closes #N` to the description. GitHub auto-closes the linked issue on merge, and the Project's auto-status workflow moves it to **Done**.
 
-When you later open the PR, the agent reads that git config and appends `Closes #N` to the description automatically. GitHub natively closes the linked issue when the PR merges — no external integration needed.
+## Manual setup checklist
 
-The link is per-branch and survives across sessions.
+For first-time setup or when wiring a new dev environment:
 
-### Example session
+1. **Authenticate `gh`** with the right scopes:
+   ```bash
+   gh auth login                              # if not already
+   gh auth refresh -s repo,project,read:org   # add scopes for projects + Issue Types
+   ```
+2. **Run the bootstrap script**:
 
-```
-You: simple branch or worktree?
-Agent: <recommends, you choose>
-You: let's add a CSV export of the individuals list
-Agent: I found these:
-       #12 · open · CSV export of individuals (label: ui)
-       #31 · open · Bulk export options
-       Which one — #12, #31, create new, or no link?
-You: #12
-Agent: Linked to #12. Proceeding.
-... work happens ...
-You: open the PR
-Agent: <opens PR; description includes "Closes #12">
-```
+   ```bash
+   bash scripts/setup-gh-project.sh
+   ```
 
-### What does _not_ happen
+   It reconciles labels (drops obsolete ones, adds missing) and creates the **Vata Roadmap** Project + Status + Priority fields if missing. Idempotent.
 
-- The agent doesn't auto-pick — Phase A always asks
-- The agent doesn't search GitHub at PR time — only at task start
-- Branch names are not modified to include the issue number
-- Existing commits are not amended
+3. **Configure the Auto-add workflow** in the Project UI (one-time, not scriptable):
+   - Project → **Workflows** → enable **Auto-add to project**
+   - Repository: `vata-apps/vata-app`
+   - Filter: `is:issue,open`
 
----
+4. **Configure auto-status workflows** (built-ins, also UI-only):
+   - **Item added to project** → set Status: `Backlog`
+   - **Pull request opened** → set Status: `In Review`
+   - **Pull request merged** → set Status: `Done`
+   - **Issue closed** → set Status: `Done`
+
+5. **Set up views**:
+   - Board grouped by Status
+   - Table grouped by Type
+   - (optional) Roadmap if you start using dates / iterations
+
+The bootstrap script prints these manual steps after running.
 
 ## Troubleshooting
 
-- **`gh` not authenticated**: run `gh auth login`, then retry.
-- **No labels applied when you expected one** (capture flow): the agent only applies labels when the match is unambiguous. Add the label in the repo and the next capture will see it.
-- **Forgot to link at task start**: re-trigger the skill mid-task — _"link this task to a GitHub issue"_ — Phase A runs again and updates `git config`.
+- **`gh` not authenticated**: `gh auth login`.
+- **Skill fails on the type-setting GraphQL step**: missing `read:org` scope. `gh auth refresh -s read:org`.
+- **`setup-gh-project.sh` fails to create a Project field**: confirm the `project` scope is present (`gh auth status`). The script prints manual instructions for any field it couldn't create.
+- **Auto-add isn't picking up new issues**: the workflow on the Project must be enabled (UI step 3 above).
+- **Forgot to link at task start**: trigger `link-task` mid-task — _"link this task to a GitHub issue"_ — Phase A runs again and overwrites `git config`.
 - **Wrong issue linked**: re-run Phase A; `git config` overwrites cleanly.
-- **PR already opened without `Closes #N`**: edit the PR description in GitHub and add the footer manually, or run `gh pr edit --body "..."`. Future PRs on this branch will pick up the link from `git config` automatically if you re-run Phase B.
+- **PR already opened without `Closes #N`**: edit the PR description manually or via `gh pr edit --body "..."`.
+- **Issue lacks a Type after capture**: the GraphQL step failed silently. Set the type from the GitHub UI (issue header → "Type" dropdown).

--- a/scripts/setup-gh-project.sh
+++ b/scripts/setup-gh-project.sh
@@ -128,27 +128,33 @@ Project ready: $PROJECT_URL
 
 Manual UI steps still required (not scriptable):
 
-1. Auto-add workflow
+1. Add 'Icebox' to the Status field
+   $PROJECT_URL/settings → Fields → Status → "Add option" → Icebox
+   Drag Icebox to FIRST position so the pipeline reads:
+     Icebox → Todo → In Progress → Done
+
+2. Auto-add workflow
    $PROJECT_URL/workflows
    → Enable "Auto-add to project"
    → Repository: $ORG/$REPO
    → Filter: is:issue,open
 
-2. Auto-status workflow
-   Same workflows page → enable built-in (Status defaults: Todo / In Progress / Done):
+3. Auto-status workflows (built-ins, same Workflows page):
    - "Item added to project"     → set Status: Todo
+     (the capture-idea skill overrides to Icebox after creation)
    - "Pull request opened"       → set Status: In Progress
    - "Pull request merged"       → set Status: Done
    - "Issue closed"              → set Status: Done
 
-3. Views (recommended)
-   - Board grouped by Status
-   - Table grouped by Type (built-in field, maps to org Issue Types)
-   - Roadmap if you start using dates / iterations
+4. Recommended views
+   - Now: Board, group by Status, filter "is:open -status:Icebox -status:Done"
+   - Icebox: Table, group by Type, filter "is:open status:Icebox"
+   - Bugs: Board, group by Status, filter "is:open type:Bug"
+   - Backlog by Priority: Table, group by Priority, filter "is:open -status:Icebox -status:Done"
 
-4. Verify the Issue Types are visible
-   $PROJECT_URL → check that the "Type" column shows Task/Bug/Feature
-   on existing items. If empty, the items predate Issue Types and
-   types must be set on each issue.
+5. Verify Issue Types render
+   $PROJECT_URL → confirm the "Type" column shows Task/Bug/Feature
+   on existing items. Items that predate Issue Types need their
+   type set manually.
 ---------------------------------------------------------------------
 EOF

--- a/scripts/setup-gh-project.sh
+++ b/scripts/setup-gh-project.sh
@@ -8,30 +8,30 @@
 
 set -euo pipefail
 
-ORG="vata-apps"
-REPO="vata-app"
-PROJECT_TITLE="Vata Roadmap"
+ORG="${VATA_ORG:-vata-apps}"
+REPO="${VATA_REPO:-vata-app}"
+PROJECT_TITLE="${VATA_PROJECT_TITLE:-Vata Roadmap}"
 
 # ---------------------------------------------------------------- helpers ---
 
-info()  { printf "\033[1;34mℹ\033[0m  %s\n" "$*"; }
-ok()    { printf "\033[1;32m✓\033[0m  %s\n" "$*"; }
-warn()  { printf "\033[1;33m!\033[0m  %s\n" "$*"; }
-fatal() { printf "\033[1;31m✗\033[0m  %s\n" "$*" >&2; exit 1; }
-
-# Wrap a command that may legitimately fail (already done) and ignore the error.
-soft() { "$@" 2>/dev/null || true; }
+info()  { printf "[INFO]  %s\n" "$*"; }
+ok()    { printf "[OK]    %s\n" "$*"; }
+warn()  { printf "[WARN]  %s\n" "$*" >&2; }
+fatal() { printf "[FATAL] %s\n" "$*" >&2; exit 1; }
 
 # --------------------------------------------------------------- preflight ---
 
 command -v gh >/dev/null 2>&1 || fatal "gh CLI not found. Install: https://cli.github.com/"
+command -v jq >/dev/null 2>&1 || fatal "jq not found. Install: https://stedolan.github.io/jq/"
 
 if ! gh auth status >/dev/null 2>&1; then
   fatal "gh not authenticated. Run: gh auth login"
 fi
 
-# Verify required scopes
-SCOPES=$(gh auth status 2>&1 | grep -oE "Token scopes:.*" || echo "")
+# Verify required scopes by parsing 'gh auth status'. The text format is stable
+# enough for current versions; if a future gh changes it, the loop below will
+# tell the user which scope it failed to detect.
+SCOPES=$(gh auth status 2>&1 | grep -oE "Token scopes:.*" || true)
 for scope in repo project read:org; do
   if ! echo "$SCOPES" | grep -q "$scope"; then
     warn "Missing scope: $scope"
@@ -46,18 +46,23 @@ ok "gh authenticated with required scopes"
 
 info "Reconciling labels in $ORG/$REPO..."
 
+EXISTING_LABELS=$(gh label list --repo "$ORG/$REPO" --json name --jq '.[].name')
+
 # Delete labels that are no longer part of the taxonomy
 for label in "area:ui" "shadcn-cleanup" "tech-debt"; do
-  if gh label list --repo "$ORG/$REPO" --json name --jq '.[].name' | grep -qx "$label"; then
-    soft gh label delete "$label" --repo "$ORG/$REPO" --yes
-    ok "deleted label '$label'"
+  if echo "$EXISTING_LABELS" | grep -qx "$label"; then
+    if gh label delete "$label" --repo "$ORG/$REPO" --yes; then
+      ok "deleted label '$label'"
+    else
+      warn "could not delete label '$label' — investigate manually"
+    fi
   fi
 done
 
 # Ensure new labels exist
 ensure_label() {
   local name="$1" color="$2" desc="$3"
-  if gh label list --repo "$ORG/$REPO" --json name --jq '.[].name' | grep -qx "$name"; then
+  if echo "$EXISTING_LABELS" | grep -qx "$name"; then
     return 0
   fi
   gh label create "$name" --repo "$ORG/$REPO" --color "$color" --description "$desc"
@@ -74,8 +79,7 @@ ok "Labels reconciled"
 info "Checking org Project '$PROJECT_TITLE'..."
 
 PROJECT_NUM=$(gh project list --owner "$ORG" --format json \
-  | jq -r --arg t "$PROJECT_TITLE" '.projects[] | select(.title == $t) | .number' \
-  | head -n1 || true)
+  | jq -r --arg t "$PROJECT_TITLE" '[.projects[] | select(.title == $t) | .number] | first // empty')
 
 if [[ -z "$PROJECT_NUM" ]]; then
   info "Creating Project '$PROJECT_TITLE' in org $ORG..."
@@ -90,9 +94,8 @@ fi
 
 info "Reconciling custom fields..."
 
-# Get existing fields
 EXISTING_FIELDS=$(gh project field-list "$PROJECT_NUM" --owner "$ORG" --format json \
-  | jq -r '.fields[].name' || echo "")
+  | jq -r '.fields[].name')
 
 ensure_field() {
   local name="$1" options="$2"

--- a/scripts/setup-gh-project.sh
+++ b/scripts/setup-gh-project.sh
@@ -113,7 +113,8 @@ ensure_field() {
   fi
 }
 
-ensure_field "Status" "Backlog,Todo,In Progress,In Review,Done"
+# Status is a built-in single-select field with default options
+# (Todo / In Progress / Done). We keep the defaults — no need to recreate.
 ensure_field "Priority" "P0,P1,P2"
 
 # -------------------------------------------------------------- next steps ---
@@ -134,9 +135,9 @@ Manual UI steps still required (not scriptable):
    → Filter: is:issue,open
 
 2. Auto-status workflow
-   Same workflows page → enable built-in:
-   - "Item added to project"     → set Status: Backlog
-   - "Pull request opened"       → set Status: In Review
+   Same workflows page → enable built-in (Status defaults: Todo / In Progress / Done):
+   - "Item added to project"     → set Status: Todo
+   - "Pull request opened"       → set Status: In Progress
    - "Pull request merged"       → set Status: Done
    - "Issue closed"              → set Status: Done
 

--- a/scripts/setup-gh-project.sh
+++ b/scripts/setup-gh-project.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# Bootstraps the Vata GitHub Issues + Project structure.
+# Idempotent: safe to rerun. Prints manual UI steps that are not scriptable.
+#
+# Requires: gh CLI authenticated with scopes `repo`, `project`, `read:org`.
+# Run from anywhere — the script does not depend on cwd.
+
+set -euo pipefail
+
+ORG="vata-apps"
+REPO="vata-app"
+PROJECT_TITLE="Vata Roadmap"
+
+# ---------------------------------------------------------------- helpers ---
+
+info()  { printf "\033[1;34mℹ\033[0m  %s\n" "$*"; }
+ok()    { printf "\033[1;32m✓\033[0m  %s\n" "$*"; }
+warn()  { printf "\033[1;33m!\033[0m  %s\n" "$*"; }
+fatal() { printf "\033[1;31m✗\033[0m  %s\n" "$*" >&2; exit 1; }
+
+# Wrap a command that may legitimately fail (already done) and ignore the error.
+soft() { "$@" 2>/dev/null || true; }
+
+# --------------------------------------------------------------- preflight ---
+
+command -v gh >/dev/null 2>&1 || fatal "gh CLI not found. Install: https://cli.github.com/"
+
+if ! gh auth status >/dev/null 2>&1; then
+  fatal "gh not authenticated. Run: gh auth login"
+fi
+
+# Verify required scopes
+SCOPES=$(gh auth status 2>&1 | grep -oE "Token scopes:.*" || echo "")
+for scope in repo project read:org; do
+  if ! echo "$SCOPES" | grep -q "$scope"; then
+    warn "Missing scope: $scope"
+    info "Refresh with: gh auth refresh -s repo,project,read:org"
+    fatal "Re-run this script after refreshing scopes."
+  fi
+done
+
+ok "gh authenticated with required scopes"
+
+# ----------------------------------------------------------------- labels ---
+
+info "Reconciling labels in $ORG/$REPO..."
+
+# Delete labels that are no longer part of the taxonomy
+for label in "area:ui" "shadcn-cleanup" "tech-debt"; do
+  if gh label list --repo "$ORG/$REPO" --json name --jq '.[].name' | grep -qx "$label"; then
+    soft gh label delete "$label" --repo "$ORG/$REPO" --yes
+    ok "deleted label '$label'"
+  fi
+done
+
+# Ensure new labels exist
+ensure_label() {
+  local name="$1" color="$2" desc="$3"
+  if gh label list --repo "$ORG/$REPO" --json name --jq '.[].name' | grep -qx "$name"; then
+    return 0
+  fi
+  gh label create "$name" --repo "$ORG/$REPO" --color "$color" --description "$desc"
+  ok "created label '$name'"
+}
+
+ensure_label "docs" "0075CA" "Documentation work"
+ensure_label "good-first-issue" "7057FF" "Good for newcomers / small surface"
+
+ok "Labels reconciled"
+
+# ---------------------------------------------------------------- project ---
+
+info "Checking org Project '$PROJECT_TITLE'..."
+
+PROJECT_NUM=$(gh project list --owner "$ORG" --format json \
+  | jq -r --arg t "$PROJECT_TITLE" '.projects[] | select(.title == $t) | .number' \
+  | head -n1 || true)
+
+if [[ -z "$PROJECT_NUM" ]]; then
+  info "Creating Project '$PROJECT_TITLE' in org $ORG..."
+  CREATE_OUT=$(gh project create --owner "$ORG" --title "$PROJECT_TITLE" --format json)
+  PROJECT_NUM=$(echo "$CREATE_OUT" | jq -r '.number')
+  ok "Project created (number: $PROJECT_NUM)"
+else
+  ok "Project '$PROJECT_TITLE' already exists (number: $PROJECT_NUM)"
+fi
+
+# ---------------------------------------------------------- custom fields ---
+
+info "Reconciling custom fields..."
+
+# Get existing fields
+EXISTING_FIELDS=$(gh project field-list "$PROJECT_NUM" --owner "$ORG" --format json \
+  | jq -r '.fields[].name' || echo "")
+
+ensure_field() {
+  local name="$1" options="$2"
+  if echo "$EXISTING_FIELDS" | grep -qx "$name"; then
+    ok "field '$name' already exists"
+    return 0
+  fi
+  if gh project field-create "$PROJECT_NUM" \
+       --owner "$ORG" \
+       --name "$name" \
+       --data-type SINGLE_SELECT \
+       --single-select-options "$options" >/dev/null; then
+    ok "created field '$name'"
+  else
+    warn "field-create failed for '$name'. Create manually in the Project UI:"
+    warn "  Field: $name (single-select)"
+    warn "  Options: $options"
+  fi
+}
+
+ensure_field "Status" "Backlog,Todo,In Progress,In Review,Done"
+ensure_field "Priority" "P0,P1,P2"
+
+# -------------------------------------------------------------- next steps ---
+
+PROJECT_URL="https://github.com/orgs/$ORG/projects/$PROJECT_NUM"
+
+cat <<EOF
+
+---------------------------------------------------------------------
+Project ready: $PROJECT_URL
+
+Manual UI steps still required (not scriptable):
+
+1. Auto-add workflow
+   $PROJECT_URL/workflows
+   → Enable "Auto-add to project"
+   → Repository: $ORG/$REPO
+   → Filter: is:issue,open
+
+2. Auto-status workflow
+   Same workflows page → enable built-in:
+   - "Item added to project"     → set Status: Backlog
+   - "Pull request opened"       → set Status: In Review
+   - "Pull request merged"       → set Status: Done
+   - "Issue closed"              → set Status: Done
+
+3. Views (recommended)
+   - Board grouped by Status
+   - Table grouped by Type (built-in field, maps to org Issue Types)
+   - Roadmap if you start using dates / iterations
+
+4. Verify the Issue Types are visible
+   $PROJECT_URL → check that the "Type" column shows Task/Bug/Feature
+   on existing items. If empty, the items predate Issue Types and
+   types must be set on each issue.
+---------------------------------------------------------------------
+EOF

--- a/scripts/setup-gh-project.sh
+++ b/scripts/setup-gh-project.sh
@@ -46,7 +46,7 @@ ok "gh authenticated with required scopes"
 
 info "Reconciling labels in $ORG/$REPO..."
 
-EXISTING_LABELS=$(gh label list --repo "$ORG/$REPO" --json name --jq '.[].name')
+EXISTING_LABELS=$(gh label list --repo "$ORG/$REPO" --limit 2000 --json name --jq '.[].name')
 
 # Delete labels that are no longer part of the taxonomy
 for label in "area:ui" "shadcn-cleanup" "tech-debt"; do


### PR DESCRIPTION
## Summary

- Wire `vata-apps` as Vata's single backlog: GitHub Issues + an org-level GH Project replace what Linear was supposed to do.
- Three issue templates (`bug`, `feature`, `task`) auto-set the org-level Issue Type so every web-UI submission is correctly classified.
- Two skills wrap `gh` for friction-free flow inside Claude Code:
  - `capture-idea` — triggers on "faire plus tard" / "to do later" / etc., creates an issue, sets Type via GraphQL `updateIssueIssueType`, adds it to the Vata Roadmap project, and pins Status to **Icebox** so vague ideas land in a parking lot rather than the active queue.
  - `link-task` — at task start, searches open issues with GraphQL (returns `issueType` so the candidate display shows it), persists the chosen `#N` in `git config branch.<branch>.ghIssue`. At PR creation, injects `Closes #N` into the description.
- Idempotent bootstrap script (`scripts/setup-gh-project.sh`) reconciles labels (drops `area:ui`, `shadcn-cleanup`, `tech-debt`; adds `docs`, `good-first-issue`), creates the Project + Priority field, and prints the manual UI steps that aren't scriptable (auto-add workflow, auto-status, views).
- Doc consolidates the whole story under `docs/dev-tools/issue-tracking.md` — Issue Types, templates, labels (split into area / meta), the Project (4-stage `Icebox → Todo → In Progress → Done` pipeline, four recommended views with their filter queries), skills, manual setup checklist, troubleshooting.

## Status pipeline

```
Icebox (vague idea, parked) → Todo (queued for soon) → In Progress → Done
```

`capture-idea` lands items in **Icebox**; web-UI submissions land in **Todo**. The transition Icebox → Todo is the explicit promotion moment.

## Test plan

End-to-end smoke tests run against the live `vata-apps/vata-app` repo and Vata Roadmap project:

- [x] Templates render at `https://github.com/vata-apps/vata-app/issues/new/choose` (3 templates, no blank issue option)
- [x] `gh issue create` + `updateIssueIssueType` mutation applies Feature type correctly (verified on closed issue #64)
- [x] `addProjectV2ItemById` + `updateProjectV2ItemFieldValue` lands an issue at Status=Icebox (verified on closed issue #65)
- [x] Auto-add workflow picks up new issues, auto-status moves to Todo (verified manually)
- [x] `gh issue list --json ... issueType` rejected by CLI; switched to GraphQL `search` API (caught during smoke test, fixed in commit `e28defa`)
- [x] `/simplify` review run; 15 findings addressed in commit `4c123d9` (false positives skipped)
- [ ] `pnpm review:all` — skipped per request
- [ ] First real-world capture and link via the skills (will happen organically)

## Notes

- Hardcoded IDs in `capture-idea` (project ID `PVT_kwDODVrl8M4BWWni`, Status field ID, Icebox option ID, three Type IDs) are stable for the `vata-apps` org. If a type or field is renamed/recreated, the skill body has the GraphQL query to re-resolve.
- Smoke test issues #64 and #65 are closed with comments documenting the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)