### PR TITLE
feat(menu): replace File > Close Window with Close Tree

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,9 @@
 use image::ImageReader;
+use tauri::menu::{AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu};
+use tauri::{AppHandle, Emitter, Runtime};
+
+const CLOSE_TREE_MENU_ID: &str = "close-tree";
+const CLOSE_TREE_MENU_EVENT: &str = "menu:close-tree";
 
 #[tauri::command]
 async fn generate_thumbnail(
@@ -19,13 +24,113 @@ async fn generate_thumbnail(
     Ok(())
 }
 
+fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
+    let pkg_info = app.package_info();
+    let config = app.config();
+    let about_metadata = AboutMetadata {
+        name: Some(pkg_info.name.clone()),
+        version: Some(pkg_info.version.to_string()),
+        copyright: config.bundle.copyright.clone(),
+        authors: config.bundle.publisher.clone().map(|p| vec![p]),
+        ..Default::default()
+    };
+
+    let close_tree = MenuItem::with_id(
+        app,
+        CLOSE_TREE_MENU_ID,
+        "Close Tree",
+        true,
+        Some("CmdOrCtrl+W"),
+    )?;
+
+    Menu::with_items(
+        app,
+        &[
+            #[cfg(target_os = "macos")]
+            &Submenu::with_items(
+                app,
+                &pkg_info.name,
+                true,
+                &[
+                    &PredefinedMenuItem::about(app, None, Some(about_metadata.clone()))?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &PredefinedMenuItem::services(app, None)?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &PredefinedMenuItem::hide(app, None)?,
+                    &PredefinedMenuItem::hide_others(app, None)?,
+                    &PredefinedMenuItem::show_all(app, None)?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &PredefinedMenuItem::quit(app, None)?,
+                ],
+            )?,
+            &Submenu::with_items(
+                app,
+                "File",
+                true,
+                &[
+                    &close_tree,
+                    #[cfg(not(target_os = "macos"))]
+                    &PredefinedMenuItem::quit(app, None)?,
+                ],
+            )?,
+            &Submenu::with_items(
+                app,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::undo(app, None)?,
+                    &PredefinedMenuItem::redo(app, None)?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &PredefinedMenuItem::cut(app, None)?,
+                    &PredefinedMenuItem::copy(app, None)?,
+                    &PredefinedMenuItem::paste(app, None)?,
+                    &PredefinedMenuItem::select_all(app, None)?,
+                ],
+            )?,
+            #[cfg(target_os = "macos")]
+            &Submenu::with_items(
+                app,
+                "View",
+                true,
+                &[&PredefinedMenuItem::fullscreen(app, None)?],
+            )?,
+            &Submenu::with_items(
+                app,
+                "Window",
+                true,
+                &[
+                    &PredefinedMenuItem::minimize(app, None)?,
+                    &PredefinedMenuItem::maximize(app, None)?,
+                ],
+            )?,
+            &Submenu::with_items(
+                app,
+                "Help",
+                true,
+                &[
+                    #[cfg(not(target_os = "macos"))]
+                    &PredefinedMenuItem::about(app, None, Some(about_metadata))?,
+                ],
+            )?,
+        ],
+    )
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_sql::Builder::default().build())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_store::Builder::default().build());
+        .plugin(tauri_plugin_store::Builder::default().build())
+        .menu(build_app_menu)
+        .on_menu_event(|app, event| {
+            if event.id().as_ref() == CLOSE_TREE_MENU_ID {
+                if let Err(err) = app.emit(CLOSE_TREE_MENU_EVENT, ()) {
+                    eprintln!("Failed to emit {CLOSE_TREE_MENU_EVENT}: {err}");
+                }
+            }
+        });
 
     #[cfg(debug_assertions)]
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,14 +105,12 @@ fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
                     &PredefinedMenuItem::maximize(app, None)?,
                 ],
             )?,
+            #[cfg(not(target_os = "macos"))]
             &Submenu::with_items(
                 app,
                 "Help",
                 true,
-                &[
-                    #[cfg(not(target_os = "macos"))]
-                    &PredefinedMenuItem::about(app, None, Some(about_metadata))?,
-                ],
+                &[&PredefinedMenuItem::about(app, None, Some(about_metadata))?],
             )?,
         ],
     )

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,8 @@ async fn generate_thumbnail(
     Ok(())
 }
 
+// Mirrors `tauri::menu::Menu::default` with File > "Close Window" replaced by
+// "Close Tree" and Window > "Close Window" removed. Re-sync on Tauri upgrades.
 fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     let pkg_info = app.package_info();
     let config = app.config();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,9 +1,11 @@
 use image::ImageReader;
 use tauri::menu::{AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu};
-use tauri::{AppHandle, Emitter, Runtime};
+use tauri::{AppHandle, Emitter, Manager, Runtime, State};
 
 const CLOSE_TREE_MENU_ID: &str = "close-tree";
 const CLOSE_TREE_MENU_EVENT: &str = "menu:close-tree";
+
+struct CloseTreeMenuItem(MenuItem<tauri::Wry>);
 
 #[tauri::command]
 async fn generate_thumbnail(
@@ -26,7 +28,7 @@ async fn generate_thumbnail(
 
 // Mirrors `tauri::menu::Menu::default` with File > "Close Window" replaced by
 // "Close Tree" and Window > "Close Window" removed. Re-sync on Tauri upgrades.
-fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
+fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<(Menu<R>, MenuItem<R>)> {
     let pkg_info = app.package_info();
     let config = app.config();
     let about_metadata = AboutMetadata {
@@ -37,15 +39,17 @@ fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
         ..Default::default()
     };
 
+    // Disabled by default; the React tree shell route enables it on mount and
+    // disables it on unmount via `set_close_tree_enabled`.
     let close_tree = MenuItem::with_id(
         app,
         CLOSE_TREE_MENU_ID,
         "Close Tree",
-        true,
+        false,
         Some("CmdOrCtrl+W"),
     )?;
 
-    Menu::with_items(
+    let menu = Menu::with_items(
         app,
         &[
             #[cfg(target_os = "macos")]
@@ -113,7 +117,17 @@ fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
                 &[&PredefinedMenuItem::about(app, None, Some(about_metadata))?],
             )?,
         ],
-    )
+    )?;
+
+    Ok((menu, close_tree))
+}
+
+#[tauri::command]
+fn set_close_tree_enabled(
+    state: State<'_, CloseTreeMenuItem>,
+    enabled: bool,
+) -> Result<(), String> {
+    state.0.set_enabled(enabled).map_err(|e| e.to_string())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -123,7 +137,11 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_store::Builder::default().build())
-        .menu(build_app_menu)
+        .menu(|app| {
+            let (menu, close_tree) = build_app_menu(app)?;
+            app.manage(CloseTreeMenuItem(close_tree));
+            Ok(menu)
+        })
         .on_menu_event(|app, event| {
             if event.id().as_ref() == CLOSE_TREE_MENU_ID {
                 if let Err(err) = app.emit(CLOSE_TREE_MENU_EVENT, ()) {
@@ -138,7 +156,10 @@ pub fn run() {
     }
 
     builder
-        .invoke_handler(tauri::generate_handler![generate_thumbnail])
+        .invoke_handler(tauri::generate_handler![
+            generate_thumbnail,
+            set_close_tree_enabled
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/routes/tree/$treeId.tsx
+++ b/src/routes/tree/$treeId.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Outlet, useNavigate } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { getTreeById } from '$/db/system/trees';
 import { openTreeDb, closeTreeDb, isTreeDbOpen, getCurrentTreePath } from '$/db/connection';
@@ -54,6 +55,17 @@ export const Route = createFileRoute('/tree/$treeId')({
     useEffect(() => {
       return () => {
         void closeTreeDb();
+      };
+    }, []);
+
+    useEffect(() => {
+      invoke('set_close_tree_enabled', { enabled: true }).catch((err) => {
+        console.error('Failed to enable Close Tree menu item:', err);
+      });
+      return () => {
+        invoke('set_close_tree_enabled', { enabled: false }).catch((err) => {
+          console.error('Failed to disable Close Tree menu item:', err);
+        });
       };
     }, []);
 

--- a/src/routes/tree/$treeId.tsx
+++ b/src/routes/tree/$treeId.tsx
@@ -59,35 +59,39 @@ export const Route = createFileRoute('/tree/$treeId')({
     }, []);
 
     useEffect(() => {
-      invoke('set_close_tree_enabled', { enabled: true }).catch((err) => {
-        console.error('Failed to enable Close Tree menu item:', err);
-      });
-      return () => {
-        invoke('set_close_tree_enabled', { enabled: false }).catch((err) => {
-          console.error('Failed to disable Close Tree menu item:', err);
-        });
-      };
-    }, []);
-
-    useEffect(() => {
       let unlisten: UnlistenFn | undefined;
       let cancelled = false;
+      let enabled = false;
+
       void listen('menu:close-tree', () => {
         void navigate({ to: '/' });
       })
         .then((fn) => {
           if (cancelled) {
             fn();
-          } else {
-            unlisten = fn;
+            return;
           }
+          unlisten = fn;
+          return invoke('set_close_tree_enabled', { enabled: true }).then(() => {
+            if (cancelled) {
+              void invoke('set_close_tree_enabled', { enabled: false }).catch(() => {});
+            } else {
+              enabled = true;
+            }
+          });
         })
         .catch((err) => {
-          console.error('Failed to register menu:close-tree listener:', err);
+          console.error('Failed to register Close Tree menu handler:', err);
         });
+
       return () => {
         cancelled = true;
         unlisten?.();
+        if (enabled) {
+          invoke('set_close_tree_enabled', { enabled: false }).catch((err) => {
+            console.error('Failed to disable Close Tree menu item:', err);
+          });
+        }
       };
     }, [navigate]);
 

--- a/src/routes/tree/$treeId.tsx
+++ b/src/routes/tree/$treeId.tsx
@@ -62,13 +62,17 @@ export const Route = createFileRoute('/tree/$treeId')({
       let cancelled = false;
       void listen('menu:close-tree', () => {
         void navigate({ to: '/' });
-      }).then((fn) => {
-        if (cancelled) {
-          fn();
-        } else {
-          unlisten = fn;
-        }
-      });
+      })
+        .then((fn) => {
+          if (cancelled) {
+            fn();
+          } else {
+            unlisten = fn;
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to register menu:close-tree listener:', err);
+        });
       return () => {
         cancelled = true;
         unlisten?.();

--- a/src/routes/tree/$treeId.tsx
+++ b/src/routes/tree/$treeId.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { createFileRoute, Outlet, useNavigate } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { getTreeById } from '$/db/system/trees';
 import { openTreeDb, closeTreeDb, isTreeDbOpen, getCurrentTreePath } from '$/db/connection';
 import { queryKeys } from '$lib/query-keys';
@@ -10,6 +11,7 @@ export const Route = createFileRoute('/tree/$treeId')({
   component: function TreeLayout() {
     const { t } = useTranslation(['common', 'trees']);
     const { treeId } = Route.useParams();
+    const navigate = useNavigate();
     const [dbReady, setDbReady] = useState(false);
     const [dbError, setDbError] = useState(false);
 
@@ -54,6 +56,24 @@ export const Route = createFileRoute('/tree/$treeId')({
         void closeTreeDb();
       };
     }, []);
+
+    useEffect(() => {
+      let unlisten: UnlistenFn | undefined;
+      let cancelled = false;
+      void listen('menu:close-tree', () => {
+        void navigate({ to: '/' });
+      }).then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      });
+      return () => {
+        cancelled = true;
+        unlisten?.();
+      };
+    }, [navigate]);
 
     if (treeLoading) {
       return <p>{t('trees:loadingOne')}</p>;


### PR DESCRIPTION
## Summary

- Defines a custom Tauri menu in Rust that mirrors the platform default but swaps the **File** submenu's "Close Window" (Cmd+W) for **"Close Tree"**.
- The menu emits `menu:close-tree` to the webview; the tree shell route (`src/routes/tree/$treeId.tsx`) listens for it and navigates back to `/`. Existing unmount cleanup in `$treeId.tsx` closes the tree DB.
- The menu item is **disabled by default** — a Tauri command `set_close_tree_enabled` is invoked by the tree shell route on mount (true) and unmount (false), so the item is grayed out and Cmd+W is a no-op on the picker page.
- Drops "Close Window" from the **Window** submenu so Cmd+W never closes the app while a tree is open.
- Omits the empty Help submenu on macOS (About lives in the App menu).

Fixes the UX issue where File > Close Window / Cmd+W closed the entire app instead of returning to the tree picker.

## Test plan

- [x] On the picker (`/`): File > "Close Tree" is grayed out; Cmd+W is a no-op
- [x] Inside a tree: File > "Close Tree" is enabled and returns to the picker without closing the app; Cmd+W behaves the same
- [x] Window menu has no "Close Window" entry; Minimize / Maximize still work
- [x] App > Quit (Cmd+Q) still closes the app