### PR TITLE
chore: switch GitHub labels to product-axis taxonomy

### DIFF
--- a/.claude/skills/capture-idea/SKILL.md
+++ b/.claude/skills/capture-idea/SKILL.md
@@ -56,7 +56,7 @@ Vata's labels are **product-shaped, not codebase-shaped** — each one names a u
 | Label             | Apply when the idea touches…                                           |
 | ----------------- | ---------------------------------------------------------------------- |
 | `individuals`     | People, names, lifespan formatting                                     |
-| `families`        | Spouse links, parent/child links, pedigree                             |
+| `families`        | Spouse / parent / child links, pedigree                                |
 | `events`          | Life events, dates, witnesses                                          |
 | `places`          | Geography, place hierarchy, external place lookup                      |
 | `sources`         | Sources, citations, evidence linking, repositories                     |

--- a/.claude/skills/capture-idea/SKILL.md
+++ b/.claude/skills/capture-idea/SKILL.md
@@ -51,15 +51,31 @@ Don't pass `--repo` — `gh` infers it from the current working directory's git 
 
 ### 4. Pick labels
 
-Select **0 to 2** labels whose name or description clearly matches the item. Examples (current Vata taxonomy):
+Vata's labels are **product-shaped, not codebase-shaped** — each one names a user-facing concept, not a folder of code. Select **0 to 2** labels whose name or description clearly matches the item. Current taxonomy and how to read them:
 
-- GEDCOM import/export → `gedcom`
-- UI copy or layout → `ui`
-- Query / migration / schema → `db`
-- Rust shell or Tauri permissions → `tauri`
-- Documentation → `docs`
+| Label             | Apply when the idea touches…                                           |
+| ----------------- | ---------------------------------------------------------------------- |
+| `individuals`     | People, names, lifespan formatting                                     |
+| `families`        | Spouse links, parent/child links, pedigree                             |
+| `events`          | Life events, dates, witnesses                                          |
+| `places`          | Geography, place hierarchy, external place lookup                      |
+| `sources`         | Sources, citations, evidence linking, repositories                     |
+| `media`           | Photos, scans, documents, image attachments and editing                |
+| `gedcom`          | GEDCOM 5.5.1 import / export, interoperability                         |
+| `data-quality`    | Completion tracking, duplicate detection, validation                   |
+| `tree-management` | Creating / opening / importing trees, storage location                 |
+| `design-system`   | Storybook, UI wrappers, design tokens, shadcn migrations               |
+| `monetization`    | Paid-tier ideas (Vata is open source and free; these are aspirational) |
 
-If nothing fits cleanly, **pass no labels**. Do not invent or stretch a match. Do not create new labels from this skill.
+Combine two only when the issue is genuinely about the intersection (e.g., "tag people on photos" → `media` + `individuals`). If the idea is a Tauri-shell change, a generic refactor, or a small typo with no clear product surface, **pass no labels**. Do not stretch a match.
+
+#### When no existing label fits
+
+If the captured idea points at a recurring product surface that the current taxonomy doesn't cover (e.g., search/filtering, accessibility, performance, i18n) — proceed to create the issue with **no label**, and in the step-8 report, propose a new label by name with a one-line rationale. Example:
+
+> Captured #42 (Feature, no label). Suggestion: create new label `search` for this and future filter/search ideas — reply yes to add it.
+
+Do **not** create the label without confirmation. The user accepts or rejects in the next message; on `yes`, run `gh label create <name> --color <hex> --description <desc>` and `gh issue edit 42 --add-label <name>`. This keeps the taxonomy small until a real second issue appears for that domain.
 
 ### 5. Create the issue
 
@@ -164,9 +180,9 @@ Mentioning "Icebox" reinforces that the item is parked, not queued. Do not summa
 
 ## What this skill must not do
 
-- Ask for confirmation before creating
-- Force a label when no existing label fits
-- Create new labels
+- Ask for confirmation before creating the issue
+- Force a label when no existing label fits — pass none and propose a new one in the report
+- Create new labels without explicit user confirmation
 - Pick more than one Issue Type (each issue gets exactly one)
 - Modify or close existing issues — capture only
 - Skip step 6 — the type must be set for consistency with web-UI issues

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -4,13 +4,13 @@ Single backlog for everything — bugs, ideas, tasks. GitHub Issues + one org-le
 
 ## Quick start
 
-| Where      | What                                                                                      |
-| ---------- | ----------------------------------------------------------------------------------------- |
-| Issue Type | One of `Task` / `Bug` / `Feature`, set at the org level (max 25 across all repos)         |
-| Templates  | `.github/ISSUE_TEMPLATE/{bug,feature,task}.yml` — auto-set the type on web UI             |
-| Labels     | 5 area labels (`db`, `ui`, `gedcom`, `tauri`, `docs`) + 1 meta label (`good-first-issue`) |
-| Project    | Org-level "Vata Roadmap" — Status / Priority / Type fields, auto-add for new issues       |
-| Skills     | `capture-idea` (file an idea), `link-task` (bind PR to existing issue)                    |
+| Where      | What                                                                                               |
+| ---------- | -------------------------------------------------------------------------------------------------- |
+| Issue Type | One of `Task` / `Bug` / `Feature`, set at the org level (max 25 across all repos)                  |
+| Templates  | `.github/ISSUE_TEMPLATE/{bug,feature,task}.yml` — auto-set the type on web UI                      |
+| Labels     | 11 product-axis labels (genealogy domains, monetization, etc.) + 1 meta label (`good-first-issue`) |
+| Project    | Org-level "Vata Roadmap" — Status / Priority / Type fields, auto-add for new issues                |
+| Skills     | `capture-idea` (file an idea), `link-task` (bind PR to existing issue)                             |
 
 ## Issue Types
 
@@ -40,18 +40,26 @@ Three YAML issue forms live in `.github/ISSUE_TEMPLATE/`. Each preset its `type:
 
 ## Labels
 
-Labels split into two groups: **area** (which part of the codebase) and **meta** (how an issue should be triaged). Issue Type, Priority, and Status are not labels — they live on the issue itself or on the Project.
+Labels are **product-shaped**, not codebase-shaped. Each one names a user-facing concept (an entity, a workflow, a product surface) so triage and filtering ("show me everything about places") stay useful even as the codebase moves around. Issue Type, Priority, and Status are not labels — they live on the issue itself or on the Project.
 
-| Label              | Group | Meaning                               | Color     |
-| ------------------ | ----- | ------------------------------------- | --------- |
-| `db`               | area  | Schema, queries, migrations           | `#0E8A16` |
-| `ui`               | area  | Components, pages, routing            | `#1D76DB` |
-| `gedcom`           | area  | Import/export GEDCOM                  | `#D93F0B` |
-| `tauri`            | area  | Rust shell, permissions, capabilities | `#5319E7` |
-| `docs`             | area  | Documentation work                    | `#0075CA` |
-| `good-first-issue` | meta  | Good for newcomers / small surface    | `#7057FF` |
+| Label              | Group         | Meaning                                                               | Color     |
+| ------------------ | ------------- | --------------------------------------------------------------------- | --------- |
+| `individuals`      | data          | People, names, lifespan formatting                                    | `#0E8A16` |
+| `families`         | data          | Spouse / parent / child links, pedigree                               | `#196127` |
+| `events`           | data          | Life events, dates, witnesses                                         | `#5DC461` |
+| `places`           | data          | Geography, place hierarchy, external place lookup                     | `#0052CC` |
+| `sources`          | data          | Sources, citations, evidence linking, repositories                    | `#1D76DB` |
+| `media`            | data          | Photos, scans, documents, image attachments and editing               | `#5319E7` |
+| `gedcom`           | data          | GEDCOM 5.5.1 import / export, interoperability                        | `#D93F0B` |
+| `data-quality`     | cross-cutting | Completion tracking, duplicate detection, validation                  | `#FBCA04` |
+| `tree-management`  | platform      | Creating / opening / importing trees, storage location                | `#BFD4F2` |
+| `design-system`    | platform      | Storybook, UI wrappers, design tokens, shadcn migrations              | `#C5DEF5` |
+| `monetization`     | platform      | Paid-tier ideas; Vata is open source and free, these are aspirational | `#B60205` |
+| `good-first-issue` | meta          | Good for newcomers / small surface                                    | `#7057FF` |
 
-An issue can have **0–2 area labels** plus optional meta labels. Most have one area label or none.
+An issue can have **0–2 product labels** plus optional meta labels. Combine two only when the issue is genuinely about the intersection (e.g., "tag people on photos" → `media` + `individuals`).
+
+**Adding a new label**: do it only when a recurring product surface emerges that none of the existing labels cover (likely future candidates: `search`, `i18n`, `accessibility`). The `capture-idea` skill proposes a new label in its report when nothing fits cleanly, and creates it on user confirmation. Don't multiply labels speculatively.
 
 ## The Project
 

--- a/scripts/setup-gh-project.sh
+++ b/scripts/setup-gh-project.sh
@@ -49,7 +49,7 @@ info "Reconciling labels in $ORG/$REPO..."
 EXISTING_LABELS=$(gh label list --repo "$ORG/$REPO" --limit 2000 --json name --jq '.[].name')
 
 # Delete labels that are no longer part of the taxonomy
-for label in "area:ui" "shadcn-cleanup" "tech-debt"; do
+for label in "area:ui" "shadcn-cleanup" "tech-debt" "db" "ui" "tauri" "docs"; do
   if echo "$EXISTING_LABELS" | grep -qx "$label"; then
     if gh label delete "$label" --repo "$ORG/$REPO" --yes; then
       ok "deleted label '$label'"
@@ -69,7 +69,20 @@ ensure_label() {
   ok "created label '$name'"
 }
 
-ensure_label "docs" "0075CA" "Documentation work"
+# Genealogy data domains
+ensure_label "individuals"      "0E8A16" "People, names, lifespan"
+ensure_label "families"         "196127" "Relationships, pedigree"
+ensure_label "events"           "5DC461" "Life events, dates, witnesses"
+ensure_label "places"           "0052CC" "Geography, locations"
+ensure_label "sources"          "1D76DB" "Sources, citations, repositories"
+ensure_label "media"            "5319E7" "Photos, scans, documents"
+ensure_label "gedcom"           "D93F0B" "Import/export GEDCOM"
+# Cross-cutting capability
+ensure_label "data-quality"     "FBCA04" "Completion, duplicates, validation"
+# Platform & meta
+ensure_label "tree-management"  "BFD4F2" "Tree lifecycle and storage"
+ensure_label "design-system"    "C5DEF5" "Storybook, wrappers, tokens"
+ensure_label "monetization"     "B60205" "Paid-tier ideas (Vata is open source and free)"
 ensure_label "good-first-issue" "7057FF" "Good for newcomers / small surface"
 
 ok "Labels reconciled"

--- a/scripts/setup-gh-project.sh
+++ b/scripts/setup-gh-project.sh
@@ -71,7 +71,7 @@ ensure_label() {
 
 # Genealogy data domains
 ensure_label "individuals"      "0E8A16" "People, names, lifespan"
-ensure_label "families"         "196127" "Relationships, pedigree"
+ensure_label "families"         "196127" "Spouse / parent / child links, pedigree"
 ensure_label "events"           "5DC461" "Life events, dates, witnesses"
 ensure_label "places"           "0052CC" "Geography, locations"
 ensure_label "sources"          "1D76DB" "Sources, citations, repositories"

--- a/scripts/setup-gh-project.sh
+++ b/scripts/setup-gh-project.sh
@@ -63,6 +63,8 @@ done
 ensure_label() {
   local name="$1" color="$2" desc="$3"
   if echo "$EXISTING_LABELS" | grep -qx "$name"; then
+    gh label edit "$name" --repo "$ORG/$REPO" --color "$color" --description "$desc" >/dev/null
+    ok "reconciled label '$name'"
     return 0
   fi
   gh label create "$name" --repo "$ORG/$REPO" --color "$color" --description "$desc"


### PR DESCRIPTION
## Summary

- Replace codebase-axis labels (`db`, `ui`, `tauri`, `docs`) with **11 product-axis labels** that name user-facing concepts: `individuals`, `families`, `events`, `places`, `sources`, `media`, `gedcom`, `data-quality`, `tree-management`, `design-system`, `monetization`. `good-first-issue` kept.
- Filter and triage now answer "what part of the product is this?" instead of "which folder of code touches this?".
- `monetization` is a single label collapsing the previous `billing` / `sync-and-backup` ideas — Vata is open source and free, these are aspirational ways to sustain the project.
- `capture-idea` skill updated to use the new taxonomy and to **propose a new label when nothing fits cleanly** (creates it on user confirmation, instead of silently dropping the label).
- All 14 previously-labelled issues were relabelled in place; the 4 deleted old labels held no orphaned data.
- Bootstrap script (`scripts/setup-gh-project.sh`) updated so a fresh checkout converges to the new taxonomy idempotently.

## Why

The old labels (`db`, `ui`, `tauri`, `docs`) described where in the codebase an issue lived. Only `gedcom` was actually useful because it named a clean product topic. Triage filters like "all issues touching places" or "all monetization ideas" were impossible. After migration, a triager can ask product questions of the backlog directly.

## Files

- `.claude/skills/capture-idea/SKILL.md` — new label table + propose-new-label branch
- `docs/dev-tools/issue-tracking.md` — labels section rewritten
- `scripts/setup-gh-project.sh` — delete-list and ensure-label calls updated

## Test plan

- [x] `gh label list` shows exactly 12 labels (11 product + `good-first-issue`)
- [x] Existing 14 labelled issues all carry a product label (`gh issue list --state all --json number,labels` verified)
- [x] Spot-check filtering: `gh issue list --label media` returns #74, #75; `gh issue list --label design-system` returns #55, #56, #57, #68, #69; `gh issue list --label monetization` returns #70, #71, #72
- [x] `pnpm review:all` (CodeRabbit local) — no findings
- [x] `/simplify` (3-agent local review) — only nit was a families description mismatch across the three files, fixed in fea1b16
- [ ] Re-run `bash scripts/setup-gh-project.sh` on a fresh shell to confirm idempotency on top of the migrated state (not blocking — script is read-then-mutate idempotent by construction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)