### PR TITLE
feat: add design-system-expert agent and standards skill

### DIFF
--- a/.claude/agents/design-system-expert.md
+++ b/.claude/agents/design-system-expert.md
@@ -1,0 +1,137 @@
+---
+name: design-system-expert
+description: |
+  Use this agent when planning a new feature or page from a mockup (Pencil .pen file, screenshot/image, text description, or an existing route/page file), or when auditing the vata-app design system for duplication, dead components, and token drift. The agent identifies every UI element in the input, classifies each as reuse-as-is / extend-existing / create-new, names the underlying primitive (existing wrapper, Radix primitive, or shadcn registry item), and flags consolidation opportunities. Read-only — produces a structured component plan, never edits code. <example>Context: User opens a Pencil mockup of a new "Family detail" page and wants to plan the component work. user: "Here's the family page mockup — what do we reuse and what do we need to create?" assistant: "Let me dispatch the design-system-expert agent to analyse the mockup and produce a component plan." <commentary>The agent reads the .pen via Pencil MCP tools, walks the wrappers in src/components/ui/, and reports reuse / extend / create-new per element.</commentary></example> <example>Context: User wants to know if the DS has accumulated dead code. user: "Audit the design system — anything unused, anything we should consolidate?" assistant: "I'll dispatch design-system-expert in audit mode." <commentary>The agent greps imports across src/, lists usage counts, flags zero-import wrappers, and looks for duplicated tv() bases or repeated Radix compositions.</commentary></example>
+model: sonnet
+tools: Read, Glob, Grep, Bash, mcp__pencil__get_editor_state, mcp__pencil__batch_get, mcp__pencil__get_screenshot, mcp__pencil__get_guidelines, mcp__pencil__get_variables, mcp__pencil__search_all_unique_properties, mcp__pencil__snapshot_layout, mcp__pencil__export_nodes, mcp__pencil__find_empty_space_on_canvas, mcp__pencil__open_document
+---
+
+You are the Design System Expert for the Vata genealogy desktop app. Your job is to keep the UI built on a small, intentional set of components — by classifying every new UI need against the existing system before any wrapper is added or duplicated.
+
+You are read-only. You produce a structured component plan; the caller does the implementation.
+
+## When to use
+
+- Planning a feature/page from a Pencil `.pen` file (use the Pencil MCP tools)
+- Planning from a screenshot or image (use `Read` — multimodal)
+- Planning from a text description ("a profile header with avatar, name, two primary buttons…")
+- Reviewing an existing route/page file and proposing how it should map to the DS
+- Auditing the DS for duplication, dead components, and token drift (audit mode)
+
+## Mandatory first step
+
+Read these fresh, every invocation — the rules evolve and memory drifts:
+
+- `.claude/skills/design-system-standards/SKILL.md`
+- `.claude/skills/design-system-standards/checklist.md`
+
+Treat the SKILL.md as your decision tree and the checklist as the bar your report must clear.
+
+## Workflow
+
+### Step 1 — Ingest the input
+
+| Input form               | How to read it                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------------ |
+| Pencil `.pen` file       | `mcp__pencil__get_editor_state` first; then `mcp__pencil__batch_get` and `mcp__pencil__get_screenshot` |
+| Image (PNG, JPG, …)      | `Read` with the file path (multimodal)                                                                 |
+| Text description         | Already in the prompt — work from it                                                                   |
+| Existing route/page file | `Read` the file plus its imports                                                                       |
+| Audit mode (no input)    | Skip to Step 2; treat the whole `src/` tree as the input                                               |
+
+### Step 2 — Inventory the current design system
+
+Run in parallel (single message, multiple tool calls):
+
+- `Glob src/components/ui/*.tsx` — find every wrapper
+- For each wrapper, `Read` the file to extract: variants, sizes, props, JSDoc
+- `Read src/styles/app.css` to extract `@theme` tokens
+- `Grep` for imports of each wrapper across `src/` (informs reuse-first and dead-component judgements)
+
+Quote variant names verbatim from the `tv()` recipes — do not invent.
+
+### Step 3 — Classify each element
+
+For each UI element identified in Step 1, walk the SKILL.md decision tree top-down and pick the first step that fits:
+
+1. **Reuse as-is** — name the wrapper, variant, size, and any props
+2. **Extend existing** — name the wrapper and the precise change (new `tv()` variant value, new prop, new icon registry entry)
+3. **Compose existing** — describe the composition (no new file)
+4. **Create new** — name the proposed wrapper, the underlying Radix primitive or shadcn registry item, and a one-sentence justification of why nothing existing fits
+5. **Custom from scratch** — only when nothing in Radix or shadcn covers it; document why
+
+### Step 4 — Audit (always run a light pass; full pass in audit mode)
+
+- Spot duplicated `tv()` bases or repeated Radix compositions
+- Spot wrappers with zero imports across `src/`
+- Spot token drift: hardcoded `oklch`, hex, `rgb`, or `dark:` overrides outside `src/styles/`
+
+### Step 5 — Report
+
+Use the template below verbatim. Cite file paths and line numbers for every claim. Quote variants and tokens from the source — never paraphrase.
+
+## Report template
+
+```
+## Design System Plan
+
+### Input
+- [type: .pen / image / text / file / audit]
+- [path or short summary]
+
+### Components identified
+| # | Element in input | DS match | Classification | Reasoning |
+|---|---|---|---|---|
+| 1 | … | Button (primary, md) | Reuse-as-is | Standard CTA |
+| 2 | … | Avatar | Create-new | No existing wrapper; ≥2 uses planned |
+
+### Reuse as-is
+- **<Wrapper variant="…" size="…">** at <where in mockup>
+  - Props: <list>
+
+### Extend existing
+- **<Wrapper>** — add `<change>`
+  - Why props beat duplication: <reason>
+  - Files to touch: `src/components/ui/<name>.tsx`, `src/components/ui/<name>.stories.tsx`
+
+### Create new
+- **<ProposedWrapper>** — wraps <Radix primitive> / shadcn `<registry-item>` / custom
+  - Justification: <one sentence>
+  - API sketch: variants, sizes, props
+  - Companion files required: `<name>.tsx`, `<name>.stories.tsx` (with `play()` tests per `storybook-stories`)
+
+### Compose existing (inline in the page, no new file)
+- <description of composition>
+
+### Token usage
+- Covered by tokens: <list>
+- Drift / missing tokens: <list, with file:line>
+
+### DS health flags
+- Duplications spotted: <list>
+- Zero-import wrappers: <list>
+- Variants that should be props: <list>
+- Token drift: <file:line list>
+
+### Open questions
+- <anything you could not decide without user input>
+```
+
+## Hard rules
+
+- **Read-only.** No `Edit`, no `Write`. The agent file's `tools:` whitelist enforces this — never circumvent.
+- **No `class="…"` literal evidence.** Read variants from `tv()` recipes, tokens from `@theme`. If you can't find the source, say so in Open questions.
+- **Reuse first.** Creating a new wrapper requires a one-sentence justification of why no existing wrapper or extension fits.
+- **Props over variants over duplication.** If the same JSX appears 3+ times, propose a wrapper or a prop, not copy-paste.
+- **Quote, don't invent.** Radix primitive names, `tailwind-variants` patterns, shadcn registry items — quote them verbatim from the actual codebase or registry. Never invent a wrapper name and pretend it exists.
+- **Cite usage counts** with the actual `grep` output, not estimates.
+
+## What you must NOT do
+
+- Lecture on Tailwind basics, CSS-in-JS philosophy, or React fundamentals
+- Propose a component for one-off page chrome (the answer there is "compose existing")
+- Suggest renaming existing wrappers (out of scope; raise as Open question only)
+- Audit accessibility — that lives in `play()` tests + `testing-standards`
+- Touch i18n — that lives in the project's i18n rules
+- Touch component prop typing — that lives in `typescript-standards`
+- Run shadcn CLI commands that mutate the project (no `add`, no `apply`)

--- a/.claude/agents/design-system-expert.md
+++ b/.claude/agents/design-system-expert.md
@@ -3,7 +3,7 @@ name: design-system-expert
 description: |
   Use this agent when planning a new feature or page from a mockup (Pencil .pen file, screenshot/image, text description, or an existing route/page file), or when auditing the vata-app design system for duplication, dead components, and token drift. The agent identifies every UI element in the input, classifies each as reuse-as-is / extend-existing / create-new, names the underlying primitive (existing wrapper, Radix primitive, or shadcn registry item), and flags consolidation opportunities. Read-only — produces a structured component plan, never edits code. <example>Context: User opens a Pencil mockup of a new "Family detail" page and wants to plan the component work. user: "Here's the family page mockup — what do we reuse and what do we need to create?" assistant: "Let me dispatch the design-system-expert agent to analyse the mockup and produce a component plan." <commentary>The agent reads the .pen via Pencil MCP tools, walks the wrappers in src/components/ui/, and reports reuse / extend / create-new per element.</commentary></example> <example>Context: User wants to know if the DS has accumulated dead code. user: "Audit the design system — anything unused, anything we should consolidate?" assistant: "I'll dispatch design-system-expert in audit mode." <commentary>The agent greps imports across src/, lists usage counts, flags zero-import wrappers, and looks for duplicated tv() bases or repeated Radix compositions.</commentary></example>
 model: sonnet
-tools: Read, Glob, Grep, Bash, mcp__pencil__get_editor_state, mcp__pencil__batch_get, mcp__pencil__get_screenshot, mcp__pencil__get_guidelines, mcp__pencil__get_variables, mcp__pencil__search_all_unique_properties, mcp__pencil__snapshot_layout, mcp__pencil__export_nodes, mcp__pencil__find_empty_space_on_canvas, mcp__pencil__open_document
+tools: Read, Glob, Grep, Bash, mcp__pencil__get_editor_state, mcp__pencil__batch_get, mcp__pencil__get_screenshot, mcp__pencil__snapshot_layout, mcp__pencil__search_all_unique_properties
 ---
 
 You are the Design System Expert for the Vata genealogy desktop app. Your job is to keep the UI built on a small, intentional set of components — by classifying every new UI need against the existing system before any wrapper is added or duplicated.
@@ -41,30 +41,24 @@ Treat the SKILL.md as your decision tree and the checklist as the bar your repor
 
 ### Step 2 — Inventory the current design system
 
-Run in parallel (single message, multiple tool calls):
+Run in parallel (single message, multiple tool calls). Prefer `rg`/`Grep` over `Read` for whole files — only `Read` a wrapper when grep is ambiguous:
 
-- `Glob src/components/ui/*.tsx` — find every wrapper
-- For each wrapper, `Read` the file to extract: variants, sizes, props, JSDoc
-- `Read src/styles/app.css` to extract `@theme` tokens
-- `Grep` for imports of each wrapper across `src/` (informs reuse-first and dead-component judgements)
+- `Glob src/components/ui/*.tsx` — list every wrapper file
+- `rg -n "tv\(|variants:|defaultVariants" src/components/ui/` — extract recipes/axes
+- `rg -n "^export (interface|type|const|function)" src/components/ui/` — extract public API surface
+- `rg -n "^\s*--(color|radius|font|spacing)" src/styles/app.css` — list live tokens
+- For each wrapper, `Grep` imports across `src/` (informs reuse-first and dead-component judgements) — see SKILL.md "Dead components" for the exact command
 
-Quote variant names verbatim from the `tv()` recipes — do not invent.
+Quote variant names verbatim from the `tv()` recipes — do not invent. If grep output is ambiguous (e.g. compound variants), `Read` the specific wrapper.
 
 ### Step 3 — Classify each element
 
-For each UI element identified in Step 1, walk the SKILL.md decision tree top-down and pick the first step that fits:
-
-1. **Reuse as-is** — name the wrapper, variant, size, and any props
-2. **Extend existing** — name the wrapper and the precise change (new `tv()` variant value, new prop, new icon registry entry)
-3. **Compose existing** — describe the composition (no new file)
-4. **Create new** — name the proposed wrapper, the underlying Radix primitive or shadcn registry item, and a one-sentence justification of why nothing existing fits
-5. **Custom from scratch** — only when nothing in Radix or shadcn covers it; document why
+Walk the SKILL.md decision tree top-down for each element identified in Step 1; the first matching step wins. Record: classification (reuse / extend / compose / create-new / custom), the named wrapper or primitive, and a one-sentence justification.
 
 ### Step 4 — Audit (always run a light pass; full pass in audit mode)
 
-- Spot duplicated `tv()` bases or repeated Radix compositions
-- Spot wrappers with zero imports across `src/`
-- Spot token drift: hardcoded `oklch`, hex, `rgb`, or `dark:` overrides outside `src/styles/`
+- **Light pass** (always): dead-component grep + token-drift grep, both per the SKILL.md "Audit heuristics" commands
+- **Full pass** (audit mode only): also scan for duplicated `tv()` bases and repeated Radix compositions across `src/components`, `src/pages`, `src/routes`
 
 ### Step 5 — Report
 
@@ -119,19 +113,20 @@ Use the template below verbatim. Cite file paths and line numbers for every clai
 
 ## Hard rules
 
-- **Read-only.** No `Edit`, no `Write`. The agent file's `tools:` whitelist enforces this — never circumvent.
-- **No `class="…"` literal evidence.** Read variants from `tv()` recipes, tokens from `@theme`. If you can't find the source, say so in Open questions.
+- **Read-only.** The frontmatter `tools:` whitelist excludes `Edit` / `Write` / shadcn CLI mutations — never circumvent.
 - **Reuse first.** Creating a new wrapper requires a one-sentence justification of why no existing wrapper or extension fits.
 - **Props over variants over duplication.** If the same JSX appears 3+ times, propose a wrapper or a prop, not copy-paste.
-- **Quote, don't invent.** Radix primitive names, `tailwind-variants` patterns, shadcn registry items — quote them verbatim from the actual codebase or registry. Never invent a wrapper name and pretend it exists.
-- **Cite usage counts** with the actual `grep` output, not estimates.
+- **Quote, don't invent.** Radix primitive names, `tailwind-variants` patterns, shadcn registry items, wrapper variant values — quote them verbatim from grep output. Never name a wrapper that the inventory grep did not find.
+- **Cite usage counts** with the actual `rg`/`grep` output, not estimates.
+- **Output only the report template.** No prose tutorials on Tailwind, CSS, or React.
+- **In API sketches, mark user-facing labels as `t('...')`** — Vata is i18n-strict; never propose hardcoded UI strings.
 
-## What you must NOT do
+## Out of scope
 
-- Lecture on Tailwind basics, CSS-in-JS philosophy, or React fundamentals
-- Propose a component for one-off page chrome (the answer there is "compose existing")
-- Suggest renaming existing wrappers (out of scope; raise as Open question only)
-- Audit accessibility — that lives in `play()` tests + `testing-standards`
-- Touch i18n — that lives in the project's i18n rules
-- Touch component prop typing — that lives in `typescript-standards`
-- Run shadcn CLI commands that mutate the project (no `add`, no `apply`)
+These are owned by other skills/agents — do not duplicate their work:
+
+- Accessibility audits → `play()` tests in `*.stories.tsx` + `testing-standards`
+- i18n string review → project i18n rules
+- Component prop typing → `typescript-standards`
+- Storybook story shape → `storybook-stories`
+- Renaming existing wrappers → raise as Open question only

--- a/.claude/skills/design-system-standards/SKILL.md
+++ b/.claude/skills/design-system-standards/SKILL.md
@@ -26,13 +26,13 @@ For any UI element a mockup or feature requires, walk this tree top-down. Stop a
 
 Pick this when the wrapper already covers the need with its current props/variants. Always cite the variant + size you'd use.
 
-Existing wrappers and their variants (verify against the source — this list rots):
+Discover the live wrapper inventory at runtime — never quote variants from this skill, the source rots:
 
-| Wrapper | Variants                                              | Sizes        | Notes                                                                              |
-| ------- | ----------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------- |
-| Button  | primary, secondary, outline, ghost, destructive, link | sm, md, lg   | `leadingIcon`, `trailingIcon`, `hideLabel`, `asChild` (incompatible with icons)    |
-| Input   | state: default, error                                 | sm, md, lg   | text-shaped only (text, email, url, tel, search, password). `invalid` shortcut     |
-| Icon    | curated registry (`IconName`)                         | numeric size | `aria-hidden` defaults to true; pass `aria-label` + `aria-hidden={false}` for solo |
+```bash
+ls src/components/ui/*.tsx                                 # wrapper names
+rg -n "tv\(|variants:|defaultVariants" src/components/ui/  # recipes & axes
+rg -n "^export (interface|type|const|function)" src/components/ui/  # public API
+```
 
 ### 2. Extend an existing wrapper
 
@@ -70,19 +70,15 @@ Only when nothing in Radix or shadcn covers the need. Document why in JSDoc on t
 
 ## Token usage
 
-Every visible value (color, radius, font, spacing) should map to a `@theme` token in `src/styles/app.css`. The token catalogue:
+Every visible value (color, radius, font, spacing) should map to a `@theme` token in `src/styles/app.css`. Read the live token list at runtime — do not quote tokens from this skill:
 
-- **Colors:** `background`, `foreground`, `card`, `card-foreground`, `primary`, `primary-foreground`, `secondary`, `secondary-foreground`, `muted`, `muted-foreground`, `accent`, `accent-foreground`, `destructive`, `destructive-foreground`, `border`, `input`, `ring`. Use Tailwind utility names: `bg-primary`, `text-muted-foreground`, etc.
-- **Radii:** `--radius` (0.5rem base), `--radius-sm`, `--radius-md`, `--radius-lg`, `--radius-xl`. Use `rounded-md`, `rounded-lg`, etc.
-- **Font:** `--font-sans` (Geist) — applied globally, no per-component override
-- **Dark mode:** swapped via `.dark` class or `prefers-color-scheme: dark`. Never write `dark:bg-…` overrides — use semantic tokens that already swap.
+```bash
+rg -n "^\s*--(color|radius|font|spacing)" src/styles/app.css
+```
 
-**Drift signals to flag:**
+Use Tailwind utility names that map to those CSS variables (`bg-primary`, `text-muted-foreground`, `rounded-md`, …). Never hand-write `dark:` overrides — semantic tokens swap automatically via the `.dark` class and `prefers-color-scheme`.
 
-- Hardcoded `oklch(...)`, `#hex`, `rgb(...)` in JSX or component recipes
-- Hardcoded pixel sizes for radii or spacing where a token exists
-- `dark:` utility prefixes overriding semantic tokens
-- Raw Tailwind palette utilities for status (`bg-blue-500`, `text-emerald-600`) instead of semantic tokens or `Badge`-style components
+For the canonical visual specification (gender colors, type scale, motion curves), see `docs/ui/design-system.md`. Drift rules (no hardcoded `oklch`/hex/rgb, no raw palette utilities for status, no `dark:` overrides) are enumerated in `.claude/skills/shadcn/SKILL.md` Styling rules — flag those when they appear outside `src/styles/`.
 
 ## Variants vs duplication
 
@@ -101,7 +97,14 @@ Run when invoked in audit mode, or when something stands out during normal revie
 
 ### Dead components
 
-A wrapper is dead if `grep -r "from '\$components/ui/<name>'" src/` returns zero hits across `src/` (excluding the wrapper's own story and any test scaffolding). Confirm by also checking imports via the bare name (`import { Foo }`) and by alias variants.
+A wrapper is dead if no file under `src/` (excluding its own `*.stories.tsx` and `*.test.tsx`) imports it. Run for each wrapper `<name>`:
+
+```bash
+rg -n "from ['\"]\\\$(components|/components)/ui/<name>['\"]" src/ \
+  --glob '!**/*.stories.tsx' --glob '!**/*.test.tsx'
+```
+
+Also grep for the bare exported symbol (e.g. `\bButton\b`) to catch direct re-exports through index files.
 
 ### Duplication
 
@@ -113,28 +116,33 @@ Three signals to grep for, in priority order:
 
 ### Token drift
 
-Ripgrep these patterns under `src/components/**`, `src/pages/**`, `src/routes/**`:
+Ripgrep these patterns, scoped to source and skipping fixtures, tests, stories, and GEDCOM byte literals:
 
-- `oklch\(`, `rgb\(`, `rgba\(` outside `src/styles/`
-- `#[0-9a-fA-F]{3,8}\b` outside `src/styles/` (skip imports and comments)
-- `\bdark:(bg|text|border)-` — dark-mode overrides should be unnecessary if semantic tokens are used
+```bash
+rg -n "oklch\(|rgb\(|rgba\(|#[0-9a-fA-F]{3,8}\b" \
+  src/components src/pages src/routes \
+  --glob '!**/*.stories.tsx' --glob '!**/*.test.tsx' \
+  --glob '!src/lib/gedcom/**' --glob '!src/styles/**'
+
+rg -n "\bdark:(bg|text|border|ring)-" src/components src/pages src/routes
+```
 
 ## Pen-to-code mapping
 
-When the input is a Pencil `.pen` file, common node types map to vata-app primitives like this:
+When the input is a Pencil `.pen` file, map nodes to existing wrappers (discovered via the runtime grep above) before considering new ones:
 
-| Pencil node                  | Likely vata primitive                                                       |
-| ---------------------------- | --------------------------------------------------------------------------- |
-| Frame with background fill   | `Card`-style wrapper (when one exists), else `<div>` with semantic bg token |
-| Stack (vertical/horizontal)  | `<div className="flex flex-col gap-N">` / `flex-row`                        |
-| Text (display / headings)    | semantic heading element with type-scale class                              |
-| Text (body)                  | bare text in `text-foreground` / `text-muted-foreground`                    |
-| Image (avatar-shaped)        | dedicated `Avatar` wrapper (create if ≥2 uses)                              |
-| Vector / glyph / icon        | `Icon` from the curated registry — flag if missing                          |
-| Button / interactive element | `Button` with the right variant                                             |
-| Input field                  | `Input` (or its future `Textarea` / `Select` siblings)                      |
+| Pencil node                    | Mapping                                                                                            |
+| ------------------------------ | -------------------------------------------------------------------------------------------------- |
+| Button / interactive element   | Existing `Button` wrapper if found — pick the variant; else propose extension                      |
+| Input field (text-shaped)      | Existing `Input` wrapper if found — pick the size and `invalid` if errored; else propose extension |
+| Vector / glyph / icon          | Existing `Icon` wrapper if the glyph is in its registry; flag as registry-extension if missing     |
+| Frame with background fill     | If a card-style wrapper exists, use it; else compose inline with semantic bg token                 |
+| Stack (vertical / horizontal)  | Inline `<div className="flex flex-col gap-N">` / `flex-row gap-N`; never a new wrapper             |
+| Text (display / headings)      | Semantic heading element with the type-scale class from `docs/ui/design-system.md`                 |
+| Text (body)                    | Bare text using `text-foreground` / `text-muted-foreground`                                        |
+| Image (avatar-shaped, ≥2 uses) | Propose a new `Avatar` wrapper (no existing one); justify and pair with story + `play()` test      |
 
-Always map verbatim — don't invent new vocabulary that doesn't exist in this skill or in `src/components/ui/`.
+Quote real wrapper names from the live `src/components/ui/` listing — never name a wrapper that the inventory grep did not find.
 
 ## Out of scope for this skill
 

--- a/.claude/skills/design-system-standards/SKILL.md
+++ b/.claude/skills/design-system-standards/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: design-system-standards
+description: Conventions for vata-app's design system — when to reuse an existing wrapper, when to extend it, when to compose Radix primitives directly, when to add a new wrapper under src/components/ui/, when to drop to raw Tailwind. Token usage rules. Audit heuristics for spotting duplication, dead components, and token drift. Use when designing or reviewing UI under src/components/ui/, src/pages/**, or src/components/**.
+---
+
+# Design System Standards — Vata
+
+Vata's UI is built on a small, intentional set of tokenised wrappers. The point of this skill is to keep it that way: every new component should justify its existence, and every duplication should be challenged before it spreads.
+
+## Source-of-truth files
+
+Read these first when applying this skill:
+
+- `src/components/ui/` — every wrapper currently shipping (`button.tsx`, `input.tsx`, `icon.tsx` today)
+- `src/styles/app.css` — `@theme` tokens (colors, radii, font)
+- `docs/ui/design-system.md` — DS philosophy, token reference, gender + semantic colors
+- `docs/ui/storybook.md` — story conventions; any new wrapper needs a colocated `<name>.stories.tsx` with `play()` tests
+- `.claude/skills/storybook-stories/SKILL.md` — story rules for new wrappers
+- `.claude/skills/shadcn/SKILL.md` — registry rules; check before proposing custom-from-scratch
+
+## Decision tree
+
+For any UI element a mockup or feature requires, walk this tree top-down. Stop at the first step that fits.
+
+### 1. Reuse an existing wrapper as-is
+
+Pick this when the wrapper already covers the need with its current props/variants. Always cite the variant + size you'd use.
+
+Existing wrappers and their variants (verify against the source — this list rots):
+
+| Wrapper | Variants                                              | Sizes        | Notes                                                                              |
+| ------- | ----------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------- |
+| Button  | primary, secondary, outline, ghost, destructive, link | sm, md, lg   | `leadingIcon`, `trailingIcon`, `hideLabel`, `asChild` (incompatible with icons)    |
+| Input   | state: default, error                                 | sm, md, lg   | text-shaped only (text, email, url, tel, search, password). `invalid` shortcut     |
+| Icon    | curated registry (`IconName`)                         | numeric size | `aria-hidden` defaults to true; pass `aria-label` + `aria-hidden={false}` for solo |
+
+### 2. Extend an existing wrapper
+
+Pick this when the new need is a variation (color, size, slot, state) of an existing wrapper. The fix is usually:
+
+- Add a `tv()` variant value (e.g., `variant: { ..., success: '...' }`)
+- Add a new prop with a documented purpose
+- Add an entry to a curated registry (e.g., a new icon in `iconRegistry`)
+
+**Hard rule:** if you find yourself copying a wrapper into a new file just to change a color or a size, stop — extend the original instead.
+
+### 3. Compose existing wrappers (no new file)
+
+Pick this when the need is a layout of known atoms — e.g., a profile header is `Avatar` + heading + `Button` row. Build it inline in the page or feature directory. Do **not** create a new wrapper unless the same composition is reused in ≥2 places.
+
+### 4. Add a new wrapper under `src/components/ui/`
+
+Pick this when:
+
+- ≥2 places need the same composition or restricted API, **or**
+- Project-specific defaults must be enforced (like `Icon` restricting to a curated registry, `Input` restricting to text-shaped types), **or**
+- There are variants worth tracking centrally (size, intent, state)
+
+Before creating, check the shadcn registry: `npx shadcn@latest search <keyword>`. If a registry component fits, install it via `npx shadcn@latest add` (per the `shadcn` skill) rather than rolling a custom wrapper.
+
+A new wrapper requires, in the same commit:
+
+- The wrapper file `<name>.tsx` with rich JSDoc on the component and its props
+- A colocated `<name>.stories.tsx` with one story per variant, a matrix story, and `play()` tests (per `storybook-stories`)
+- No separate `<name>.test.tsx` — `play()` is the test
+
+### 5. Custom from scratch (rare)
+
+Only when nothing in Radix or shadcn covers the need. Document why in JSDoc on the component.
+
+## Token usage
+
+Every visible value (color, radius, font, spacing) should map to a `@theme` token in `src/styles/app.css`. The token catalogue:
+
+- **Colors:** `background`, `foreground`, `card`, `card-foreground`, `primary`, `primary-foreground`, `secondary`, `secondary-foreground`, `muted`, `muted-foreground`, `accent`, `accent-foreground`, `destructive`, `destructive-foreground`, `border`, `input`, `ring`. Use Tailwind utility names: `bg-primary`, `text-muted-foreground`, etc.
+- **Radii:** `--radius` (0.5rem base), `--radius-sm`, `--radius-md`, `--radius-lg`, `--radius-xl`. Use `rounded-md`, `rounded-lg`, etc.
+- **Font:** `--font-sans` (Geist) — applied globally, no per-component override
+- **Dark mode:** swapped via `.dark` class or `prefers-color-scheme: dark`. Never write `dark:bg-…` overrides — use semantic tokens that already swap.
+
+**Drift signals to flag:**
+
+- Hardcoded `oklch(...)`, `#hex`, `rgb(...)` in JSX or component recipes
+- Hardcoded pixel sizes for radii or spacing where a token exists
+- `dark:` utility prefixes overriding semantic tokens
+- Raw Tailwind palette utilities for status (`bg-blue-500`, `text-emerald-600`) instead of semantic tokens or `Badge`-style components
+
+## Variants vs duplication
+
+Two near-identical wrappers that differ only by color/size/state are a smell — they should be one wrapper with a variant.
+
+Quick rule:
+
+- 0 differences besides class names → consolidate immediately
+- 1 axis of variation → `variants: { axis: { … } }` in the recipe
+- 2+ axes → compound variants in `tv()`
+- Behavior diverges (different DOM shape, different a11y semantics, different children contract) → keep separate
+
+## Audit heuristics
+
+Run when invoked in audit mode, or when something stands out during normal review.
+
+### Dead components
+
+A wrapper is dead if `grep -r "from '\$components/ui/<name>'" src/` returns zero hits across `src/` (excluding the wrapper's own story and any test scaffolding). Confirm by also checking imports via the bare name (`import { Foo }`) and by alias variants.
+
+### Duplication
+
+Three signals to grep for, in priority order:
+
+1. **Same `tv()` base array repeated** in two component files — almost always a missed wrapper opportunity
+2. **Same Radix primitive composition** (e.g., `Dialog.Root` + `Dialog.Trigger` + `Dialog.Content` skeleton) appearing in 3+ pages without a wrapper
+3. **Same JSX shape** (an avatar circle, a status badge, a stat card) inlined in 3+ places
+
+### Token drift
+
+Ripgrep these patterns under `src/components/**`, `src/pages/**`, `src/routes/**`:
+
+- `oklch\(`, `rgb\(`, `rgba\(` outside `src/styles/`
+- `#[0-9a-fA-F]{3,8}\b` outside `src/styles/` (skip imports and comments)
+- `\bdark:(bg|text|border)-` — dark-mode overrides should be unnecessary if semantic tokens are used
+
+## Pen-to-code mapping
+
+When the input is a Pencil `.pen` file, common node types map to vata-app primitives like this:
+
+| Pencil node                  | Likely vata primitive                                                       |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| Frame with background fill   | `Card`-style wrapper (when one exists), else `<div>` with semantic bg token |
+| Stack (vertical/horizontal)  | `<div className="flex flex-col gap-N">` / `flex-row`                        |
+| Text (display / headings)    | semantic heading element with type-scale class                              |
+| Text (body)                  | bare text in `text-foreground` / `text-muted-foreground`                    |
+| Image (avatar-shaped)        | dedicated `Avatar` wrapper (create if ≥2 uses)                              |
+| Vector / glyph / icon        | `Icon` from the curated registry — flag if missing                          |
+| Button / interactive element | `Button` with the right variant                                             |
+| Input field                  | `Input` (or its future `Textarea` / `Select` siblings)                      |
+
+Always map verbatim — don't invent new vocabulary that doesn't exist in this skill or in `src/components/ui/`.
+
+## Out of scope for this skill
+
+- Accessibility audits (use the play() tests in `.stories.tsx` and the `testing-standards` skill)
+- i18n string review (`react-i18next` and the project's i18n rules cover that)
+- Type-level review of component props (covered by `typescript-standards`)
+- Storybook story shape (covered by `storybook-stories`)
+- shadcn CLI usage (covered by the `shadcn` skill)

--- a/.claude/skills/design-system-standards/checklist.md
+++ b/.claude/skills/design-system-standards/checklist.md
@@ -14,11 +14,8 @@ Walk this checklist for every UI element identified in a mockup, page, or audit 
 
 ## Token usage
 
-- [ ] Every visible color in the input maps to a semantic token (`bg-primary`, `text-muted-foreground`, …)
-- [ ] No hardcoded `oklch(...)`, `#hex`, `rgb(...)` proposed in JSX
-- [ ] Every radius maps to `rounded-{sm,md,lg,xl}` / `--radius*`
-- [ ] No `dark:` overrides proposed — semantic tokens swap automatically
-- [ ] Status colors use `Badge`/`Alert`/destructive variants, not raw palette utilities
+- [ ] Every visible value (color, radius, font) maps to a `@theme` token from `src/styles/app.css`
+- [ ] All token-drift rules from `.claude/skills/shadcn/SKILL.md` Styling rules satisfied (no raw `oklch`/hex/rgb outside `src/styles/`, no `dark:` overrides, no raw palette utilities for status)
 
 ## Variant hygiene
 
@@ -36,7 +33,8 @@ Walk this checklist for every UI element identified in a mockup, page, or audit 
 
 ## Report quality
 
-- [ ] Every claim cites a file path; usage counts come from real `grep` output
+- [ ] Every claim cites a file path; usage counts come from real `rg`/`grep` output
 - [ ] Variants and sizes named are quoted from the actual `tv()` recipe, not guessed
-- [ ] No new component proposed without naming the underlying Radix primitive or shadcn registry item (or explicit "custom from scratch + reason")
+- [ ] When proposing a new wrapper, named the underlying Radix primitive or shadcn registry item
+- [ ] When the answer is "custom from scratch", provided an explicit one-sentence reason
 - [ ] Open questions section lists everything the agent could not decide alone

--- a/.claude/skills/design-system-standards/checklist.md
+++ b/.claude/skills/design-system-standards/checklist.md
@@ -1,0 +1,42 @@
+# Design System Review Checklist
+
+Walk this checklist for every UI element identified in a mockup, page, or audit pass.
+
+## Per-component classification
+
+- [ ] Listed every distinct UI element in the input (button, input, icon, avatar, card, list row, …)
+- [ ] For each element, identified the matching wrapper in `src/components/ui/` (or "none")
+- [ ] When a wrapper matches, named the exact `variant` and `size` that fit
+- [ ] When close-but-not-exact, decided whether a new `tv()` variant or prop covers it (extend) vs a new wrapper (create)
+- [ ] When proposing a new wrapper, checked the shadcn registry first (`npx shadcn@latest search <keyword>`)
+- [ ] When proposing a new wrapper, justified in one sentence why no existing wrapper or extension fits
+- [ ] Flagged any "compose-only" cases where a layout reuses existing atoms — no new file
+
+## Token usage
+
+- [ ] Every visible color in the input maps to a semantic token (`bg-primary`, `text-muted-foreground`, …)
+- [ ] No hardcoded `oklch(...)`, `#hex`, `rgb(...)` proposed in JSX
+- [ ] Every radius maps to `rounded-{sm,md,lg,xl}` / `--radius*`
+- [ ] No `dark:` overrides proposed — semantic tokens swap automatically
+- [ ] Status colors use `Badge`/`Alert`/destructive variants, not raw palette utilities
+
+## Variant hygiene
+
+- [ ] No two proposed components differ only by color/size/state (consolidate into a variant)
+- [ ] Existing wrapper variants reused before adding new ones
+- [ ] If extending an existing wrapper, the new variant has a clear semantic name (intent-based, not hex-based)
+
+## Audit-mode checks (when invoked for DS health)
+
+- [ ] Each wrapper in `src/components/ui/` has at least one import in `src/` (excluding its story / test files)
+- [ ] No `tv()` base array repeated across files
+- [ ] No Radix primitive composition repeated in 3+ places without a wrapper
+- [ ] No token drift in `src/components/**`, `src/pages/**`, `src/routes/**` (no raw `oklch`, hex, rgb outside `src/styles/`)
+- [ ] Storybook story exists and is current for every wrapper
+
+## Report quality
+
+- [ ] Every claim cites a file path; usage counts come from real `grep` output
+- [ ] Variants and sizes named are quoted from the actual `tv()` recipe, not guessed
+- [ ] No new component proposed without naming the underlying Radix primitive or shadcn registry item (or explicit "custom from scratch + reason")
+- [ ] Open questions section lists everything the agent could not decide alone

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,17 +313,18 @@ The app includes `tauri-plugin-mcp-bridge` (debug builds only). You can launch t
 
 The following specialized skills are loaded automatically when relevant, or on demand via the skill tool.
 
-| Skill                  | Trigger                                                                                                               |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `sqlite-standards`     | When writing `src/db/**`, SQL queries, migrations, or DB-related docs                                                 |
-| `gedcom-standards`     | When writing `src/lib/gedcom/**`, GEDCOM docs, or XREF/tag code                                                       |
-| `docs-consistency`     | After any change to `docs/*.md`                                                                                       |
-| `typescript-standards` | When writing `src/**/*.{ts,tsx}` (components, hooks, managers, store, routes)                                         |
-| `tauri-standards`      | When writing `src-tauri/**/*.rs` or `tauri.conf.json`                                                                 |
-| `testing-standards`    | When writing `**/*.{test,spec}.{ts,tsx}` or setting up test infrastructure                                            |
-| `db-layer`             | When creating a new entity's DB operations in `src/db/trees/`                                                         |
-| `new-route`            | When adding a new page or entity view under `/tree/$treeId/`                                                          |
-| `storybook-stories`    | When touching anything under `src/components/ui/` (wrappers + their `*.stories.tsx`) or any `*.stories.tsx` elsewhere |
+| Skill                     | Trigger                                                                                                                                                                          |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sqlite-standards`        | When writing `src/db/**`, SQL queries, migrations, or DB-related docs                                                                                                            |
+| `gedcom-standards`        | When writing `src/lib/gedcom/**`, GEDCOM docs, or XREF/tag code                                                                                                                  |
+| `docs-consistency`        | After any change to `docs/*.md`                                                                                                                                                  |
+| `typescript-standards`    | When writing `src/**/*.{ts,tsx}` (components, hooks, managers, store, routes)                                                                                                    |
+| `tauri-standards`         | When writing `src-tauri/**/*.rs` or `tauri.conf.json`                                                                                                                            |
+| `testing-standards`       | When writing `**/*.{test,spec}.{ts,tsx}` or setting up test infrastructure                                                                                                       |
+| `db-layer`                | When creating a new entity's DB operations in `src/db/trees/`                                                                                                                    |
+| `new-route`               | When adding a new page or entity view under `/tree/$treeId/`                                                                                                                     |
+| `storybook-stories`       | When touching anything under `src/components/ui/` (wrappers + their `*.stories.tsx`) or any `*.stories.tsx` elsewhere                                                            |
+| `design-system-standards` | When designing or reviewing UI under `src/components/ui/`, `src/components/**`, or `src/pages/**` — decision tree for reuse / extend / create-new, token rules, audit heuristics |
 
 The UI layer is built on Tailwind v4 (CSS-first via `@theme` in `src/styles/app.css`) + Radix primitives + `tailwind-variants`. Wrappers live under `src/components/ui/` with colocated tests and Storybook stories. See `docs/ui/design-system.md` and `docs/ui/storybook.md`.
 
@@ -333,8 +334,9 @@ The UI layer is built on Tailwind v4 (CSS-first via `@theme` in `src/styles/app.
 
 The following agents can be dispatched as sub-agents for autonomous tasks.
 
-| Agent              | When to Dispatch                                                             |
-| ------------------ | ---------------------------------------------------------------------------- |
-| `docs-consistency` | After any change to `docs/*.md` — validates cross-references and consistency |
-| `code-reviewer`    | After implementing a feature — reviews code against project standards        |
-| `test-writer`      | Before implementing a feature — writes behavioral tests (TDD red phase)      |
+| Agent                  | When to Dispatch                                                                                                                                     |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `docs-consistency`     | After any change to `docs/*.md` — validates cross-references and consistency                                                                         |
+| `code-reviewer`        | After implementing a feature — reviews code against project standards                                                                                |
+| `test-writer`          | Before implementing a feature — writes behavioral tests (TDD red phase)                                                                              |
+| `design-system-expert` | When planning a feature/page from a mockup (Pencil `.pen`, image, text, route file), or when auditing the DS for duplication, dead components, drift |


### PR DESCRIPTION
## Summary

- Adds `design-system-standards` skill: decision tree (reuse / extend / compose / create-new / custom), runtime grep recipes for the live wrapper inventory, audit heuristics for dead components, duplication, and token drift.
- Adds `design-system-expert` subagent: ingests a Pencil `.pen` file, image, text spec, or existing route file, classifies every UI element against the live DS, and produces a structured component plan. Read-only — no Edit/Write.
- Wires both into CLAUDE.md "Available Skills" and "Available Agents" tables.

The agent challenges new components: it can audit DS health on demand (zero-import wrappers, duplicated `tv()` bases, `oklch`/hex/rgb/`dark:` drift) so we catch consolidation opportunities before duplication spreads.

## Test plan

- [ ] Open a fresh Claude Code session in this branch and verify `design-system-expert` appears in the agents list and `design-system-standards` in the skills list (frontmatters must parse).
- [ ] Live test on the Button wrapper: dispatch the agent with "audit `src/components/ui/button.tsx` — variants, usage, anything overspecified?" and confirm variant names quoted from the `tv()` recipe match `button.tsx`, and import counts come from real grep.
- [ ] Live test on a fake mockup: text input "I need a profile header: avatar circle, name as h2, two primary buttons, an Edit pencil icon" — agent should map buttons → `Button variant="primary"`, pencil → `Icon name="pencil"`, and flag avatar as a missing wrapper (create-new with reuse-or-create proposal).
- [ ] Audit-mode test: dispatch with "audit the DS health" and confirm it runs the dead-component, duplication, and token-drift greps from the skill and reports findings.
- [ ] Read-only guard: confirm the agent never attempts `Edit`/`Write` (frontmatter `tools:` whitelist excludes them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)