### PR TITLE
chore: add `infra` label to docs and label sweep

### DIFF
--- a/.claude/skills/capture-idea/SKILL.md
+++ b/.claude/skills/capture-idea/SKILL.md
@@ -65,6 +65,7 @@ Vata's labels are **product-shaped, not codebase-shaped** — each one names a u
 | `data-quality`    | Completion tracking, duplicate detection, validation                   |
 | `tree-management` | Creating / opening / importing trees, storage location                 |
 | `design-system`   | Storybook, UI wrappers, design tokens, Radix primitives, Tailwind v4   |
+| `infra`           | CI, scripts, tooling, repo config — non-app changes                    |
 | `monetization`    | Paid-tier ideas (Vata is open source and free; these are aspirational) |
 
 Combine two only when the issue is genuinely about the intersection (e.g., "tag people on photos" → `media` + `individuals`). If the idea is a Tauri-shell change, a generic refactor, or a small typo with no clear product surface, **pass no labels**. Do not stretch a match.

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -4,13 +4,13 @@ Single backlog for everything — bugs, ideas, tasks. GitHub Issues + one org-le
 
 ## Quick start
 
-| Where      | What                                                                                               |
-| ---------- | -------------------------------------------------------------------------------------------------- |
-| Issue Type | One of `Task` / `Bug` / `Feature`, set at the org level (max 25 across all repos)                  |
-| Templates  | `.github/ISSUE_TEMPLATE/{bug,feature,task}.yml` — auto-set the type on web UI                      |
-| Labels     | 11 product-axis labels (genealogy domains, monetization, etc.) + 1 meta label (`good-first-issue`) |
-| Project    | Org-level "Vata Roadmap" — Status / Priority / Type fields, auto-add for new issues                |
-| Skills     | `capture-idea` (file an idea), `link-task` (bind PR to existing issue)                             |
+| Where      | What                                                                                                      |
+| ---------- | --------------------------------------------------------------------------------------------------------- |
+| Issue Type | One of `Task` / `Bug` / `Feature`, set at the org level (max 25 across all repos)                         |
+| Templates  | `.github/ISSUE_TEMPLATE/{bug,feature,task}.yml` — auto-set the type on web UI                             |
+| Labels     | 12 product-axis labels (genealogy domains, monetization, infra, etc.) + 1 meta label (`good-first-issue`) |
+| Project    | Org-level "Vata Roadmap" — Status / Priority / Type fields, auto-add for new issues                       |
+| Skills     | `capture-idea` (file an idea), `link-task` (bind PR to existing issue)                                    |
 
 ## Issue Types
 
@@ -54,6 +54,7 @@ Labels are **product-shaped**, not codebase-shaped. Each one names a user-facing
 | `data-quality`     | cross-cutting | Completion tracking, duplicate detection, validation                  | `#FBCA04` |
 | `tree-management`  | platform      | Creating / opening / importing trees, storage location                | `#BFD4F2` |
 | `design-system`    | platform      | Storybook, UI wrappers, design tokens, Radix primitives, Tailwind v4  | `#C5DEF5` |
+| `infra`            | platform      | CI, scripts, tooling, repo config — non-app changes                   | `#6B7280` |
 | `monetization`     | platform      | Paid-tier ideas; Vata is open source and free, these are aspirational | `#B60205` |
 | `good-first-issue` | meta          | Good for newcomers / small surface                                    | `#7057FF` |
 

--- a/scripts/setup-gh-project.sh
+++ b/scripts/setup-gh-project.sh
@@ -84,6 +84,7 @@ ensure_label "data-quality"     "FBCA04" "Completion, duplicates, validation"
 # Platform & meta
 ensure_label "tree-management"  "BFD4F2" "Tree lifecycle and storage"
 ensure_label "design-system"    "C5DEF5" "Storybook, wrappers, tokens"
+ensure_label "infra"            "6B7280" "CI, scripts, tooling, repo config — non-app changes"
 ensure_label "monetization"     "B60205" "Paid-tier ideas (Vata is open source and free)"
 ensure_label "good-first-issue" "7057FF" "Good for newcomers / small surface"
 


### PR DESCRIPTION
## Summary

Adds the `infra` GitHub label (already created on GitHub: `#6B7280`, `CI, scripts, tooling, repo config — non-app changes`) to the three places documentation/automation reads from:

- `scripts/setup-gh-project.sh` — bootstrap reconciles it on fresh setups
- `docs/dev-tools/issue-tracking.md` — label catalog + count bumped 11 → 12
- `.claude/skills/capture-idea/SKILL.md` — table the skill reads when picking labels

## Why

Non-app changes (CI workflows, scripts, ESLint/Prettier config, lockfile bumps, repo metadata, `.claude/**`) had no domain label, so triage and auto-classification by `capture-idea` were imprecise. The `platform` group now covers it alongside `tree-management`, `design-system`, `monetization`.

## Test plan

- [x] Label exists on GitHub: `gh label list --search infra` returns the row
- [ ] Re-running `bash scripts/setup-gh-project.sh` is a no-op for `infra` (idempotent — would be confirmed on next bootstrap)
- [ ] Next `capture-idea` invocation on a tooling/CI idea picks `infra`

## Notes

CodeRabbit local review skipped per request — diff is 3 data-row additions to existing tables, no logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)