### PR TITLE
docs: app-structure spec — two-context model (picker outside vs in-tree shell)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,10 @@ pnpm vitest run src/db/trees/individuals.test.ts
 
 # Architecture
 
+## Two contexts: picker vs in-tree shell
+
+Vata is a single-tree-at-a-time desktop project editor (think VS Code / Logic Pro). The app has two contexts: the **outside picker** at URL `/`, and the **inside shell** at URL `/tree/$treeId/...`. The boundary is enforced by `src/routes/tree/$treeId.tsx`, which opens the tree DB on mount and closes it on unmount. Read [docs/architecture/app-structure.md](./docs/architecture/app-structure.md) before any work on routing, the home page, the tree shell, or anything that touches `openTreeDb` / `closeTreeDb` / `getTreeDb`.
+
 ## Tech Stack
 
 Tauri 2 (Rust shell) + React 18 + TypeScript + Vite + SQLite (`@tauri-apps/plugin-sql`). State: Zustand 4 (localStorage). Data fetching: TanStack Query v5. Routing: TanStack Router v1 (file-based). Tests: Vitest + jsdom.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Desktop application for managing genealogical trees. Local-first, GEDCOM 5.5.1 c
 
 ## Architecture
 
+- [App Structure](./architecture/app-structure.md) — Two-context model (picker outside vs in-tree shell), lifecycle, invariants for AI agents
 - [Overview](./architecture/overview.md) — Global architecture, layers, data flow, state management
 - [Database Schema](./architecture/database-schema.md) — Complete data model (system.db + tree.db)
 - [Data Flow](./architecture/data-flow.md) — Communication between layers (UI → Hooks → Managers → DB)

--- a/docs/architecture/app-structure.md
+++ b/docs/architecture/app-structure.md
@@ -12,7 +12,7 @@ Vata is in the spirit of desktop project editors like VS Code, Logic Pro, or Fin
 
 ## The Two Contexts
 
-```
+```text
 ┌────────────────────────────────────────────┐
 │  OUTSIDE  (URL: /)                         │
 │  Tree picker — pick / create / manage      │
@@ -86,7 +86,7 @@ Anything that breaks one of these breaks the contract.
 2. **Never bypass `TreeManager`** for tree-level operations (open / close / create / future rename / delete / duplicate / import / export). The manager keeps `closeTreeDb()` and the Zustand `currentTreeId` in sync.
 3. **Boot starts at `/`.** Do not add auto-resume of the last tree without an explicit decision (currently a non-goal).
 4. **One tree at a time.** Do not add tabs, multi-window, or background "open" of a second tree's DB.
-5. **The route `src/routes/tree/$treeId.tsx` owns the DB lifecycle.** Do not open or close the tree DB from page components, hooks, or managers triggered by them; trust the route layout.
+5. **Inside the tree shell, `src/routes/tree/$treeId.tsx` owns the DB lifecycle.** Do not open or close the tree DB from page components or hooks; trust the route layout. (`TreeManager` remains the authority for tree-level actions from the picker — see invariant 2.)
 6. **Never `SELECT *`** (general SQLite rule, particularly relevant when adding system-DB queries for picker stats — see `docs/architecture/database-schema.md`).
 
 ## Where to Look Next

--- a/docs/architecture/app-structure.md
+++ b/docs/architecture/app-structure.md
@@ -1,0 +1,101 @@
+# Application Structure
+
+> **TL;DR for AI agents.** Vata is a single-tree-at-a-time desktop project editor. The app has two **contexts**: an **outside** picker at URL `/` for choosing and managing tree files, and an **inside** shell at URL `/tree/$treeId/...` for working in one tree. The boundary is enforced by `src/routes/tree/$treeId.tsx`, which opens the tree database on mount and closes it on unmount. Never call `getTreeDb()` from an outside route — it throws.
+
+---
+
+## Mental Model
+
+Vata is in the spirit of desktop project editors like VS Code, Logic Pro, or Final Cut. A genealogical tree is a **project file** (a `.db` SQLite database, in a directory chosen by the user). The picker is a **transit screen**, not a destination — equivalent to a workspace launcher or "File > Open Recent". Once a tree is open, the entire app belongs to that one tree: routes, navigation, sidebars, command palette, native menu items all reflect a single context.
+
+**Single tree at a time.** No tabs, no multi-window. Closing returns to the picker so the user can pick another.
+
+## The Two Contexts
+
+```
+┌────────────────────────────────────────────┐
+│  OUTSIDE  (URL: /)                         │
+│  Tree picker — pick / create / manage      │
+│  No tree DB open                           │
+└──────────────┬─────────────────────────────┘
+               │ user opens a tree
+               ▼ (openTreeDb)
+┌────────────────────────────────────────────┐
+│  INSIDE  (URL: /tree/$treeId/...)          │
+│  In-tree shell — work in one tree          │
+│  Tree DB open; getTreeDb() works           │
+└──────────────┬─────────────────────────────┘
+               │ user closes the tree (⌘W or fallback)
+               ▼ (closeTreeDb)
+        Back to OUTSIDE
+```
+
+**Boot rule.** The app always starts on `/`. No auto-resume of the last-opened tree (deferred decision).
+
+## Outside: the Tree Picker
+
+**Role:** full lifecycle of trees as files — list, open, create, import GEDCOM, rename, delete, export, duplicate.
+
+**Where it lives:**
+
+- Route: `src/routes/index.tsx` → `src/pages/Home.tsx`
+- Manager: `src/managers/TreeManager.ts` — `open`, `close`, `create`. Extend here for new operations (rename / delete / duplicate / import / export).
+- System DB queries: `src/db/system/trees.ts`
+
+**UI specifics:** see [`docs/ui/screens/home.md`](../ui/screens/home.md) and the _Home Layout_ section of [`docs/ui/layouts.md`](../ui/layouts.md).
+
+## Inside: the In-Tree Shell
+
+**Role:** persistent workspace for one tree. Every route under `/tree/$treeId/...` lives in this context.
+
+**Where it lives:**
+
+- Layout route (the context boundary): `src/routes/tree/$treeId.tsx` — opens the DB before rendering children, closes it on unmount.
+- Tree dashboard (in-tree "home"): `src/pages/TreeView.tsx` — the landing page after opening, accessed via the Home icon in the top nav.
+- Entity routes under `src/routes/tree/$treeId/`: `individuals.tsx`, `families.tsx`, `sources.tsx`, `repositories.tsx`, `data.tsx`, plus detail routes (`individual/$individualId`, `family/$familyId`, `source/$sourceId`, `repository/$repositoryId`).
+- Tree DB queries: `src/db/trees/*`.
+- DB connection helpers: `src/db/connection.ts` — `getTreeDb()`, `isTreeDbOpen()`, `getCurrentTreePath()`.
+
+**UI specifics:** see the _Module Layout (Three-Panel)_ section of [`docs/ui/layouts.md`](../ui/layouts.md), plus per-screen docs in `docs/ui/screens/`.
+
+## Lifecycle
+
+### Open
+
+1. User clicks "Open" on a tree card in the picker.
+2. Router navigates to `/tree/$treeId/`.
+3. `src/routes/tree/$treeId.tsx` fetches the tree row from system DB, then calls `openTreeDb(tree.path)`.
+4. Children render (`<Outlet />`) once the DB is ready.
+5. When the open is initiated through `TreeManager.open(treeId)`, it also marks `last_opened_at` in system DB and updates the Zustand `currentTreeId`.
+
+### Close
+
+- **Primary (planned):** native macOS menu `File > Close Tree` (`⌘W`). When wired, the menu event maps to a router navigation back to `/` and to `closeTreeDb()`.
+- **Effect today:** when the layout route `src/routes/tree/$treeId.tsx` unmounts, its cleanup effect calls `closeTreeDb()`. So navigating away from `/tree/$treeId/...` already closes the tree DB correctly.
+- **Fallback affordance** (discrete, not first-class): location TBD during visual work — candidates include the command palette, a Settings menu item, or the tree-name area in the top nav.
+
+### Switch
+
+Not a separate operation. Switching to another tree = close (return to picker) + open (pick another). Maintains single-tree-at-a-time.
+
+## Invariants for AI Agents
+
+Anything that breaks one of these breaks the contract.
+
+1. **Never call `getTreeDb()` from an outside route.** It throws (`"No tree database is currently open"`). Code that reads tree data must live under `/tree/$treeId/...`.
+2. **Never bypass `TreeManager`** for tree-level operations (open / close / create / future rename / delete / duplicate / import / export). The manager keeps `closeTreeDb()` and the Zustand `currentTreeId` in sync.
+3. **Boot starts at `/`.** Do not add auto-resume of the last tree without an explicit decision (currently a non-goal).
+4. **One tree at a time.** Do not add tabs, multi-window, or background "open" of a second tree's DB.
+5. **The route `src/routes/tree/$treeId.tsx` owns the DB lifecycle.** Do not open or close the tree DB from page components, hooks, or managers triggered by them; trust the route layout.
+6. **Never `SELECT *`** (general SQLite rule, particularly relevant when adding system-DB queries for picker stats — see `docs/architecture/database-schema.md`).
+
+## Where to Look Next
+
+| Question                                                | Doc                                                                                                |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| What does each layout look like in detail?              | [`docs/ui/layouts.md`](../ui/layouts.md)                                                           |
+| What's in the picker / tree dashboard / module screens? | [`docs/ui/screens/`](../ui/screens/)                                                               |
+| How are layers connected (UI → Hooks → Manager → DB)?   | [`docs/architecture/overview.md`](./overview.md)                                                   |
+| What's in `system.db` vs `tree.db`?                     | [`docs/architecture/database-schema.md`](./database-schema.md)                                     |
+| What's the database CRUD contract?                      | [`docs/api/database-layer.md`](../api/database-layer.md)                                           |
+| Why two databases?                                      | [`docs/decisions/adr-003-database-architecture.md`](../decisions/adr-003-database-architecture.md) |

--- a/docs/ui/layouts.md
+++ b/docs/ui/layouts.md
@@ -4,6 +4,8 @@
 
 Définir les structures de layout réutilisables. L'app utilise une **barre de navigation en haut** combinée à un **layout trois panneaux** (sidebar / centre / aside) pour les modules d'entités, et un layout pleine largeur pour l'écran d'accueil.
 
+> The two layout modes below are the visual expression of the **two app contexts** (outside picker vs in-tree shell). For the architectural framing, lifecycle, and invariants, see [`docs/architecture/app-structure.md`](../architecture/app-structure.md).
+
 ---
 
 ## What We Display

--- a/src/db/connection.test.ts
+++ b/src/db/connection.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock Tauri plugins so importing connection.ts doesn't pull in native bindings.
+// These mocks are not exercised — they only need to satisfy the imports.
+vi.mock('@tauri-apps/plugin-sql', () => ({
+  default: {
+    load: vi.fn(),
+  },
+}));
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  mkdir: vi.fn(),
+  rename: vi.fn(),
+  exists: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/path', () => ({
+  appDataDir: vi.fn(),
+}));
+
+import { getTreeDb, closeTreeDb, isTreeDbOpen, getCurrentTreePath } from './connection';
+
+// These tests lock the no-tree-open contract documented in
+// docs/architecture/app-structure.md ("Invariants for AI Agents").
+// They guard against regressions where outside routes might silently get a
+// tree DB instead of an error, or where state leaks between contexts.
+describe('connection — no tree open invariants', () => {
+  it('reports no tree open in initial state', () => {
+    expect(isTreeDbOpen()).toBe(false);
+    expect(getCurrentTreePath()).toBeNull();
+  });
+
+  it('getTreeDb rejects when called outside an open tree context', async () => {
+    await expect(getTreeDb()).rejects.toThrow('No tree database is currently open');
+  });
+
+  it('closeTreeDb is a no-op when no tree is open', async () => {
+    await expect(closeTreeDb()).resolves.toBeUndefined();
+    expect(isTreeDbOpen()).toBe(false);
+    expect(getCurrentTreePath()).toBeNull();
+  });
+});

--- a/src/db/connection.test.ts
+++ b/src/db/connection.test.ts
@@ -1,21 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// Mock Tauri plugins so importing connection.ts doesn't pull in native bindings.
-// These mocks are not exercised — they only need to satisfy the imports.
 vi.mock('@tauri-apps/plugin-sql', () => ({
-  default: {
-    load: vi.fn(),
-  },
-}));
-
-vi.mock('@tauri-apps/plugin-fs', () => ({
-  mkdir: vi.fn(),
-  rename: vi.fn(),
-  exists: vi.fn(),
-}));
-
-vi.mock('@tauri-apps/api/path', () => ({
-  appDataDir: vi.fn(),
+  default: { load: vi.fn() },
 }));
 
 import { getTreeDb, closeTreeDb, isTreeDbOpen, getCurrentTreePath } from './connection';


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/app-structure.md`, a single-file primer that captures the **two-context mental model** agreed during brainstorming: an **outside picker** at `/` for choosing/managing trees, and an **inside shell** at `/tree/$treeId/...` for working in one tree. Includes lifecycle (open/close/boot), invariants for AI agents (e.g., "never call `getTreeDb()` from an outside route"), and pointers into existing layout/screen docs.
- Adds a top-of-Architecture link in `CLAUDE.md`, registers the new doc in `docs/README.md`, and adds a reverse pointer from `docs/ui/layouts.md` so the two existing layout modes are explicitly framed as the visual expression of the two contexts.
- Adds `src/db/connection.test.ts` to lock the no-tree-open contract (initial state, `getTreeDb()` rejects, `closeTreeDb()` is a no-op). These guard the invariants documented in the spec.

No production code changes; no schema changes.

## Test plan

- [x] `pnpm exec vitest run` — 567 tests pass (3 new)
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `docs-consistency` skill — cross-references verified, terminology aligned with `docs/ui/layouts.md`
- [x] `/simplify` (3-agent reuse / quality / efficiency review) — applied: dropped two unused `vi.mock` blocks. Skipped a stylistic-nit constant extraction
- [x] `pnpm review:all` (CodeRabbit local) — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)