### PR TITLE
docs: require new branches/worktrees to start from up-to-date main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,19 @@ Before any edit on a new task, ask the user: **"simple branch or worktree?"** wi
 - Long task likely to span sessions or be interrupted
 - Need to keep `main` clean for parallel work
 
+## Step 1 — Sync `main`, then create the branch/worktree
+
+Every new branch and every new worktree MUST start from a `main` synced with `origin/main`. Exception: branch off something else only when the user explicitly says so; ask if unclear.
+
+From any branch, with a clean working tree:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+```
+
+If the working tree has uncommitted changes or `main` cannot fast-forward, stop and ask the user — never stash, reset, or discard their work to satisfy this rule.
+
 ### Simple branch mode
 
 ```bash
@@ -222,6 +235,8 @@ git checkout -b <type>/<short-desc>
 ### Worktree mode
 
 **ALWAYS use the `EnterWorktree` tool. NEVER use `git worktree add` via Bash. NEVER use the `superpowers:using-git-worktrees` skill** — its `git worktree add` approach bypasses the session lifecycle that `ExitWorktree` relies on.
+
+`EnterWorktree` branches from current `HEAD`, so call it with `main` checked out (the sync above guarantees this).
 
 ## Branch naming
 


### PR DESCRIPTION
## Summary

- Adds **Step 1** to the Git Workflow section of `CLAUDE.md`: every new branch and every new worktree must start from a `main` synced with `origin/main`, unless the user explicitly asks to branch off something else.
- Documents the sync commands (`git checkout main && git pull --ff-only origin main`) and the stop-rule for dirty working trees (ask the user — never stash/reset to satisfy the rule).
- Adds a one-liner under Worktree mode reminding that `EnterWorktree` branches from current `HEAD`, so `main` must be checked out before invoking it.

## Why

Avoid silently branching off a stale `main` and ending up with conflict noise on PRs.

## Pre-PR review

- `/simplify` — three-agent review run; redundant `git fetch`, redundant code-fence comment, verbose exception clause, and `git switch` inconsistency all addressed before commit.
- `pnpm review:all` (CodeRabbit local) — **No findings**.

## Test plan

- [ ] Read the new Step 1 in `CLAUDE.md` and confirm wording matches intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)