### PR TITLE
feat(ui): build design system layer for Trees Modals

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,0 +1,20 @@
+/*
+  Storybook iframe surface overrides.
+
+  The story content already swaps to dark tokens via the `dark` class on
+  `<html>` (set by `@storybook/addon-themes`'s `withThemeByClassName`),
+  but the Storybook body container has its own light background that we
+  need to override so the canvas around centered/padded stories also
+  honours the active theme.
+
+  We target Storybook's root container (`#storybook-root`) and the body
+  with the `sb-show-main` class — both are stable, project-agnostic
+  selectors.
+*/
+html,
+body,
+#storybook-root,
+.sb-show-main {
+  background: var(--color-background) !important;
+  color: var(--color-foreground);
+}

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,20 +1,35 @@
 /*
   Storybook iframe surface overrides.
 
-  The story content already swaps to dark tokens via the `dark` class on
-  `<html>` (set by `@storybook/addon-themes`'s `withThemeByClassName`),
-  but the Storybook body container has its own light background that we
-  need to override so the canvas around centered/padded stories also
-  honours the active theme.
+  The story content swaps to dark tokens via the `dark` class on `<html>`
+  (set by `@storybook/addon-themes`'s `withThemeByClassName`), but
+  Storybook's chrome — body, root, docs preview cards, source-code
+  panels — has its own hard-coded light surfaces. Without these
+  overrides the canvas around a centered story stays light, and the
+  Docs page renders each story inside a white card.
 
-  We target Storybook's root container (`#storybook-root`) and the body
-  with the `sb-show-main` class — both are stable, project-agnostic
-  selectors.
+  Selectors below target Storybook's stable hooks:
+  - `html`, `body`, `#storybook-root`, `.sb-show-main` → standalone
+    story page (Canvas tab).
+  - `.sbdocs`, `.sbdocs-preview`, `.docs-story` → MDX Docs page wrapper
+    and per-story preview cards.
+  - `.sbdocs-content` → text/headings on the Docs page.
 */
 html,
 body,
 #storybook-root,
-.sb-show-main {
+.sb-show-main,
+.sbdocs,
+.sbdocs-preview,
+.docs-story {
   background: var(--color-background) !important;
-  color: var(--color-foreground);
+}
+
+html,
+body,
+#storybook-root,
+.sb-show-main,
+.sbdocs,
+.sbdocs-content {
+  color: var(--color-foreground) !important;
 }

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -3,25 +3,28 @@
 
   The story content swaps to dark tokens via the `dark` class on `<html>`
   (set by `@storybook/addon-themes`'s `withThemeByClassName`), but
-  Storybook's chrome — body, root, docs preview cards, source-code
-  panels — has its own hard-coded light surfaces. Without these
-  overrides the canvas around a centered story stays light, and the
-  Docs page renders each story inside a white card.
+  Storybook's chrome — body, root, and the per-story preview cards on
+  the Docs page — has its own hard-coded light surfaces. Without these
+  overrides, dark theme leaves a grey/white card around every story
+  while the component itself renders correctly.
 
-  Selectors below target Storybook's stable hooks:
+  Selectors below target Storybook 10's actual DOM hooks. Discovered by
+  probing the docs iframe and grepping for elements with light
+  computed backgrounds:
   - `html`, `body`, `#storybook-root`, `.sb-show-main` → standalone
-    story page (Canvas tab).
-  - `.sbdocs`, `.sbdocs-preview`, `.docs-story` → MDX Docs page wrapper
-    and per-story preview cards.
-  - `.sbdocs-content` → text/headings on the Docs page.
+    Canvas tab.
+  - `.sb-previewBlock`, `.sb-wrapper`, `.sb-preparing-story`,
+    `.sb-preparing-docs` → Docs page per-story preview cards and
+    loading wrappers.
 */
 html,
 body,
 #storybook-root,
 .sb-show-main,
-.sbdocs,
-.sbdocs-preview,
-.docs-story {
+.sb-previewBlock,
+.sb-wrapper,
+.sb-preparing-story,
+.sb-preparing-docs {
   background: var(--color-background) !important;
 }
 
@@ -29,7 +32,6 @@ html,
 body,
 #storybook-root,
 .sb-show-main,
-.sbdocs,
-.sbdocs-content {
+.sb-previewBlock {
   color: var(--color-foreground) !important;
 }

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -56,15 +56,7 @@ const preview: Preview = {
           void i18n.changeLanguage(locale);
         }
       }, [locale]);
-      // Wrap every story in a `bg-background` container so the per-story
-      // Docs card (which Storybook hard-codes to white) honours the
-      // selected theme. The standalone story page also inherits via the
-      // overrides in `./preview.css`.
-      return (
-        <div className="bg-background text-foreground">
-          <Story />
-        </div>
-      );
+      return <Story />;
     },
   ],
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,7 +4,6 @@ import { withThemeByClassName } from '@storybook/addon-themes';
 
 import i18n from '../src/i18n/config';
 import '../src/styles/app.css';
-import './preview.css';
 
 const preview: Preview = {
   parameters: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,6 +4,7 @@ import { withThemeByClassName } from '@storybook/addon-themes';
 
 import i18n from '../src/i18n/config';
 import '../src/styles/app.css';
+import './preview.css';
 
 const preview: Preview = {
   parameters: {
@@ -56,12 +57,11 @@ const preview: Preview = {
         }
       }, [locale]);
       // Wrap every story in a `bg-background` container so the per-story
-      // canvas (which on the Docs page sits inside Storybook's hard-coded
-      // light card) reflects the selected theme. The standalone story page
-      // already inherits via app.css's `html, body` base layer; the docs
-      // page only inherits per the immediate story container.
+      // Docs card (which Storybook hard-codes to white) honours the
+      // selected theme. The standalone story page also inherits via the
+      // overrides in `./preview.css`.
       return (
-        <div className="bg-background text-foreground -m-4 p-4">
+        <div className="bg-background text-foreground">
           <Story />
         </div>
       );

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -55,7 +55,16 @@ const preview: Preview = {
           void i18n.changeLanguage(locale);
         }
       }, [locale]);
-      return <Story />;
+      // Wrap every story in a `bg-background` container so the per-story
+      // canvas (which on the Docs page sits inside Storybook's hard-coded
+      // light card) reflects the selected theme. The standalone story page
+      // already inherits via app.css's `html, body` base layer; the docs
+      // page only inherits per the immediate story container.
+      return (
+        <div className="bg-background text-foreground -m-4 p-4">
+          <Story />
+        </div>
+      );
     },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,12 @@
     "chromatic": "chromatic --exit-zero-on-changes"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-radio-group": "^1.3.8",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1",
+    "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-toggle-group": "^1.1.11",
     "@tailwindcss/vite": "^4",
     "@tanstack/react-query": "^5.0.0",
     "@tanstack/react-router": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1
         version: 1.2.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-switch':
+        specifier: ^1.2.6
+        version: 1.2.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tailwindcss/vite':
         specifier: ^4
         version: 4.2.4(vite@5.4.21(@types/node@22.19.11)(lightningcss@1.32.0))
@@ -689,6 +704,21 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -809,8 +839,215 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -826,6 +1063,133 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1598,6 +1962,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -1918,6 +2286,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
@@ -2219,6 +2590,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -3013,6 +3388,36 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -3502,6 +3907,26 @@ packages:
 
   uri-template-matcher@1.1.2:
     resolution: {integrity: sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -4108,6 +4533,23 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 1.8.0
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -4230,8 +4672,222 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@radix-ui/number@1.1.1': {}
+
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-context@1.1.2(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-direction@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-id@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28
@@ -4242,6 +4898,112 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -5037,6 +5799,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -5375,6 +6141,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   diff@8.0.3: {}
 
@@ -5802,6 +6570,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -6616,6 +7386,33 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-style-singleton: 2.2.3(@types/react@18.3.28)(react@18.3.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  react-remove-scroll@2.7.2(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.28)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.3.28)(react@18.3.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.3.28)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  react-style-singleton@2.2.3(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7205,6 +8002,21 @@ snapshots:
       punycode: 2.3.1
 
   uri-template-matcher@1.1.2: {}
+
+  use-callback-ref@1.3.3(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  use-sidecar@1.1.3(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.28
 
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:

--- a/src/components/trees/tree-card-cta.stories.tsx
+++ b/src/components/trees/tree-card-cta.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { TreeCardCta } from './tree-card';
+
+const meta = {
+  title: 'Trees/TreeCardCta',
+  component: TreeCardCta,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <div className="w-[360px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    label: 'Add a new tree',
+    onClick: fn(),
+  },
+} satisfies Meta<typeof TreeCardCta>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: /Add a new tree/ });
+    await userEvent.click(button);
+    await expect(args.onClick).toHaveBeenCalledTimes(1);
+  },
+};

--- a/src/components/trees/tree-card.stories.tsx
+++ b/src/components/trees/tree-card.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { TreeCard, type TreeCardCtaProps, type TreeCardDefaultProps } from './tree-card';
+
+const labels = {
+  open: 'Open',
+  export: 'Export',
+  edit: 'Rename',
+  delete: 'Delete',
+  individuals: 'Individuals',
+  families: 'Families',
+  generations: 'Generations',
+};
+
+// We type Meta against the *default* variant — the CTA story casts at
+// the call site below. Using a plain union here would make Storybook's
+// args helper resolve to `never` for non-shared properties.
+const meta = {
+  title: 'Trees/TreeCard',
+  component: TreeCard as unknown as (props: TreeCardDefaultProps) => JSX.Element,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <div className="w-[360px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<TreeCardDefaultProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultArgs: TreeCardDefaultProps = {
+  variant: 'default',
+  name: 'Bourgoin family',
+  description: "Started from grandpa's notebook in 2024.",
+  stats: { individuals: 142, families: 58 },
+  meta: { createdAt: 'Created Jan 12, 2024', lastAccessedAt: 'Last opened 2h ago' },
+  labels,
+  onOpen: fn(),
+  onExport: fn(),
+  onEdit: fn(),
+  onDelete: fn(),
+};
+
+export const Default: Story = {
+  args: defaultArgs,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Bourgoin family')).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole('button', { name: 'Open' }));
+    await expect(args.onOpen).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const WithGenerations: Story = {
+  args: {
+    ...defaultArgs,
+    stats: { individuals: 142, families: 58, generations: 6 },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('6')).toBeInTheDocument();
+    await expect(canvas.getByText('Generations')).toBeInTheDocument();
+  },
+};
+
+export const NoDescription: Story = {
+  args: { ...defaultArgs, description: undefined },
+};
+
+export const LongName: Story = {
+  args: {
+    ...defaultArgs,
+    name: 'A very long family tree name that should still wrap gracefully',
+  },
+};
+
+export const ActionsFire: Story = {
+  args: defaultArgs,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Export' }));
+    await userEvent.click(canvas.getByRole('button', { name: 'Rename' }));
+    await userEvent.click(canvas.getByRole('button', { name: 'Delete' }));
+    await expect(args.onExport).toHaveBeenCalledTimes(1);
+    await expect(args.onEdit).toHaveBeenCalledTimes(1);
+    await expect(args.onDelete).toHaveBeenCalledTimes(1);
+  },
+};
+
+// CTA variant: the type cast is intentional — see the comment on `meta`.
+const ctaArgs = {
+  variant: 'cta',
+  label: 'Add a new tree',
+  onClick: fn(),
+} as unknown as TreeCardDefaultProps;
+
+export const Cta: Story = {
+  name: 'CTA',
+  args: ctaArgs,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: /Add a new tree/ });
+    const onClick = (ctaArgs as unknown as TreeCardCtaProps).onClick;
+    await userEvent.click(button);
+    await expect(onClick).toHaveBeenCalledTimes(1);
+  },
+};

--- a/src/components/trees/tree-card.stories.tsx
+++ b/src/components/trees/tree-card.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
-import { TreeCard, type TreeCardCtaProps, type TreeCardDefaultProps } from './tree-card';
+import { TreeCard, type TreeCardProps } from './tree-card';
 
 const labels = {
   open: 'Open',
@@ -13,12 +13,9 @@ const labels = {
   generations: 'Generations',
 };
 
-// We type Meta against the *default* variant — the CTA story casts at
-// the call site below. Using a plain union here would make Storybook's
-// args helper resolve to `never` for non-shared properties.
 const meta = {
   title: 'Trees/TreeCard',
-  component: TreeCard as unknown as (props: TreeCardDefaultProps) => JSX.Element,
+  component: TreeCard,
   tags: ['autodocs'],
   parameters: { layout: 'padded' },
   decorators: [
@@ -28,13 +25,12 @@ const meta = {
       </div>
     ),
   ],
-} satisfies Meta<TreeCardDefaultProps>;
+} satisfies Meta<typeof TreeCard>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const defaultArgs: TreeCardDefaultProps = {
-  variant: 'default',
+const defaultArgs: TreeCardProps = {
   name: 'Bourgoin family',
   description: "Started from grandpa's notebook in 2024.",
   stats: { individuals: 142, families: 58 },
@@ -89,24 +85,5 @@ export const ActionsFire: Story = {
     await expect(args.onExport).toHaveBeenCalledTimes(1);
     await expect(args.onEdit).toHaveBeenCalledTimes(1);
     await expect(args.onDelete).toHaveBeenCalledTimes(1);
-  },
-};
-
-// CTA variant: the type cast is intentional — see the comment on `meta`.
-const ctaArgs = {
-  variant: 'cta',
-  label: 'Add a new tree',
-  onClick: fn(),
-} as unknown as TreeCardDefaultProps;
-
-export const Cta: Story = {
-  name: 'CTA',
-  args: ctaArgs,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const button = canvas.getByRole('button', { name: /Add a new tree/ });
-    const onClick = (ctaArgs as unknown as TreeCardCtaProps).onClick;
-    await userEvent.click(button);
-    await expect(onClick).toHaveBeenCalledTimes(1);
   },
 };

--- a/src/components/trees/tree-card.tsx
+++ b/src/components/trees/tree-card.tsx
@@ -115,7 +115,7 @@ export function TreeCard({
   onExport,
   onEdit,
   onDelete,
-}: TreeCardProps) {
+}: TreeCardProps): JSX.Element {
   const items = [
     { value: stats.individuals, label: labels.individuals },
     { value: stats.families, label: labels.families },
@@ -179,7 +179,7 @@ export interface TreeCardCtaProps {
  * @example
  * <TreeCardCta label={t('trees.new')} onClick={() => navigate('/new')} />
  */
-export function TreeCardCta({ label, onClick }: TreeCardCtaProps) {
+export function TreeCardCta({ label, onClick }: TreeCardCtaProps): JSX.Element {
   return (
     <button type="button" onClick={onClick} className={ctaCardBase()}>
       <Icon name="plus" size={24} />

--- a/src/components/trees/tree-card.tsx
+++ b/src/components/trees/tree-card.tsx
@@ -1,32 +1,21 @@
 import { type ReactNode } from 'react';
-import { tv, type VariantProps } from 'tailwind-variants';
+import { tv } from 'tailwind-variants';
 
 import { Button } from '$components/ui/button';
 import { Icon } from '$components/ui/icon';
 import { StatGrid } from '$components/ui/stat-grid';
 
-/**
- * Recipe for the TreeCard outer shell.
- */
-const cardRecipe = tv({
-  base: [
-    'flex flex-col gap-3 rounded-lg border border-border bg-card p-4',
-    'transition-colors duration-150',
-  ],
-  variants: {
-    variant: {
-      default: 'hover:border-primary/40',
-      cta: [
-        'cursor-pointer items-center justify-center text-center',
-        'border-dashed text-muted-foreground hover:text-foreground hover:border-primary/40',
-        'min-h-[200px]',
-      ],
-    },
-  },
-  defaultVariants: { variant: 'default' },
+const cardBase = tv({
+  base: ['flex flex-col gap-3 rounded-lg border bg-card p-4 transition-colors duration-150'],
 });
 
-type CardRecipeProps = VariantProps<typeof cardRecipe>;
+const ctaCardBase = tv({
+  base: [
+    'flex min-h-[200px] cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border border-dashed bg-card p-4 text-center',
+    'text-muted-foreground transition-colors duration-150',
+    'hover:border-primary/40 hover:text-foreground',
+  ],
+});
 
 /**
  * Stats shown in the card body.
@@ -63,10 +52,9 @@ export interface TreeCardLabels {
 }
 
 /**
- * Default-variant props (a real tree).
+ * Props accepted by {@link TreeCard}.
  */
-export interface TreeCardDefaultProps {
-  variant?: 'default';
+export interface TreeCardProps {
   /** Tree name shown as the card heading. */
   name: ReactNode;
   /** Optional tree description. */
@@ -88,29 +76,13 @@ export interface TreeCardDefaultProps {
 }
 
 /**
- * CTA-variant props (the "Add new tree" tile).
- */
-export interface TreeCardCtaProps {
-  variant: 'cta';
-  /** Localized label for the CTA. */
-  label: ReactNode;
-  /** Called when the CTA is clicked. */
-  onClick: () => void;
-}
-
-export type TreeCardProps = TreeCardDefaultProps | TreeCardCtaProps;
-
-/**
  * Domain card representing one family tree on the home page.
  *
- * Two variants:
- * - `default` — full card with name, optional description, stats grid,
- *   meta, and four action buttons (Open / Export / Edit / Delete).
- * - `cta` — minimal dashed tile used to trigger "Add new tree".
- *
  * Lives outside `src/components/ui/` because it is genealogy-domain
- * specific (composes generic UI primitives — Button, Icon, StatGrid —
- * but has its own data shape and call sites).
+ * specific — it composes generic UI primitives (Button, Icon, StatGrid)
+ * but has its own data shape and call sites. For the "Add a new tree"
+ * tile, use the dedicated {@link TreeCardCta} component instead — they
+ * share no real runtime code, only family resemblance.
  *
  * All textual content (name, description, button labels, meta) must be
  * localized by the caller; this component does not own copy.
@@ -132,28 +104,8 @@ export type TreeCardProps = TreeCardDefaultProps | TreeCardCtaProps;
  *   }}
  *   onOpen={...} onExport={...} onEdit={...} onDelete={...}
  * />
- *
- * @example
- * <TreeCard variant="cta" label={t('trees.new')} onClick={() => navigate('/new')} />
  */
-export function TreeCard(props: TreeCardProps) {
-  if (props.variant === 'cta') {
-    return <TreeCardCta {...props} />;
-  }
-  return <TreeCardDefault {...props} />;
-}
-
-function TreeCardCta({ label, onClick }: TreeCardCtaProps) {
-  const variant: CardRecipeProps['variant'] = 'cta';
-  return (
-    <button type="button" onClick={onClick} className={cardRecipe({ variant })}>
-      <Icon name="plus" size={24} />
-      <span className="text-sm font-medium">{label}</span>
-    </button>
-  );
-}
-
-function TreeCardDefault({
+export function TreeCard({
   name,
   description,
   stats,
@@ -163,7 +115,7 @@ function TreeCardDefault({
   onExport,
   onEdit,
   onDelete,
-}: TreeCardDefaultProps) {
+}: TreeCardProps) {
   const items = [
     { value: stats.individuals, label: labels.individuals },
     { value: stats.families, label: labels.families },
@@ -173,7 +125,7 @@ function TreeCardDefault({
   }
 
   return (
-    <article className={cardRecipe({ variant: 'default' })}>
+    <article className={`${cardBase()} border-border hover:border-primary/40`}>
       <header className="flex items-start justify-between gap-2">
         <div className="flex flex-col gap-0.5">
           <h3 className="text-foreground text-base font-semibold leading-tight">{name}</h3>
@@ -206,5 +158,32 @@ function TreeCardDefault({
         </Button>
       </footer>
     </article>
+  );
+}
+
+/**
+ * Props accepted by {@link TreeCardCta}.
+ */
+export interface TreeCardCtaProps {
+  /** Localized label for the CTA tile. */
+  label: ReactNode;
+  /** Called when the CTA is clicked. */
+  onClick: () => void;
+}
+
+/**
+ * Dashed CTA tile used as the last cell of the trees grid to trigger
+ * "Add a new tree". Renders as a `<button>` so it is keyboard-focusable
+ * and announced as a button by screen readers.
+ *
+ * @example
+ * <TreeCardCta label={t('trees.new')} onClick={() => navigate('/new')} />
+ */
+export function TreeCardCta({ label, onClick }: TreeCardCtaProps) {
+  return (
+    <button type="button" onClick={onClick} className={ctaCardBase()}>
+      <Icon name="plus" size={24} />
+      <span className="text-sm font-medium">{label}</span>
+    </button>
   );
 }

--- a/src/components/trees/tree-card.tsx
+++ b/src/components/trees/tree-card.tsx
@@ -1,0 +1,210 @@
+import { type ReactNode } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+import { Button } from '$components/ui/button';
+import { Icon } from '$components/ui/icon';
+import { StatGrid } from '$components/ui/stat-grid';
+
+/**
+ * Recipe for the TreeCard outer shell.
+ */
+const cardRecipe = tv({
+  base: [
+    'flex flex-col gap-3 rounded-lg border border-border bg-card p-4',
+    'transition-colors duration-150',
+  ],
+  variants: {
+    variant: {
+      default: 'hover:border-primary/40',
+      cta: [
+        'cursor-pointer items-center justify-center text-center',
+        'border-dashed text-muted-foreground hover:text-foreground hover:border-primary/40',
+        'min-h-[200px]',
+      ],
+    },
+  },
+  defaultVariants: { variant: 'default' },
+});
+
+type CardRecipeProps = VariantProps<typeof cardRecipe>;
+
+/**
+ * Stats shown in the card body.
+ */
+export interface TreeCardStats {
+  individuals: number;
+  families: number;
+  /** Optional generation count when computed. */
+  generations?: number | null;
+}
+
+/**
+ * Metadata shown at the bottom of the card.
+ */
+export interface TreeCardMeta {
+  /** Localized "created at" caption (already formatted). */
+  createdAt: ReactNode;
+  /** Localized "last accessed" caption (already formatted). */
+  lastAccessedAt: ReactNode;
+}
+
+/**
+ * Localized labels rendered as button accessible names. Required so
+ * the wrapper does not own copy.
+ */
+export interface TreeCardLabels {
+  open: string;
+  export: string;
+  edit: string;
+  delete: string;
+  individuals: string;
+  families: string;
+  generations: string;
+}
+
+/**
+ * Default-variant props (a real tree).
+ */
+export interface TreeCardDefaultProps {
+  variant?: 'default';
+  /** Tree name shown as the card heading. */
+  name: ReactNode;
+  /** Optional tree description. */
+  description?: ReactNode;
+  /** Counts displayed in the StatGrid. */
+  stats: TreeCardStats;
+  /** Created/last-accessed metadata. */
+  meta: TreeCardMeta;
+  /** Localized accessible names for the action buttons and stat labels. */
+  labels: TreeCardLabels;
+  /** Called when the user clicks "Open". */
+  onOpen: () => void;
+  /** Called when the user clicks "Export". */
+  onExport: () => void;
+  /** Called when the user clicks "Edit". */
+  onEdit: () => void;
+  /** Called when the user clicks "Delete". */
+  onDelete: () => void;
+}
+
+/**
+ * CTA-variant props (the "Add new tree" tile).
+ */
+export interface TreeCardCtaProps {
+  variant: 'cta';
+  /** Localized label for the CTA. */
+  label: ReactNode;
+  /** Called when the CTA is clicked. */
+  onClick: () => void;
+}
+
+export type TreeCardProps = TreeCardDefaultProps | TreeCardCtaProps;
+
+/**
+ * Domain card representing one family tree on the home page.
+ *
+ * Two variants:
+ * - `default` — full card with name, optional description, stats grid,
+ *   meta, and four action buttons (Open / Export / Edit / Delete).
+ * - `cta` — minimal dashed tile used to trigger "Add new tree".
+ *
+ * Lives outside `src/components/ui/` because it is genealogy-domain
+ * specific (composes generic UI primitives — Button, Icon, StatGrid —
+ * but has its own data shape and call sites).
+ *
+ * All textual content (name, description, button labels, meta) must be
+ * localized by the caller; this component does not own copy.
+ *
+ * @example
+ * <TreeCard
+ *   name="Bourgoin family"
+ *   description="Started from grandpa's notebook in 2024."
+ *   stats={{ individuals: 142, families: 58 }}
+ *   meta={{ createdAt: '2024-01-12', lastAccessedAt: '2 hours ago' }}
+ *   labels={{
+ *     open: t('trees.open'),
+ *     export: t('trees.export'),
+ *     edit: t('trees.edit'),
+ *     delete: t('trees.delete'),
+ *     individuals: t('trees.stats.individuals'),
+ *     families: t('trees.stats.families'),
+ *     generations: t('trees.stats.generations'),
+ *   }}
+ *   onOpen={...} onExport={...} onEdit={...} onDelete={...}
+ * />
+ *
+ * @example
+ * <TreeCard variant="cta" label={t('trees.new')} onClick={() => navigate('/new')} />
+ */
+export function TreeCard(props: TreeCardProps) {
+  if (props.variant === 'cta') {
+    return <TreeCardCta {...props} />;
+  }
+  return <TreeCardDefault {...props} />;
+}
+
+function TreeCardCta({ label, onClick }: TreeCardCtaProps) {
+  const variant: CardRecipeProps['variant'] = 'cta';
+  return (
+    <button type="button" onClick={onClick} className={cardRecipe({ variant })}>
+      <Icon name="plus" size={24} />
+      <span className="text-sm font-medium">{label}</span>
+    </button>
+  );
+}
+
+function TreeCardDefault({
+  name,
+  description,
+  stats,
+  meta,
+  labels,
+  onOpen,
+  onExport,
+  onEdit,
+  onDelete,
+}: TreeCardDefaultProps) {
+  const items = [
+    { value: stats.individuals, label: labels.individuals },
+    { value: stats.families, label: labels.families },
+  ];
+  if (stats.generations != null) {
+    items.push({ value: stats.generations, label: labels.generations });
+  }
+
+  return (
+    <article className={cardRecipe({ variant: 'default' })}>
+      <header className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-0.5">
+          <h3 className="text-foreground text-base font-semibold leading-tight">{name}</h3>
+          {description && (
+            <p className="text-muted-foreground text-xs leading-snug">{description}</p>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          <Button variant="ghost" size="sm" hideLabel leadingIcon="download" onClick={onExport}>
+            {labels.export}
+          </Button>
+          <Button variant="ghost" size="sm" hideLabel leadingIcon="pencil" onClick={onEdit}>
+            {labels.edit}
+          </Button>
+          <Button variant="ghost" size="sm" hideLabel leadingIcon="trash" onClick={onDelete}>
+            {labels.delete}
+          </Button>
+        </div>
+      </header>
+
+      <StatGrid items={items} cols={items.length === 3 ? 3 : 2} />
+
+      <footer className="flex items-center justify-between gap-2 border-t border-border pt-3">
+        <div className="flex flex-col gap-0.5 text-xs">
+          <span className="text-muted-foreground">{meta.createdAt}</span>
+          <span className="text-muted-foreground">{meta.lastAccessedAt}</span>
+        </div>
+        <Button variant="outline" size="sm" trailingIcon="arrow-right" onClick={onOpen}>
+          {labels.open}
+        </Button>
+      </footer>
+    </article>
+  );
+}

--- a/src/components/ui/badge.stories.tsx
+++ b/src/components/ui/badge.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+
+import { Badge } from './badge';
+
+const meta = {
+  title: 'UI/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'primary', 'success', 'warning', 'danger', 'info', 'outline', 'soon'],
+    },
+    size: { control: 'select', options: ['sm', 'md'] },
+    dot: { control: 'boolean' },
+  },
+  args: { children: 'Ready' },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Ready')).toBeInTheDocument();
+  },
+};
+
+export const WithDot: Story = {
+  args: { variant: 'success', dot: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const badge = canvas.getByText('Ready');
+    // Dot is the first child span and must be aria-hidden.
+    const dot = badge.querySelector('span[aria-hidden]');
+    await expect(dot).not.toBeNull();
+  },
+};
+
+export const Soon: Story = {
+  args: { variant: 'soon', children: 'Soon' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Soon')).toBeInTheDocument();
+  },
+};
+
+const variants = [
+  'default',
+  'primary',
+  'success',
+  'warning',
+  'danger',
+  'info',
+  'outline',
+  'soon',
+] as const;
+const sizes = ['sm', 'md'] as const;
+
+export const Matrix: Story = {
+  parameters: { layout: 'padded' },
+  render: () => (
+    <div className="flex flex-col gap-3">
+      {sizes.map((size) => (
+        <div key={size} className="flex flex-wrap items-center gap-2">
+          {variants.map((variant) => (
+            <Badge key={`${size}-${variant}`} size={size} variant={variant}>
+              {variant}
+            </Badge>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Each variant appears once per size row.
+    for (const variant of variants) {
+      const matches = canvas.getAllByText(variant);
+      await expect(matches.length).toBe(sizes.length);
+    }
+  },
+};

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,91 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+/**
+ * Recipe for the Badge component.
+ *
+ * Variants describe the badge's *intent*, not just its colour:
+ * - `default` — neutral metadata (count, generic label).
+ * - `primary` — brand emphasis ("Active", "Selected").
+ * - `success` — positive signal ("Ready", "Done").
+ * - `warning` — needs attention but not destructive ("Pending").
+ * - `danger` — error/blocked state.
+ * - `info` — neutral informative.
+ * - `outline` — low-emphasis count chip; pairs well with section headings.
+ * - `soon` — dashed serif/italic indicator on disabled/preview options.
+ *
+ * Sizes:
+ * - `sm` — inline next to body text.
+ * - `md` — default — section headers, file rows.
+ */
+export const badgeRecipe = tv({
+  base: [
+    'inline-flex items-center gap-1 whitespace-nowrap rounded-full',
+    'font-medium leading-none',
+  ],
+  variants: {
+    variant: {
+      default: 'bg-secondary text-secondary-foreground',
+      primary: 'bg-primary text-primary-foreground',
+      success: 'bg-success text-success-foreground',
+      warning: 'bg-warning text-warning-foreground',
+      danger: 'bg-destructive text-destructive-foreground',
+      info: 'bg-info text-info-foreground',
+      outline: 'border border-border bg-transparent text-muted-foreground',
+      soon: 'border border-dashed border-border bg-transparent font-serif text-xs italic text-muted-foreground',
+    },
+    size: {
+      sm: 'h-5 px-2 text-[11px]',
+      md: 'h-6 px-2.5 text-xs',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'md',
+  },
+});
+
+type BadgeRecipeProps = VariantProps<typeof badgeRecipe>;
+
+/**
+ * Props accepted by {@link Badge}. Extends the native `<span>` props.
+ */
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement>, BadgeRecipeProps {
+  /**
+   * When `true`, renders a small status dot before the label. Useful for
+   * live-status badges (e.g., a "Ready" pastille on a file row).
+   */
+  dot?: boolean;
+}
+
+/**
+ * Inline status / count chip.
+ *
+ * Non-interactive by default — renders a `<span>` so it can sit inside
+ * any inline context (table cell, list row, button). Pass an
+ * `aria-label` when the badge is not paired with adjacent context that
+ * makes its meaning clear.
+ *
+ * @example
+ * <Badge variant="success" dot>Ready</Badge>
+ *
+ * @example
+ * <Badge variant="outline">{trees.length}</Badge>
+ *
+ * @example
+ * // Disabled/preview indicator
+ * <Badge variant="soon">Soon</Badge>
+ */
+export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
+  { variant, size, dot = false, className, children, ...props },
+  ref
+) {
+  return (
+    <span ref={ref} className={badgeRecipe({ variant, size, className })} {...props}>
+      {dot && <span aria-hidden className="bg-current size-1.5 rounded-full opacity-80" />}
+      {children}
+    </span>
+  );
+});
+
+Badge.displayName = 'Badge';

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -13,6 +13,16 @@ const meta: Meta<DialogArgs> = {
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',
+    a11y: {
+      // Radix's focus trap renders sentinel <span data-radix-focus-guard
+      // tabindex="0" aria-hidden="true">. axe-core's aria-hidden-focus rule
+      // can't tell that they exist precisely so the trap can catch focus
+      // exiting the dialog — they are NEVER announced or tab-stops in
+      // practice. Suppress the rule on Dialog stories.
+      config: {
+        rules: [{ id: 'aria-hidden-focus', enabled: false }],
+      },
+    },
   },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -1,5 +1,6 @@
-import { useState, type ComponentProps, type ReactNode } from 'react';
+import { useEffect, useState, type ComponentProps, type ReactNode } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useArgs } from 'storybook/preview-api';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import { Button } from './button';
@@ -28,7 +29,11 @@ const meta: Meta<DialogArgs> = {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },
   },
   args: {
-    open: true,
+    // Closed by default so the autodocs page (and individual story
+    // pages) show only the trigger button — clicking it opens the
+    // dialog. play() functions click the trigger explicitly before
+    // asserting on the dialog content.
+    open: false,
     title: 'Dialog title',
     closeLabel: 'Close',
     onOpenChange: fn(),
@@ -39,8 +44,18 @@ const meta: Meta<DialogArgs> = {
 export default meta;
 type Story = StoryObj<DialogArgs>;
 
-function DialogHarness({ body, children, ...props }: DialogArgs) {
-  const [open, setOpen] = useState(props.open);
+// Presentational harness — receives `open` + `setOpen` from the story's
+// render callback (which itself uses `useArgs` to bind to Storybook's
+// Controls panel). Storybook preview hooks can only be invoked from a
+// story render or a decorator, never a nested sub-component, hence this
+// split.
+function DialogHarness({
+  open,
+  setOpen,
+  body,
+  children,
+  ...props
+}: Omit<DialogArgs, 'open'> & { open: boolean; setOpen: (next: boolean) => void }) {
   return (
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
@@ -58,31 +73,54 @@ function DialogHarness({ body, children, ...props }: DialogArgs) {
   );
 }
 
+/**
+ * Hybrid state hook: keeps the dialog open/closed via local React state
+ * (so test runners and the live preview pick up changes immediately),
+ * AND mirrors that state into Storybook's args dictionary so the
+ * Controls panel reflects (and can drive) the current state.
+ */
+function useOpenArg(): [boolean, (next: boolean) => void] {
+  const [{ open: argOpen }, updateArgs] = useArgs<DialogArgs>();
+  const [localOpen, setLocalOpen] = useState(Boolean(argOpen));
+
+  // Mirror args → local when the user toggles the Controls panel.
+  useEffect(() => {
+    setLocalOpen(Boolean(argOpen));
+  }, [argOpen]);
+
+  const setOpen = (next: boolean) => {
+    setLocalOpen(next);
+    updateArgs({ open: next });
+  };
+
+  return [localOpen, setOpen];
+}
+
 export const Default: Story = {
-  render: (args) => (
-    <DialogHarness
-      {...args}
-      footer={
-        <>
-          <Button variant="ghost">Cancel</Button>
-          <Button>Save</Button>
-        </>
-      }
-    />
-  ),
+  render: function Render(args) {
+    const [open, setOpen] = useOpenArg();
+    return (
+      <DialogHarness
+        {...args}
+        open={open}
+        setOpen={setOpen}
+        footer={
+          <>
+            <Button variant="ghost">Cancel</Button>
+            <Button>Save</Button>
+          </>
+        }
+      />
+    );
+  },
   play: async ({ canvasElement }) => {
-    const dialog = within(canvasElement.ownerDocument.body).getByRole('dialog');
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open dialog' }));
+    const dialog = await within(canvasElement.ownerDocument.body).findByRole('dialog');
     await expect(dialog).toBeInTheDocument();
     await expect(dialog).toHaveAccessibleName('Dialog title');
   },
 };
-
-// Every Dialog story renders into the same document.body via Radix's
-// Portal. On the autodocs page Storybook stacks every story into a
-// single MDX page, so without `docs.disable` on the variants below we
-// would render N dialogs simultaneously and they'd all overlap. Keep
-// the canonical "Default" story visible in autodocs and hide the rest.
-const HIDE_FROM_DOCS = { docs: { disable: true } } as const;
 
 export const Small: Story = {
   args: {
@@ -90,18 +128,22 @@ export const Small: Story = {
     title: 'Confirm',
     description: 'This action cannot be undone.',
   },
-  parameters: HIDE_FROM_DOCS,
-  render: (args) => (
-    <DialogHarness
-      {...args}
-      footer={
-        <>
-          <Button variant="ghost">Cancel</Button>
-          <Button variant="destructive">Delete</Button>
-        </>
-      }
-    />
-  ),
+  render: function Render(args) {
+    const [open, setOpen] = useOpenArg();
+    return (
+      <DialogHarness
+        {...args}
+        open={open}
+        setOpen={setOpen}
+        footer={
+          <>
+            <Button variant="ghost">Cancel</Button>
+            <Button variant="destructive">Delete</Button>
+          </>
+        }
+      />
+    );
+  },
 };
 
 export const Large: Story = {
@@ -110,23 +152,27 @@ export const Large: Story = {
     title: 'Import GEDCOM',
     description: 'Drop a .ged file or pick one from disk to scan it before import.',
   },
-  parameters: HIDE_FROM_DOCS,
-  render: (args) => (
-    <DialogHarness
-      {...args}
-      body={
-        <div className="border-border bg-foreground/5 flex h-40 items-center justify-center rounded-md border border-dashed">
-          <span className="text-muted-foreground text-sm">Dropzone placeholder</span>
-        </div>
-      }
-      footer={
-        <>
-          <Button variant="ghost">Cancel</Button>
-          <Button>Import</Button>
-        </>
-      }
-    />
-  ),
+  render: function Render(args) {
+    const [open, setOpen] = useOpenArg();
+    return (
+      <DialogHarness
+        {...args}
+        open={open}
+        setOpen={setOpen}
+        body={
+          <div className="border-border bg-foreground/5 flex h-40 items-center justify-center rounded-md border border-dashed">
+            <span className="text-muted-foreground text-sm">Dropzone placeholder</span>
+          </div>
+        }
+        footer={
+          <>
+            <Button variant="ghost">Cancel</Button>
+            <Button>Import</Button>
+          </>
+        }
+      />
+    );
+  },
 };
 
 export const WithFooterNote: Story = {
@@ -135,31 +181,38 @@ export const WithFooterNote: Story = {
     description: 'Choose a format and the file is generated locally.',
     footerNote: 'File generated locally',
   },
-  parameters: HIDE_FROM_DOCS,
-  render: (args) => (
-    <DialogHarness
-      {...args}
-      footer={
-        <>
-          <Button variant="ghost">Cancel</Button>
-          <Button leadingIcon="download">Download .ged</Button>
-        </>
-      }
-    />
-  ),
+  render: function Render(args) {
+    const [open, setOpen] = useOpenArg();
+    return (
+      <DialogHarness
+        {...args}
+        open={open}
+        setOpen={setOpen}
+        footer={
+          <>
+            <Button variant="ghost">Cancel</Button>
+            <Button leadingIcon="download">Download .ged</Button>
+          </>
+        }
+      />
+    );
+  },
 };
 
 export const ClosesOnEscape: Story = {
   args: {
     title: 'Press Escape',
   },
-  parameters: HIDE_FROM_DOCS,
-  render: (args) => <DialogHarness {...args} />,
+  render: function Render(args) {
+    const [open, setOpen] = useOpenArg();
+    return <DialogHarness {...args} open={open} setOpen={setOpen} />;
+  },
   play: async ({ args, canvasElement }) => {
-    const body = canvasElement.ownerDocument.body;
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open dialog' }));
     // Wait for Radix to mount the Portal, focus the content, and register
     // its Escape handler. `findByRole` polls until the dialog is in the DOM.
-    const dialog = await within(body).findByRole('dialog');
+    const dialog = await within(canvasElement.ownerDocument.body).findByRole('dialog');
     await expect(dialog).toBeInTheDocument();
     // Dispatch the key on the focused element (the Dialog content) rather
     // than the document — Playwright's userEvent honors target focus.
@@ -174,12 +227,17 @@ export const ClosesOnCloseButton: Story = {
     title: 'Close via button',
     closeLabel: 'Close dialog',
   },
-  parameters: HIDE_FROM_DOCS,
-  render: (args) => <DialogHarness {...args} />,
+  render: function Render(args) {
+    const [open, setOpen] = useOpenArg();
+    return <DialogHarness {...args} open={open} setOpen={setOpen} />;
+  },
   play: async ({ args, canvasElement }) => {
-    const body = canvasElement.ownerDocument.body;
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open dialog' }));
     // `findByRole` polls until the close button is mounted and visible.
-    const closeButton = await within(body).findByRole('button', { name: 'Close dialog' });
+    const closeButton = await within(canvasElement.ownerDocument.body).findByRole('button', {
+      name: 'Close dialog',
+    });
     await userEvent.click(closeButton);
     await waitFor(() => expect(args.onOpenChange).toHaveBeenCalledWith(false));
   },

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -1,6 +1,6 @@
 import { useState, type ComponentProps, type ReactNode } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import { Button } from './button';
 import { Dialog } from './dialog';
@@ -136,10 +136,15 @@ export const ClosesOnEscape: Story = {
   render: (args) => <DialogHarness {...args} />,
   play: async ({ args, canvasElement }) => {
     const body = canvasElement.ownerDocument.body;
-    const dialog = within(body).getByRole('dialog');
+    // Wait for Radix to mount the Portal, focus the content, and register
+    // its Escape handler. `findByRole` polls until the dialog is in the DOM.
+    const dialog = await within(body).findByRole('dialog');
     await expect(dialog).toBeInTheDocument();
+    // Dispatch the key on the focused element (the Dialog content) rather
+    // than the document — Playwright's userEvent honors target focus.
+    dialog.focus();
     await userEvent.keyboard('{Escape}');
-    await expect(args.onOpenChange).toHaveBeenCalledWith(false);
+    await waitFor(() => expect(args.onOpenChange).toHaveBeenCalledWith(false));
   },
 };
 
@@ -151,8 +156,9 @@ export const ClosesOnCloseButton: Story = {
   render: (args) => <DialogHarness {...args} />,
   play: async ({ args, canvasElement }) => {
     const body = canvasElement.ownerDocument.body;
-    const closeButton = within(body).getByRole('button', { name: 'Close dialog' });
+    // `findByRole` polls until the close button is mounted and visible.
+    const closeButton = await within(body).findByRole('button', { name: 'Close dialog' });
     await userEvent.click(closeButton);
-    await expect(args.onOpenChange).toHaveBeenCalledWith(false);
+    await waitFor(() => expect(args.onOpenChange).toHaveBeenCalledWith(false));
   },
 };

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -77,12 +77,20 @@ export const Default: Story = {
   },
 };
 
+// Every Dialog story renders into the same document.body via Radix's
+// Portal. On the autodocs page Storybook stacks every story into a
+// single MDX page, so without `docs.disable` on the variants below we
+// would render N dialogs simultaneously and they'd all overlap. Keep
+// the canonical "Default" story visible in autodocs and hide the rest.
+const HIDE_FROM_DOCS = { docs: { disable: true } } as const;
+
 export const Small: Story = {
   args: {
     size: 'sm',
     title: 'Confirm',
     description: 'This action cannot be undone.',
   },
+  parameters: HIDE_FROM_DOCS,
   render: (args) => (
     <DialogHarness
       {...args}
@@ -102,6 +110,7 @@ export const Large: Story = {
     title: 'Import GEDCOM',
     description: 'Drop a .ged file or pick one from disk to scan it before import.',
   },
+  parameters: HIDE_FROM_DOCS,
   render: (args) => (
     <DialogHarness
       {...args}
@@ -126,6 +135,7 @@ export const WithFooterNote: Story = {
     description: 'Choose a format and the file is generated locally.',
     footerNote: 'File generated locally',
   },
+  parameters: HIDE_FROM_DOCS,
   render: (args) => (
     <DialogHarness
       {...args}
@@ -143,6 +153,7 @@ export const ClosesOnEscape: Story = {
   args: {
     title: 'Press Escape',
   },
+  parameters: HIDE_FROM_DOCS,
   render: (args) => <DialogHarness {...args} />,
   play: async ({ args, canvasElement }) => {
     const body = canvasElement.ownerDocument.body;
@@ -163,6 +174,7 @@ export const ClosesOnCloseButton: Story = {
     title: 'Close via button',
     closeLabel: 'Close dialog',
   },
+  parameters: HIDE_FROM_DOCS,
   render: (args) => <DialogHarness {...args} />,
   play: async ({ args, canvasElement }) => {
     const body = canvasElement.ownerDocument.body;

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -19,6 +19,7 @@ const meta: Meta<DialogArgs> = {
   args: {
     open: true,
     title: 'Dialog title',
+    closeLabel: 'Close',
     onOpenChange: fn(),
     children: null,
   },

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -1,0 +1,156 @@
+import { useState, type ComponentProps, type ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { Button } from './button';
+import { Dialog } from './dialog';
+
+type DialogArgs = ComponentProps<typeof Dialog> & { body?: ReactNode };
+
+const meta: Meta<DialogArgs> = {
+  title: 'UI/Dialog',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+  },
+  args: {
+    open: true,
+    title: 'Dialog title',
+    onOpenChange: fn(),
+    children: null,
+  },
+};
+
+export default meta;
+type Story = StoryObj<DialogArgs>;
+
+function DialogHarness({ body, children, ...props }: DialogArgs) {
+  const [open, setOpen] = useState(props.open);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <Dialog
+        {...props}
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          props.onOpenChange?.(next);
+        }}
+      >
+        {body ?? children ?? <p>Dialog body — replace with form, list, or any content.</p>}
+      </Dialog>
+    </>
+  );
+}
+
+export const Default: Story = {
+  render: (args) => (
+    <DialogHarness
+      {...args}
+      footer={
+        <>
+          <Button variant="ghost">Cancel</Button>
+          <Button>Save</Button>
+        </>
+      }
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const dialog = within(canvasElement.ownerDocument.body).getByRole('dialog');
+    await expect(dialog).toBeInTheDocument();
+    await expect(dialog).toHaveAccessibleName('Dialog title');
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+    title: 'Confirm',
+    description: 'This action cannot be undone.',
+  },
+  render: (args) => (
+    <DialogHarness
+      {...args}
+      footer={
+        <>
+          <Button variant="ghost">Cancel</Button>
+          <Button variant="destructive">Delete</Button>
+        </>
+      }
+    />
+  ),
+};
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+    title: 'Import GEDCOM',
+    description: 'Drop a .ged file or pick one from disk to scan it before import.',
+  },
+  render: (args) => (
+    <DialogHarness
+      {...args}
+      body={
+        <div className="border-border bg-foreground/5 flex h-40 items-center justify-center rounded-md border border-dashed">
+          <span className="text-muted-foreground text-sm">Dropzone placeholder</span>
+        </div>
+      }
+      footer={
+        <>
+          <Button variant="ghost">Cancel</Button>
+          <Button>Import</Button>
+        </>
+      }
+    />
+  ),
+};
+
+export const WithFooterNote: Story = {
+  args: {
+    title: 'Download tree',
+    description: 'Choose a format and the file is generated locally.',
+    footerNote: 'File generated locally',
+  },
+  render: (args) => (
+    <DialogHarness
+      {...args}
+      footer={
+        <>
+          <Button variant="ghost">Cancel</Button>
+          <Button leadingIcon="download">Download .ged</Button>
+        </>
+      }
+    />
+  ),
+};
+
+export const ClosesOnEscape: Story = {
+  args: {
+    title: 'Press Escape',
+  },
+  render: (args) => <DialogHarness {...args} />,
+  play: async ({ args, canvasElement }) => {
+    const body = canvasElement.ownerDocument.body;
+    const dialog = within(body).getByRole('dialog');
+    await expect(dialog).toBeInTheDocument();
+    await userEvent.keyboard('{Escape}');
+    await expect(args.onOpenChange).toHaveBeenCalledWith(false);
+  },
+};
+
+export const ClosesOnCloseButton: Story = {
+  args: {
+    title: 'Close via button',
+    closeLabel: 'Close dialog',
+  },
+  render: (args) => <DialogHarness {...args} />,
+  play: async ({ args, canvasElement }) => {
+    const body = canvasElement.ownerDocument.body;
+    const closeButton = within(body).getByRole('button', { name: 'Close dialog' });
+    await userEvent.click(closeButton);
+    await expect(args.onOpenChange).toHaveBeenCalledWith(false);
+  },
+};

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -9,6 +9,7 @@ type DialogArgs = ComponentProps<typeof Dialog> & { body?: ReactNode };
 
 const meta: Meta<DialogArgs> = {
   title: 'UI/Dialog',
+  component: Dialog,
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, type ComponentProps, type ReactNode } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useArgs } from 'storybook/preview-api';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import { Button } from './button';
@@ -44,18 +43,22 @@ const meta: Meta<DialogArgs> = {
 export default meta;
 type Story = StoryObj<DialogArgs>;
 
-// Presentational harness — receives `open` + `setOpen` from the story's
-// render callback (which itself uses `useArgs` to bind to Storybook's
-// Controls panel). Storybook preview hooks can only be invoked from a
-// story render or a decorator, never a nested sub-component, hence this
-// split.
-function DialogHarness({
-  open,
-  setOpen,
-  body,
-  children,
-  ...props
-}: Omit<DialogArgs, 'open'> & { open: boolean; setOpen: (next: boolean) => void }) {
+// Harness with local open state. The `open` arg from the Controls panel
+// drives the *initial* state and any subsequent panel changes (synced via
+// useEffect). User-triggered closes (Escape, close-button, click outside)
+// only update the local state — the panel won't auto-update to `false`,
+// but the dialog will close visually. Toggle the panel to reopen it.
+//
+// Storybook's `useArgs` would give us full two-way binding but it throws
+// "preview hooks can only be called inside decorators and story
+// functions" when an autodocs story (rendered inline in MDX) calls it,
+// so we fall back to one-way arg → state sync here.
+function DialogHarness({ body, children, open: argOpen, ...props }: DialogArgs) {
+  const [open, setOpen] = useState(Boolean(argOpen));
+  useEffect(() => {
+    setOpen(Boolean(argOpen));
+  }, [argOpen]);
+
   return (
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
@@ -73,46 +76,18 @@ function DialogHarness({
   );
 }
 
-/**
- * Hybrid state hook: keeps the dialog open/closed via local React state
- * (so test runners and the live preview pick up changes immediately),
- * AND mirrors that state into Storybook's args dictionary so the
- * Controls panel reflects (and can drive) the current state.
- */
-function useOpenArg(): [boolean, (next: boolean) => void] {
-  const [{ open: argOpen }, updateArgs] = useArgs<DialogArgs>();
-  const [localOpen, setLocalOpen] = useState(Boolean(argOpen));
-
-  // Mirror args → local when the user toggles the Controls panel.
-  useEffect(() => {
-    setLocalOpen(Boolean(argOpen));
-  }, [argOpen]);
-
-  const setOpen = (next: boolean) => {
-    setLocalOpen(next);
-    updateArgs({ open: next });
-  };
-
-  return [localOpen, setOpen];
-}
-
 export const Default: Story = {
-  render: function Render(args) {
-    const [open, setOpen] = useOpenArg();
-    return (
-      <DialogHarness
-        {...args}
-        open={open}
-        setOpen={setOpen}
-        footer={
-          <>
-            <Button variant="ghost">Cancel</Button>
-            <Button>Save</Button>
-          </>
-        }
-      />
-    );
-  },
+  render: (args) => (
+    <DialogHarness
+      {...args}
+      footer={
+        <>
+          <Button variant="ghost">Cancel</Button>
+          <Button>Save</Button>
+        </>
+      }
+    />
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('button', { name: 'Open dialog' }));
@@ -128,22 +103,17 @@ export const Small: Story = {
     title: 'Confirm',
     description: 'This action cannot be undone.',
   },
-  render: function Render(args) {
-    const [open, setOpen] = useOpenArg();
-    return (
-      <DialogHarness
-        {...args}
-        open={open}
-        setOpen={setOpen}
-        footer={
-          <>
-            <Button variant="ghost">Cancel</Button>
-            <Button variant="destructive">Delete</Button>
-          </>
-        }
-      />
-    );
-  },
+  render: (args) => (
+    <DialogHarness
+      {...args}
+      footer={
+        <>
+          <Button variant="ghost">Cancel</Button>
+          <Button variant="destructive">Delete</Button>
+        </>
+      }
+    />
+  ),
 };
 
 export const Large: Story = {
@@ -152,27 +122,22 @@ export const Large: Story = {
     title: 'Import GEDCOM',
     description: 'Drop a .ged file or pick one from disk to scan it before import.',
   },
-  render: function Render(args) {
-    const [open, setOpen] = useOpenArg();
-    return (
-      <DialogHarness
-        {...args}
-        open={open}
-        setOpen={setOpen}
-        body={
-          <div className="border-border bg-foreground/5 flex h-40 items-center justify-center rounded-md border border-dashed">
-            <span className="text-muted-foreground text-sm">Dropzone placeholder</span>
-          </div>
-        }
-        footer={
-          <>
-            <Button variant="ghost">Cancel</Button>
-            <Button>Import</Button>
-          </>
-        }
-      />
-    );
-  },
+  render: (args) => (
+    <DialogHarness
+      {...args}
+      body={
+        <div className="border-border bg-foreground/5 flex h-40 items-center justify-center rounded-md border border-dashed">
+          <span className="text-muted-foreground text-sm">Dropzone placeholder</span>
+        </div>
+      }
+      footer={
+        <>
+          <Button variant="ghost">Cancel</Button>
+          <Button>Import</Button>
+        </>
+      }
+    />
+  ),
 };
 
 export const WithFooterNote: Story = {
@@ -181,32 +146,24 @@ export const WithFooterNote: Story = {
     description: 'Choose a format and the file is generated locally.',
     footerNote: 'File generated locally',
   },
-  render: function Render(args) {
-    const [open, setOpen] = useOpenArg();
-    return (
-      <DialogHarness
-        {...args}
-        open={open}
-        setOpen={setOpen}
-        footer={
-          <>
-            <Button variant="ghost">Cancel</Button>
-            <Button leadingIcon="download">Download .ged</Button>
-          </>
-        }
-      />
-    );
-  },
+  render: (args) => (
+    <DialogHarness
+      {...args}
+      footer={
+        <>
+          <Button variant="ghost">Cancel</Button>
+          <Button leadingIcon="download">Download .ged</Button>
+        </>
+      }
+    />
+  ),
 };
 
 export const ClosesOnEscape: Story = {
   args: {
     title: 'Press Escape',
   },
-  render: function Render(args) {
-    const [open, setOpen] = useOpenArg();
-    return <DialogHarness {...args} open={open} setOpen={setOpen} />;
-  },
+  render: (args) => <DialogHarness {...args} />,
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('button', { name: 'Open dialog' }));
@@ -227,10 +184,7 @@ export const ClosesOnCloseButton: Story = {
     title: 'Close via button',
     closeLabel: 'Close dialog',
   },
-  render: function Render(args) {
-    const [open, setOpen] = useOpenArg();
-    return <DialogHarness {...args} open={open} setOpen={setOpen} />;
-  },
+  render: (args) => <DialogHarness {...args} />,
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('button', { name: 'Open dialog' }));

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -85,10 +85,10 @@ export interface DialogProps {
   size?: DialogRecipeProps['size'];
 
   /**
-   * Localized accessible name for the close button. Defaults to the
-   * literal `"Close"`; consumers should pass a translated string.
+   * Localized accessible name for the close button. Required (no
+   * default) so a missing translation never ships English to end users.
    */
-  closeLabel?: string;
+  closeLabel: string;
 }
 
 /**
@@ -132,7 +132,7 @@ export function Dialog({
   footer,
   footerNote,
   size,
-  closeLabel = 'Close',
+  closeLabel,
 }: DialogProps) {
   return (
     <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
@@ -161,7 +161,11 @@ export function Dialog({
 
           {footer && (
             <footer className="flex items-center justify-between gap-3 border-t border-border px-6 py-4">
-              <div className="text-muted-foreground text-xs">{footerNote}</div>
+              {footerNote ? (
+                <div className="text-muted-foreground text-xs">{footerNote}</div>
+              ) : (
+                <div />
+              )}
               <div className="flex items-center gap-2">{footer}</div>
             </footer>
           )}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -133,7 +133,7 @@ export function Dialog({
   footerNote,
   size,
   closeLabel,
-}: DialogProps) {
+}: DialogProps): JSX.Element {
   return (
     <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
       <RadixDialog.Portal>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,172 @@
+import * as RadixDialog from '@radix-ui/react-dialog';
+import { type ReactNode } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+import { Button } from './button';
+
+/**
+ * Recipe for the Dialog content's visual variants.
+ *
+ * Sizes:
+ * - `sm` — confirm/cancel prompts, simple destructive flows.
+ * - `md` — default — single-form modals (rename, edit metadata).
+ * - `lg` — multi-section modals with toggles, file pickers, or grids.
+ *
+ * The recipe only sizes the floating shell; the overlay, the header, and the
+ * footer are styled directly in the component because they don't vary.
+ */
+export const dialogContentRecipe = tv({
+  base: [
+    'bg-popover text-popover-foreground shadow-lg',
+    'fixed top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2',
+    'w-[calc(100vw-2rem)] max-h-[calc(100vh-4rem)] overflow-auto',
+    'rounded-lg border border-border',
+    'flex flex-col',
+    'focus:outline-none',
+  ],
+  variants: {
+    size: {
+      sm: 'max-w-[400px]',
+      md: 'max-w-[520px]',
+      lg: 'max-w-[720px]',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+type DialogRecipeProps = VariantProps<typeof dialogContentRecipe>;
+
+/**
+ * Props accepted by {@link Dialog}.
+ */
+export interface DialogProps {
+  /** Whether the dialog is open. Controlled by the consumer. */
+  open: boolean;
+
+  /**
+   * Called when the open state should change — Radix invokes this on
+   * Escape, click outside, and the close button.
+   */
+  onOpenChange: (open: boolean) => void;
+
+  /**
+   * Localized dialog title rendered in the header. Required for
+   * accessibility — Radix sets `aria-labelledby` to its node id.
+   */
+  title: ReactNode;
+
+  /**
+   * Optional localized description rendered under the title. When
+   * provided, Radix wires it via `aria-describedby` on the dialog content.
+   */
+  description?: ReactNode;
+
+  /** Body content of the dialog. */
+  children: ReactNode;
+
+  /**
+   * Optional footer slot — typically a row of action buttons (Cancel
+   * + primary CTA). Rendered with right-aligned actions; pair with
+   * {@link DialogProps.footerNote} for any left-aligned context text.
+   */
+  footer?: ReactNode;
+
+  /**
+   * Optional left-aligned text in the footer (e.g. "File generated
+   * locally"). Has no effect when {@link DialogProps.footer} is omitted.
+   */
+  footerNote?: ReactNode;
+
+  /**
+   * Visual size of the dialog. Defaults to `"md"`.
+   */
+  size?: DialogRecipeProps['size'];
+
+  /**
+   * Localized accessible name for the close button. Defaults to the
+   * literal `"Close"`; consumers should pass a translated string.
+   */
+  closeLabel?: string;
+}
+
+/**
+ * Modal dialog primitive built on `@radix-ui/react-dialog`.
+ *
+ * Provides the chrome shared by every modal in the app: backdrop, centered
+ * popover surface, header (title + optional description + close button),
+ * body and optional footer. Focus trap, Escape, click-outside, and ARIA
+ * wiring are delegated to Radix.
+ *
+ * The component is fully controlled — pass `open` and `onOpenChange` from
+ * the parent. All textual content (`title`, `description`, `footer`,
+ * `closeLabel`) must be localized by the caller; this primitive does not
+ * own copy.
+ *
+ * @example
+ * // Confirm modal
+ * <Dialog
+ *   open={open}
+ *   onOpenChange={setOpen}
+ *   size="sm"
+ *   title={t('individuals.delete.title')}
+ *   description={t('individuals.delete.description')}
+ *   footer={
+ *     <>
+ *       <Button variant="ghost" onClick={() => setOpen(false)}>{t('common.cancel')}</Button>
+ *       <Button variant="destructive" onClick={onConfirm}>{t('common.delete')}</Button>
+ *     </>
+ *   }
+ *   closeLabel={t('common.close')}
+ * >
+ *   <p>{t('individuals.delete.body')}</p>
+ * </Dialog>
+ */
+export function Dialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  footer,
+  footerNote,
+  size,
+  closeLabel = 'Close',
+}: DialogProps) {
+  return (
+    <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
+      <RadixDialog.Portal>
+        <RadixDialog.Overlay className="fixed inset-0 z-40 bg-foreground/40 backdrop-blur-sm" />
+        <RadixDialog.Content className={dialogContentRecipe({ size })} aria-describedby={undefined}>
+          <header className="flex items-start justify-between gap-3 border-b border-border px-6 py-4">
+            <div className="flex flex-col gap-1">
+              <RadixDialog.Title className="text-foreground text-base font-semibold leading-tight">
+                {title}
+              </RadixDialog.Title>
+              {description && (
+                <RadixDialog.Description className="text-muted-foreground text-sm">
+                  {description}
+                </RadixDialog.Description>
+              )}
+            </div>
+            <RadixDialog.Close asChild>
+              <Button variant="ghost" size="sm" hideLabel leadingIcon="x">
+                {closeLabel}
+              </Button>
+            </RadixDialog.Close>
+          </header>
+
+          <div className="flex flex-col gap-4 px-6 py-5">{children}</div>
+
+          {footer && (
+            <footer className="flex items-center justify-between gap-3 border-t border-border px-6 py-4">
+              <div className="text-muted-foreground text-xs">{footerNote}</div>
+              <div className="flex items-center gap-2">{footer}</div>
+            </footer>
+          )}
+        </RadixDialog.Content>
+      </RadixDialog.Portal>
+    </RadixDialog.Root>
+  );
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -146,7 +146,16 @@ export function Dialog({
           // prop entirely so Radix's automatic aria-describedby takes effect.
           {...(description ? {} : { 'aria-describedby': undefined })}
         >
-          <header className="flex items-start justify-between gap-3 border-b border-border px-6 py-4">
+          <header
+            className={
+              // Use `items-center` when the title has no description (so the
+              // close button visually aligns with the title text), and
+              // `items-start` once a description stacks under the title.
+              `flex justify-between gap-3 border-b border-border px-4 py-3 ${
+                description ? 'items-start' : 'items-center'
+              }`
+            }
+          >
             <div className="flex flex-col gap-1">
               <RadixDialog.Title className="text-foreground text-base font-semibold leading-tight">
                 {title}
@@ -158,16 +167,25 @@ export function Dialog({
               )}
             </div>
             <RadixDialog.Close asChild>
-              <Button variant="ghost" size="sm" hideLabel leadingIcon="x">
+              <Button
+                variant="secondary"
+                size="sm"
+                hideLabel
+                leadingIcon="x"
+                // Slightly muted-down version of the secondary background so
+                // the close button reads as interactive at idle without
+                // competing with the primary CTA in the footer.
+                className="bg-muted hover:bg-accent text-muted-foreground hover:text-foreground"
+              >
                 {closeLabel}
               </Button>
             </RadixDialog.Close>
           </header>
 
-          <div className="flex flex-col gap-4 px-6 py-5">{children}</div>
+          <div className="flex flex-col gap-4 px-4 py-4">{children}</div>
 
           {footer && (
-            <footer className="flex items-center justify-between gap-3 border-t border-border px-6 py-4">
+            <footer className="flex items-center justify-between gap-3 border-t border-border px-4 py-3">
               {footerNote ? (
                 <div className="text-muted-foreground text-xs">{footerNote}</div>
               ) : (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -138,7 +138,14 @@ export function Dialog({
     <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
       <RadixDialog.Portal>
         <RadixDialog.Overlay className="fixed inset-0 z-40 bg-foreground/40 backdrop-blur-sm" />
-        <RadixDialog.Content className={dialogContentRecipe({ size })} aria-describedby={undefined}>
+        <RadixDialog.Content
+          className={dialogContentRecipe({ size })}
+          // Only override Radix's auto-wiring when there is no Description
+          // child — `undefined` here suppresses Radix's dev-only "missing
+          // Description" warning. When `description` IS provided, omit the
+          // prop entirely so Radix's automatic aria-describedby takes effect.
+          {...(description ? {} : { 'aria-describedby': undefined })}
+        >
           <header className="flex items-start justify-between gap-3 border-b border-border px-6 py-4">
             <div className="flex flex-col gap-1">
               <RadixDialog.Title className="text-foreground text-base font-semibold leading-tight">

--- a/src/components/ui/dropzone.stories.tsx
+++ b/src/components/ui/dropzone.stories.tsx
@@ -17,6 +17,7 @@ const meta = {
   },
   args: {
     idleLabel: 'Drop a .ged file or click to browse',
+    formatName: 'GEDCOM',
     onFileSelected: fn(),
   },
   decorators: [

--- a/src/components/ui/dropzone.stories.tsx
+++ b/src/components/ui/dropzone.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, within } from 'storybook/test';
+
+import { Dropzone } from './dropzone';
+
+const meta = {
+  title: 'UI/Dropzone',
+  component: Dropzone,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    state: {
+      control: 'select',
+      options: ['idle', 'selected', 'scanning', 'done', 'error'],
+    },
+    disabled: { control: 'boolean' },
+  },
+  args: {
+    idleLabel: 'Drop a .ged file or click to browse',
+    onFileSelected: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Dropzone>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Idle: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Drop a .ged file or click to browse')).toBeInTheDocument();
+  },
+};
+
+export const Selected: Story = {
+  args: { state: 'selected', selectedName: 'family-tree.ged' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('family-tree.ged')).toBeInTheDocument();
+  },
+};
+
+export const Scanning: Story = {
+  args: { state: 'scanning', selectedName: 'family-tree.ged' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    // Scanning should be non-interactive (cursor-progress, aria-disabled).
+    await expect(button).toBeDisabled();
+  },
+};
+
+export const Done: Story = {
+  args: { state: 'done', selectedName: 'family-tree.ged' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    await expect(button).toBeDisabled();
+  },
+};
+
+export const ErrorState: Story = {
+  name: 'Error',
+  args: { state: 'error', selectedName: 'family-tree.ged' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    await expect(button).toBeDisabled();
+  },
+};
+
+export const WithHint: Story = {
+  parameters: { layout: 'padded' },
+  args: { hint: 'Max 50 MB. The original file is never modified.' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Max 50 MB/)).toBeInTheDocument();
+  },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    await expect(button).toBeDisabled();
+  },
+};

--- a/src/components/ui/dropzone.tsx
+++ b/src/components/ui/dropzone.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { useId, type ReactNode } from 'react';
 import { tv, type VariantProps } from 'tailwind-variants';
 
 import { Icon, type IconName } from './icon';
@@ -143,8 +143,10 @@ export function Dropzone({
   selectedName,
   hint,
   disabled,
-}: DropzoneProps) {
+}: DropzoneProps): JSX.Element {
   const interactive = !disabled && (state === 'idle' || state === 'selected');
+  const reactId = useId();
+  const hintId = hint ? `dropzone-${reactId}-hint` : undefined;
 
   async function handleClick() {
     if (!interactive) return;
@@ -176,6 +178,7 @@ export function Dropzone({
     <button
       type="button"
       aria-disabled={!interactive || undefined}
+      aria-describedby={hintId}
       onClick={handleClick}
       disabled={!interactive}
       className={dropzoneRecipe({ state })}
@@ -194,7 +197,9 @@ export function Dropzone({
   return (
     <div className="flex flex-col gap-1.5">
       {card}
-      <p className="text-muted-foreground text-xs">{hint}</p>
+      <p id={hintId} className="text-muted-foreground text-xs">
+        {hint}
+      </p>
     </div>
   );
 }

--- a/src/components/ui/dropzone.tsx
+++ b/src/components/ui/dropzone.tsx
@@ -138,7 +138,7 @@ export function Dropzone({
   state = 'idle',
   onFileSelected,
   accept = ['ged', 'gedcom'],
-  formatName = 'GEDCOM',
+  formatName,
   idleLabel,
   selectedName,
   hint,

--- a/src/components/ui/dropzone.tsx
+++ b/src/components/ui/dropzone.tsx
@@ -155,12 +155,11 @@ export function Dropzone({
       // mode) can still render the wrapper without trying to resolve the
       // plugin entry point at module-init time.
       const { open } = await import('@tauri-apps/plugin-dialog');
-      const selected = await open({
+      const path = await open({
         multiple: false,
         filters: [{ name: formatName, extensions: accept }],
       });
-      if (!selected) return;
-      const path = selected as string;
+      if (!path) return;
       const name = path.split(/[/\\]/).pop() ?? path;
       await onFileSelected({ path, name });
     } catch (err) {

--- a/src/components/ui/dropzone.tsx
+++ b/src/components/ui/dropzone.tsx
@@ -148,18 +148,25 @@ export function Dropzone({
 
   async function handleClick() {
     if (!interactive) return;
-    // Lazy-load so non-Tauri test contexts (Storybook in Vitest browser
-    // mode) can still render the wrapper without trying to resolve the
-    // plugin entry point at module-init time.
-    const { open } = await import('@tauri-apps/plugin-dialog');
-    const selected = await open({
-      multiple: false,
-      filters: [{ name: formatName, extensions: accept }],
-    });
-    if (!selected) return;
-    const path = selected as string;
-    const name = path.split(/[/\\]/).pop() ?? path;
-    await onFileSelected({ path, name });
+    try {
+      // Lazy-load so non-Tauri test contexts (Storybook in Vitest browser
+      // mode) can still render the wrapper without trying to resolve the
+      // plugin entry point at module-init time.
+      const { open } = await import('@tauri-apps/plugin-dialog');
+      const selected = await open({
+        multiple: false,
+        filters: [{ name: formatName, extensions: accept }],
+      });
+      if (!selected) return;
+      const path = selected as string;
+      const name = path.split(/[/\\]/).pop() ?? path;
+      await onFileSelected({ path, name });
+    } catch (err) {
+      // Surface to the dev console so the unhandled rejection isn't silent;
+      // the consumer is expected to drive the `state` prop to `'error'` from
+      // its own catch in onFileSelected when it needs user feedback.
+      console.error('[Dropzone] file dialog or onFileSelected failed:', err);
+    }
   }
 
   const iconName = stateIcon[state];

--- a/src/components/ui/dropzone.tsx
+++ b/src/components/ui/dropzone.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 import { tv, type VariantProps } from 'tailwind-variants';
 
-import { Icon } from './icon';
+import { Icon, type IconName } from './icon';
 
 /**
  * One of the visual states a Dropzone can be in. The consumer drives
@@ -68,10 +68,12 @@ export interface DropzoneProps {
   accept?: string[];
 
   /**
-   * Localized name for the file format used in the filter label and
-   * fallback strings. Defaults to `"GEDCOM"`.
+   * Localized name for the file format shown in the native open-file
+   * dialog (e.g. "GEDCOM"). Required because Tauri's filter label
+   * surfaces directly to end users — a missing translation must never
+   * fall back to English here.
    */
-  formatName?: string;
+  formatName: string;
 
   /**
    * Localized prompt rendered in the idle state (e.g.,
@@ -95,7 +97,7 @@ export interface DropzoneProps {
   disabled?: boolean;
 }
 
-const stateIcon: Record<DropzoneState, 'upload' | 'download' | 'folder-open' | 'x'> = {
+const stateIcon: Record<DropzoneState, IconName> = {
   idle: 'upload',
   selected: 'folder-open',
   scanning: 'upload',
@@ -166,7 +168,6 @@ export function Dropzone({
   const card = (
     <button
       type="button"
-      role="button"
       aria-disabled={!interactive || undefined}
       onClick={handleClick}
       disabled={!interactive}

--- a/src/components/ui/dropzone.tsx
+++ b/src/components/ui/dropzone.tsx
@@ -1,0 +1,192 @@
+import { type ReactNode } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+import { Icon } from './icon';
+
+/**
+ * One of the visual states a Dropzone can be in. The consumer drives
+ * the state — the Dropzone never transitions on its own beyond opening
+ * the file picker.
+ */
+export type DropzoneState = 'idle' | 'selected' | 'scanning' | 'done' | 'error';
+
+/**
+ * Payload passed to {@link DropzoneProps.onFileSelected}. The path
+ * matches what Tauri's `@tauri-apps/plugin-dialog#open` returns.
+ */
+export interface DropzoneFile {
+  /** Absolute filesystem path. */
+  path: string;
+  /** File name with extension. */
+  name: string;
+}
+
+/**
+ * Recipe for the Dropzone outer card. State controls the colour
+ * palette; the inner content layout is the same across states.
+ */
+const dropzoneRecipe = tv({
+  base: [
+    'flex w-full flex-col items-center justify-center gap-2',
+    'rounded-lg border border-dashed bg-card px-6 py-8 text-center',
+    'transition-colors duration-150',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    'disabled:cursor-not-allowed disabled:opacity-60',
+  ],
+  variants: {
+    state: {
+      idle: 'border-border hover:border-primary/40 cursor-pointer',
+      selected: 'border-primary/60 bg-primary/5 cursor-pointer',
+      scanning: 'border-primary/60 bg-primary/5 cursor-progress',
+      done: 'border-success/60 bg-success/5',
+      error: 'border-destructive/60 bg-destructive/5',
+    },
+  },
+  defaultVariants: { state: 'idle' },
+});
+
+type DropzoneRecipeProps = VariantProps<typeof dropzoneRecipe>;
+
+/**
+ * Props accepted by {@link Dropzone}.
+ */
+export interface DropzoneProps {
+  /** Visual state. Driven by the consumer. Defaults to `"idle"`. */
+  state?: DropzoneRecipeProps['state'];
+
+  /**
+   * Called with the picked file once the user confirms the dialog.
+   * Returns nothing — the consumer transitions the `state` prop to
+   * reflect whatever happens next (scanning, done, error).
+   */
+  onFileSelected: (file: DropzoneFile) => void | Promise<void>;
+
+  /**
+   * File extensions accepted (without the leading dot), passed through
+   * to Tauri's open() filters. Defaults to `['ged', 'gedcom']`.
+   */
+  accept?: string[];
+
+  /**
+   * Localized name for the file format used in the filter label and
+   * fallback strings. Defaults to `"GEDCOM"`.
+   */
+  formatName?: string;
+
+  /**
+   * Localized prompt rendered in the idle state (e.g.,
+   * "Drop a .ged file or click to browse"). Required so the wrapper
+   * does not own copy.
+   */
+  idleLabel: ReactNode;
+
+  /**
+   * Localized name shown in selected / scanning / done states. Skipped
+   * if not provided.
+   */
+  selectedName?: ReactNode;
+
+  /**
+   * Optional localized help text rendered below the card.
+   */
+  hint?: ReactNode;
+
+  /** Disables the dropzone (no click, no dialog). */
+  disabled?: boolean;
+}
+
+const stateIcon: Record<DropzoneState, 'upload' | 'download' | 'folder-open' | 'x'> = {
+  idle: 'upload',
+  selected: 'folder-open',
+  scanning: 'upload',
+  done: 'download',
+  error: 'x',
+};
+
+/**
+ * File picker styled as a drop zone. Clicking the card opens the
+ * native Tauri file dialog. Drag-and-drop handling is intentionally
+ * out of scope for v1 — Tauri 2's webview drag events are an OS-level
+ * concern; the click path covers the same use case with a real native
+ * dialog.
+ *
+ * The component is a controlled visual: the `state` prop drives the
+ * appearance; the consumer transitions through `idle → selected →
+ * scanning → done | error` after acting on the picked file.
+ *
+ * @example
+ * <Dropzone
+ *   state={state}
+ *   onFileSelected={async (file) => {
+ *     setSelected(file);
+ *     setState('scanning');
+ *     try {
+ *       await scan(file);
+ *       setState('done');
+ *     } catch {
+ *       setState('error');
+ *     }
+ *   }}
+ *   idleLabel={t('import.dropzone.idle')}
+ *   selectedName={selected?.name}
+ *   hint={t('import.dropzone.hint')}
+ * />
+ */
+export function Dropzone({
+  state = 'idle',
+  onFileSelected,
+  accept = ['ged', 'gedcom'],
+  formatName = 'GEDCOM',
+  idleLabel,
+  selectedName,
+  hint,
+  disabled,
+}: DropzoneProps) {
+  const interactive = !disabled && (state === 'idle' || state === 'selected');
+
+  async function handleClick() {
+    if (!interactive) return;
+    // Lazy-load so non-Tauri test contexts (Storybook in Vitest browser
+    // mode) can still render the wrapper without trying to resolve the
+    // plugin entry point at module-init time.
+    const { open } = await import('@tauri-apps/plugin-dialog');
+    const selected = await open({
+      multiple: false,
+      filters: [{ name: formatName, extensions: accept }],
+    });
+    if (!selected) return;
+    const path = selected as string;
+    const name = path.split(/[/\\]/).pop() ?? path;
+    await onFileSelected({ path, name });
+  }
+
+  const iconName = stateIcon[state];
+  const showSelectedName = state !== 'idle' && selectedName;
+
+  const card = (
+    <button
+      type="button"
+      role="button"
+      aria-disabled={!interactive || undefined}
+      onClick={handleClick}
+      disabled={!interactive}
+      className={dropzoneRecipe({ state })}
+    >
+      <Icon name={iconName} size={24} />
+      <span className="text-foreground text-sm font-medium">
+        {showSelectedName ? selectedName : idleLabel}
+      </span>
+    </button>
+  );
+
+  if (!hint) {
+    return card;
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {card}
+      <p className="text-muted-foreground text-xs">{hint}</p>
+    </div>
+  );
+}

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,0 +1,91 @@
+import { useId, type ReactNode } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+/**
+ * Recipe shared by all single-element form fields (Input, Textarea
+ * trigger style, Select trigger). Owns the colour, border, focus-ring,
+ * and disabled tokens. Per-field wrappers extend it for size-specific
+ * dimensions (height vs min-height, padding) since textareas need
+ * `min-h-` while inputs/selects use a fixed `h-`.
+ */
+export const fieldRecipe = tv({
+  base: [
+    'block w-full bg-card text-foreground placeholder:text-muted-foreground',
+    'rounded-md border',
+    'transition-colors duration-150',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+  ],
+  variants: {
+    size: {
+      sm: 'h-7 px-2 text-xs',
+      md: 'h-9 px-3 text-sm',
+      lg: 'h-11 px-4 text-base',
+    },
+    state: {
+      default: 'border-input focus-visible:ring-ring',
+      error: 'border-destructive focus-visible:ring-destructive',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    state: 'default',
+  },
+});
+
+export type FieldRecipeProps = VariantProps<typeof fieldRecipe>;
+
+/**
+ * Wires the `aria-describedby` association between a field and its
+ * optional hint. Generates a stable id pair when the caller hasn't
+ * supplied one, and merges any caller-supplied `aria-describedby` so
+ * the hint id is appended rather than overwritten.
+ *
+ * Returns `hintId === undefined` when no hint is set, signalling that
+ * the consumer should render the field bare (no wrapping div, no hint
+ * paragraph).
+ */
+export function useFieldHint({
+  id,
+  hint,
+  ariaDescribedBy,
+  prefix,
+}: {
+  id?: string;
+  hint?: ReactNode;
+  ariaDescribedBy?: string;
+  prefix: string;
+}) {
+  const reactId = useId();
+  const fieldId = id ?? `${prefix}-${reactId}`;
+  const hintId = hint ? `${fieldId}-hint` : undefined;
+  const describedBy = [ariaDescribedBy, hintId].filter(Boolean).join(' ') || undefined;
+  return { fieldId, hintId, describedBy };
+}
+
+/**
+ * Wraps a field element with its hint paragraph. Returns the field as-is
+ * when no hint is set so consumers don't pay a wrapper div for the
+ * common case.
+ */
+export function FieldWithHint({
+  field,
+  hint,
+  hintId,
+}: {
+  field: ReactNode;
+  hint: ReactNode;
+  hintId: string | undefined;
+}) {
+  if (!hint) {
+    return <>{field}</>;
+  }
+  return (
+    <div className="flex flex-col gap-1">
+      {field}
+      <p id={hintId} className="text-muted-foreground text-xs">
+        {hint}
+      </p>
+    </div>
+  );
+}

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -55,7 +55,11 @@ export function useFieldHint({
   hint?: ReactNode;
   ariaDescribedBy?: string;
   prefix: string;
-}) {
+}): {
+  fieldId: string;
+  hintId: string | undefined;
+  describedBy: string | undefined;
+} {
   const reactId = useId();
   const fieldId = id ?? `${prefix}-${reactId}`;
   const hintId = hint ? `${fieldId}-hint` : undefined;
@@ -76,7 +80,7 @@ export function FieldWithHint({
   field: ReactNode;
   hint: ReactNode;
   hintId: string | undefined;
-}) {
+}): JSX.Element {
   if (!hint) {
     return <>{field}</>;
   }

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -3,10 +3,13 @@ import {
   ArrowRight,
   ChevronDown,
   ChevronRight,
+  Download,
+  FolderOpen,
   Pencil,
   Plus,
   Search,
   Trash2,
+  Upload,
   X,
   type LucideProps,
 } from 'lucide-react';
@@ -27,10 +30,13 @@ export const iconRegistry = {
   'arrow-right': ArrowRight,
   'chevron-down': ChevronDown,
   'chevron-right': ChevronRight,
+  download: Download,
+  'folder-open': FolderOpen,
   pencil: Pencil,
   plus: Plus,
   search: Search,
   trash: Trash2,
+  upload: Upload,
   x: X,
 } as const satisfies Record<string, ComponentType<LucideProps>>;
 

--- a/src/components/ui/input.stories.tsx
+++ b/src/components/ui/input.stories.tsx
@@ -120,6 +120,30 @@ export const Sizes: Story = {
   },
 };
 
+export const WithHint: Story = {
+  parameters: { layout: 'padded' },
+  render: (args) => (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor="input-with-hint" className="text-foreground text-sm font-medium">
+        Tree name
+      </label>
+      <Input
+        {...args}
+        id="input-with-hint"
+        hint="Used as the database filename — letters, numbers, and dashes only."
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText<HTMLInputElement>('Tree name');
+    const describedBy = input.getAttribute('aria-describedby');
+    await expect(describedBy).not.toBeNull();
+    const hint = canvas.getByText(/Used as the database filename/i);
+    await expect(hint.id).toBe(describedBy);
+  },
+};
+
 const types = ['text', 'email', 'url', 'tel', 'search', 'password'] as const;
 
 export const Types: Story = {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type InputHTMLAttributes } from 'react';
+import { forwardRef, useId, type InputHTMLAttributes, type ReactNode } from 'react';
 import { tv, type VariantProps } from 'tailwind-variants';
 
 /**
@@ -75,6 +75,14 @@ export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
    * consistent signal.
    */
   invalid?: boolean;
+
+  /**
+   * Optional help text rendered below the input. When provided, the input is
+   * wrapped in a small block container and `aria-describedby` is wired so
+   * assistive tech announces the hint after the field's accessible name.
+   * Pass localized content from the consumer — the wrapper does not own copy.
+   */
+  hint?: ReactNode;
 }
 
 /**
@@ -104,17 +112,46 @@ export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
  * <Input type="search" placeholder="Search trees" aria-label="Search trees" />
  */
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { type = 'text', size, invalid = false, className, ...props },
+  {
+    type = 'text',
+    size,
+    invalid = false,
+    hint,
+    className,
+    id,
+    'aria-describedby': ariaDescribedBy,
+    ...props
+  },
   ref
 ) {
-  return (
+  const reactId = useId();
+  const inputId = id ?? (hint ? `input-${reactId}` : undefined);
+  const hintId = hint ? `${inputId}-hint` : undefined;
+  const describedBy = [ariaDescribedBy, hintId].filter(Boolean).join(' ') || undefined;
+
+  const input = (
     <input
       ref={ref}
+      id={inputId}
       type={type}
       aria-invalid={invalid || undefined}
+      aria-describedby={describedBy}
       className={inputRecipe({ size, state: invalid ? 'error' : 'default', className })}
       {...props}
     />
+  );
+
+  if (!hint) {
+    return input;
+  }
+
+  return (
+    <div className="block">
+      {input}
+      <p id={hintId} className="text-muted-foreground mt-1 text-xs">
+        {hint}
+      </p>
+    </div>
   );
 });
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,5 +1,6 @@
-import { forwardRef, useId, type InputHTMLAttributes, type ReactNode } from 'react';
-import { tv, type VariantProps } from 'tailwind-variants';
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react';
+
+import { fieldRecipe, FieldWithHint, useFieldHint, type FieldRecipeProps } from './field';
 
 /**
  * HTML input types accepted by {@link Input}. Restricted to text-shaped
@@ -9,45 +10,8 @@ import { tv, type VariantProps } from 'tailwind-variants';
  */
 export type InputTextType = 'text' | 'email' | 'url' | 'tel' | 'search' | 'password';
 
-/**
- * Recipe for the Input component's visual variants.
- *
- * Sizes:
- * - `sm` — dense forms, inline filters.
- * - `md` — default form size.
- * - `lg` — primary onboarding fields, search hero.
- *
- * State:
- * - `default` — neutral border, accent ring on focus.
- * - `error` — red border + red focus ring. Pair with `aria-invalid` and an
- *   adjacent error message; the {@link InputProps.invalid} shortcut handles both.
- */
-export const inputRecipe = tv({
-  base: [
-    'block w-full bg-card text-foreground placeholder:text-muted-foreground',
-    'rounded-md border',
-    'transition-colors duration-150',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-    'disabled:cursor-not-allowed disabled:opacity-50',
-  ],
-  variants: {
-    size: {
-      sm: 'h-7 px-2 text-xs',
-      md: 'h-9 px-3 text-sm',
-      lg: 'h-11 px-4 text-base',
-    },
-    state: {
-      default: 'border-input focus-visible:ring-ring',
-      error: 'border-destructive focus-visible:ring-destructive',
-    },
-  },
-  defaultVariants: {
-    size: 'md',
-    state: 'default',
-  },
-});
-
-type InputRecipeProps = VariantProps<typeof inputRecipe>;
+/** Re-exported for backward compatibility — prefer `fieldRecipe` from `./field`. */
+export const inputRecipe = fieldRecipe;
 
 /**
  * Props accepted by {@link Input}. Extends the native `<input>` props minus
@@ -66,7 +30,7 @@ export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
    * which is intentionally not exposed here.
    * Defaults to `"md"`.
    */
-  size?: InputRecipeProps['size'];
+  size?: FieldRecipeProps['size'];
 
   /**
    * Marks the input as invalid for both assistive tech (`aria-invalid="true"`)
@@ -124,35 +88,26 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   },
   ref
 ) {
-  const reactId = useId();
-  const inputId = id ?? (hint ? `input-${reactId}` : undefined);
-  const hintId = hint ? `${inputId}-hint` : undefined;
-  const describedBy = [ariaDescribedBy, hintId].filter(Boolean).join(' ') || undefined;
+  const { fieldId, hintId, describedBy } = useFieldHint({
+    id,
+    hint,
+    ariaDescribedBy,
+    prefix: 'input',
+  });
 
   const input = (
     <input
       ref={ref}
-      id={inputId}
+      id={fieldId}
       type={type}
       aria-invalid={invalid || undefined}
       aria-describedby={describedBy}
-      className={inputRecipe({ size, state: invalid ? 'error' : 'default', className })}
+      className={fieldRecipe({ size, state: invalid ? 'error' : 'default', className })}
       {...props}
     />
   );
 
-  if (!hint) {
-    return input;
-  }
-
-  return (
-    <div className="block">
-      {input}
-      <p id={hintId} className="text-muted-foreground mt-1 text-xs">
-        {hint}
-      </p>
-    </div>
-  );
+  return <FieldWithHint field={input} hint={hint} hintId={hintId} />;
 });
 
 Input.displayName = 'Input';

--- a/src/components/ui/option-card.stories.tsx
+++ b/src/components/ui/option-card.stories.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { OptionCard, OptionCardGroup } from './option-card';
+
+type GroupArgs = React.ComponentProps<typeof OptionCardGroup>;
+
+const meta: Meta<GroupArgs> = {
+  title: 'UI/OptionCard',
+  component: OptionCardGroup,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    cols: { control: 'select', options: [1, 2, 3] },
+  },
+  args: {
+    'aria-label': 'Starting point',
+    value: 'empty',
+    onValueChange: fn(),
+    children: null,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[600px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<GroupArgs>;
+
+export const TwoColumns: Story = {
+  args: { cols: 2 },
+  render: (args) => (
+    <OptionCardGroup {...args}>
+      <OptionCard
+        value="empty"
+        label="Empty tree"
+        description="Start from a blank canvas — no individuals, no families."
+      />
+      <OptionCard
+        value="from-me"
+        label="Tree from me"
+        description="Pre-fill with you as the starting individual."
+      />
+    </OptionCardGroup>
+  ),
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('radiogroup', { name: 'Starting point' });
+    await expect(group).toBeInTheDocument();
+    await expect(canvas.getAllByRole('radio')).toHaveLength(2);
+    await userEvent.click(canvas.getByRole('radio', { name: /Tree from me/ }));
+    await expect(args.onValueChange).toHaveBeenCalledWith('from-me');
+  },
+};
+
+export const ThreeColumns: Story = {
+  args: { cols: 3, value: 'gedcom', 'aria-label': 'Export format' },
+  render: (args) => (
+    <OptionCardGroup {...args}>
+      <OptionCard value="gedcom" label="GEDCOM" description="Standard genealogical exchange." />
+      <OptionCard
+        value="json"
+        label="JSON"
+        description="Structured archive with all internal fields."
+        soon
+      />
+      <OptionCard
+        value="zip"
+        label="ZIP archive"
+        description="GEDCOM + media files bundled together."
+        soon
+      />
+    </OptionCardGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('radio')).toHaveLength(3);
+    // The two `soon` options must be disabled.
+    const json = canvas.getByRole('radio', { name: /JSON/ });
+    const zip = canvas.getByRole('radio', { name: /ZIP archive/ });
+    await expect(json).toBeDisabled();
+    await expect(zip).toBeDisabled();
+  },
+};
+
+export const Disabled: Story = {
+  render: (args) => (
+    <OptionCardGroup {...args}>
+      <OptionCard value="empty" label="Empty" />
+      <OptionCard value="from-me" label="From me" disabled />
+    </OptionCardGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const fromMe = canvas.getByRole('radio', { name: 'From me' });
+    await expect(fromMe).toBeDisabled();
+  },
+};
+
+function ControlledGroup() {
+  const [value, setValue] = useState('empty');
+  return (
+    <OptionCardGroup value={value} onValueChange={setValue} aria-label="Starting point">
+      <OptionCard value="empty" label="Empty" />
+      <OptionCard value="from-me" label="From me" />
+    </OptionCardGroup>
+  );
+}
+
+export const Controlled: Story = {
+  render: () => <ControlledGroup />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const fromMe = canvas.getByRole('radio', { name: 'From me' });
+    await userEvent.click(fromMe);
+    await expect(fromMe).toHaveAttribute('aria-checked', 'true');
+  },
+};

--- a/src/components/ui/option-card.stories.tsx
+++ b/src/components/ui/option-card.stories.tsx
@@ -68,12 +68,14 @@ export const ThreeColumns: Story = {
         label="JSON"
         description="Structured archive with all internal fields."
         soon
+        soonLabel="Soon"
       />
       <OptionCard
         value="zip"
         label="ZIP archive"
         description="GEDCOM + media files bundled together."
         soon
+        soonLabel="Soon"
       />
     </OptionCardGroup>
   ),

--- a/src/components/ui/option-card.stories.tsx
+++ b/src/components/ui/option-card.stories.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useState, type ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { OptionCard, OptionCardGroup } from './option-card';
 
-type GroupArgs = React.ComponentProps<typeof OptionCardGroup>;
+type GroupArgs = ComponentProps<typeof OptionCardGroup>;
 
 const meta: Meta<GroupArgs> = {
   title: 'UI/OptionCard',
@@ -121,5 +121,38 @@ export const Controlled: Story = {
     const fromMe = canvas.getByRole('radio', { name: 'From me' });
     await userEvent.click(fromMe);
     await expect(fromMe).toHaveAttribute('aria-checked', 'true');
+  },
+};
+
+export const Matrix: Story = {
+  parameters: { layout: 'padded' },
+  render: () => (
+    <div className="flex flex-col gap-6">
+      {([1, 2, 3] as const).map((cols) => (
+        <OptionCardGroup
+          key={cols}
+          value="default"
+          onValueChange={() => {}}
+          aria-label={`${cols} column${cols === 1 ? '' : 's'}`}
+          cols={cols}
+        >
+          <OptionCard value="default" label="Default" description="Selectable card." />
+          {cols >= 2 && <OptionCard value="disabled" label="Disabled" disabled />}
+          {cols === 3 && (
+            <OptionCard
+              value="soon"
+              label="Soon"
+              description="Coming later."
+              soon
+              soonLabel="Soon"
+            />
+          )}
+        </OptionCardGroup>
+      ))}
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('radiogroup')).toHaveLength(3);
   },
 };

--- a/src/components/ui/option-card.tsx
+++ b/src/components/ui/option-card.tsx
@@ -1,0 +1,167 @@
+import * as RadixRadioGroup from '@radix-ui/react-radio-group';
+import { type ReactNode } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+import { Badge } from './badge';
+
+/**
+ * Recipe for the {@link OptionCardGroup} grid container.
+ */
+const groupRecipe = tv({
+  base: 'grid gap-3',
+  variants: {
+    cols: {
+      1: 'grid-cols-1',
+      2: 'grid-cols-1 sm:grid-cols-2',
+      3: 'grid-cols-1 sm:grid-cols-3',
+    },
+  },
+  defaultVariants: { cols: 2 },
+});
+
+type GroupRecipeProps = VariantProps<typeof groupRecipe>;
+
+/**
+ * Recipe for an individual {@link OptionCard}.
+ *
+ * Selected state uses Radix's `data-state="checked"` attribute to swap
+ * the border colour and ring; disabled state dims the whole card.
+ */
+const cardRecipe = tv({
+  base: [
+    'relative flex flex-col items-start gap-1 rounded-lg border bg-card p-4 text-left',
+    'transition-colors duration-150',
+    'cursor-pointer',
+    'border-border hover:border-primary/40',
+    'data-[state=checked]:border-primary data-[state=checked]:ring-2 data-[state=checked]:ring-primary/20',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    'disabled:cursor-not-allowed disabled:opacity-60',
+  ],
+});
+
+/**
+ * Props accepted by {@link OptionCardGroup}.
+ */
+export interface OptionCardGroupProps {
+  /** Currently selected value. Controlled. */
+  value: string;
+
+  /** Called when a card is selected. */
+  onValueChange: (value: string) => void;
+
+  /**
+   * Number of columns in the responsive grid (collapses to 1 on small
+   * viewports). Defaults to `2`.
+   */
+  cols?: GroupRecipeProps['cols'];
+
+  /**
+   * Localized accessible name for the radio group. Required so assistive
+   * tech announces what the cards represent (e.g., "Starting point").
+   */
+  'aria-label': string;
+
+  /** Children — typically one or more {@link OptionCard}s. */
+  children: ReactNode;
+}
+
+/**
+ * Grid of selectable option cards built on `@radix-ui/react-radio-group`.
+ *
+ * Use this when the choice between options is the *primary* decision in
+ * a form — for example, "Empty tree vs Tree from me" in the New Tree
+ * modal, or "GEDCOM vs JSON vs ZIP" in the Download modal. For dense or
+ * inline choices, prefer a regular RadioGroup or SegmentedControl.
+ *
+ * Always pass `aria-label` so the group has an accessible name.
+ *
+ * @example
+ * <OptionCardGroup
+ *   value={mode}
+ *   onValueChange={setMode}
+ *   aria-label={t('newTree.startingPoint')}
+ *   cols={2}
+ * >
+ *   <OptionCard value="empty" label={t('newTree.empty.label')} description={t('newTree.empty.description')} />
+ *   <OptionCard value="from-me" label={t('newTree.fromMe.label')} description={t('newTree.fromMe.description')} />
+ * </OptionCardGroup>
+ */
+export function OptionCardGroup({
+  value,
+  onValueChange,
+  cols,
+  'aria-label': ariaLabel,
+  children,
+}: OptionCardGroupProps) {
+  return (
+    <RadixRadioGroup.Root
+      value={value}
+      onValueChange={onValueChange}
+      aria-label={ariaLabel}
+      className={groupRecipe({ cols })}
+    >
+      {children}
+    </RadixRadioGroup.Root>
+  );
+}
+
+/**
+ * Props accepted by {@link OptionCard}.
+ */
+export interface OptionCardProps {
+  /** Unique value submitted to {@link OptionCardGroup.onValueChange}. */
+  value: string;
+
+  /** Localized label rendered as the card heading. */
+  label: ReactNode;
+
+  /** Optional localized description rendered under the label. */
+  description?: ReactNode;
+
+  /** Disables the option (cannot be selected). */
+  disabled?: boolean;
+
+  /**
+   * Marks the option as a coming-soon preview. Renders a Badge with
+   * variant `soon` in the top-right and forces `disabled` semantics.
+   */
+  soon?: boolean;
+
+  /**
+   * Localized text for the soon badge. Defaults to `"Soon"`; pass a
+   * translated string. No effect when `soon` is `false`.
+   */
+  soonLabel?: string;
+}
+
+/**
+ * Single selectable card inside an {@link OptionCardGroup}.
+ *
+ * Renders as a `<button role="radio">` so keyboard navigation
+ * (Up/Down/Left/Right between siblings, Space to select) and screen-reader
+ * announcements are handled by Radix.
+ */
+export function OptionCard({
+  value,
+  label,
+  description,
+  disabled,
+  soon = false,
+  soonLabel = 'Soon',
+}: OptionCardProps) {
+  return (
+    <RadixRadioGroup.Item value={value} disabled={disabled || soon} className={cardRecipe()}>
+      {soon && (
+        <span className="absolute right-3 top-3">
+          <Badge variant="soon" size="sm">
+            {soonLabel}
+          </Badge>
+        </span>
+      )}
+      <span className="text-foreground text-sm font-medium leading-tight">{label}</span>
+      {description && (
+        <span className="text-muted-foreground text-xs leading-snug">{description}</span>
+      )}
+    </RadixRadioGroup.Item>
+  );
+}

--- a/src/components/ui/option-card.tsx
+++ b/src/components/ui/option-card.tsx
@@ -105,10 +105,7 @@ export function OptionCardGroup({
   );
 }
 
-/**
- * Props accepted by {@link OptionCard}.
- */
-export interface OptionCardProps {
+interface OptionCardBaseProps {
   /** Unique value submitted to {@link OptionCardGroup.onValueChange}. */
   value: string;
 
@@ -120,19 +117,26 @@ export interface OptionCardProps {
 
   /** Disables the option (cannot be selected). */
   disabled?: boolean;
-
-  /**
-   * Marks the option as a coming-soon preview. Renders a Badge with
-   * variant `soon` in the top-right and forces `disabled` semantics.
-   */
-  soon?: boolean;
-
-  /**
-   * Localized text for the soon badge. Defaults to `"Soon"`; pass a
-   * translated string. No effect when `soon` is `false`.
-   */
-  soonLabel?: string;
 }
+
+/**
+ * Props accepted by {@link OptionCard}. Discriminated on `soon` so the
+ * `soonLabel` (a client-facing string) is required precisely when the
+ * Badge is rendered — never accidentally falling back to English.
+ */
+export type OptionCardProps = OptionCardBaseProps &
+  (
+    | { soon?: false; soonLabel?: never }
+    | {
+        /**
+         * Marks the option as a coming-soon preview. Renders a Badge with
+         * variant `soon` in the top-right and forces `disabled` semantics.
+         */
+        soon: true;
+        /** Localized text for the soon badge. Required when `soon` is true. */
+        soonLabel: string;
+      }
+  );
 
 /**
  * Single selectable card inside an {@link OptionCardGroup}.
@@ -141,20 +145,15 @@ export interface OptionCardProps {
  * (Up/Down/Left/Right between siblings, Space to select) and screen-reader
  * announcements are handled by Radix.
  */
-export function OptionCard({
-  value,
-  label,
-  description,
-  disabled,
-  soon = false,
-  soonLabel = 'Soon',
-}: OptionCardProps) {
+export function OptionCard(props: OptionCardProps) {
+  const { value, label, description, disabled } = props;
+  const soon = props.soon === true;
   return (
     <RadixRadioGroup.Item value={value} disabled={disabled || soon} className={cardRecipe()}>
       {soon && (
         <span className="absolute right-3 top-3">
           <Badge variant="soon" size="sm">
-            {soonLabel}
+            {props.soonLabel}
           </Badge>
         </span>
       )}

--- a/src/components/ui/option-card.tsx
+++ b/src/components/ui/option-card.tsx
@@ -92,7 +92,7 @@ export function OptionCardGroup({
   cols,
   'aria-label': ariaLabel,
   children,
-}: OptionCardGroupProps) {
+}: OptionCardGroupProps): JSX.Element {
   return (
     <RadixRadioGroup.Root
       value={value}
@@ -145,7 +145,7 @@ export type OptionCardProps = OptionCardBaseProps &
  * (Up/Down/Left/Right between siblings, Space to select) and screen-reader
  * announcements are handled by Radix.
  */
-export function OptionCard(props: OptionCardProps) {
+export function OptionCard(props: OptionCardProps): JSX.Element {
   const { value, label, description, disabled } = props;
   const soon = props.soon === true;
   return (

--- a/src/components/ui/segmented-control.stories.tsx
+++ b/src/components/ui/segmented-control.stories.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { SegmentedControl } from './segmented-control';
+
+type Args = React.ComponentProps<typeof SegmentedControl>;
+
+const sortOptions = [
+  { value: 'recent', label: 'Recent' },
+  { value: 'name', label: 'Name' },
+  { value: 'size', label: 'Size' },
+];
+
+const meta: Meta<Args> = {
+  title: 'UI/SegmentedControl',
+  component: SegmentedControl,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md'] },
+  },
+  args: {
+    'aria-label': 'Sort by',
+    value: 'recent',
+    options: sortOptions,
+    onValueChange: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<Args>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('group', { name: 'Sort by' });
+    await expect(group).toBeInTheDocument();
+    await expect(canvas.getAllByRole('radio')).toHaveLength(3);
+    const recent = canvas.getByRole('radio', { name: 'Recent' });
+    await expect(recent).toHaveAttribute('aria-checked', 'true');
+  },
+};
+
+export const TwoOptions: Story = {
+  args: {
+    'aria-label': 'Theme',
+    value: 'dark',
+    options: [
+      { value: 'dark', label: 'Dark' },
+      { value: 'light', label: 'Light' },
+    ],
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const light = canvas.getByRole('radio', { name: 'Light' });
+    await userEvent.click(light);
+    await expect(args.onValueChange).toHaveBeenCalledWith('light');
+  },
+};
+
+export const Small: Story = {
+  args: { size: 'sm' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('radio')).toHaveLength(3);
+  },
+};
+
+export const WithDisabledOption: Story = {
+  args: {
+    options: [
+      { value: 'recent', label: 'Recent' },
+      { value: 'name', label: 'Name' },
+      { value: 'size', label: 'Size', disabled: true },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const sizeOption = canvas.getByRole('radio', { name: 'Size' });
+    await expect(sizeOption).toBeDisabled();
+  },
+};
+
+function ControlledControl() {
+  const [value, setValue] = useState('recent');
+  return (
+    <SegmentedControl
+      value={value}
+      onValueChange={(next) => {
+        if (next) setValue(next);
+      }}
+      options={sortOptions}
+      aria-label="Sort"
+    />
+  );
+}
+
+export const Controlled: Story = {
+  render: () => <ControlledControl />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const name = canvas.getByRole('radio', { name: 'Name' });
+    await userEvent.click(name);
+    await expect(name).toHaveAttribute('aria-checked', 'true');
+  },
+};

--- a/src/components/ui/segmented-control.stories.tsx
+++ b/src/components/ui/segmented-control.stories.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useState, type ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { SegmentedControl } from './segmented-control';
 
-type Args = React.ComponentProps<typeof SegmentedControl>;
+type Args = ComponentProps<typeof SegmentedControl>;
 
 const sortOptions = [
   { value: 'recent', label: 'Recent' },
@@ -103,5 +103,27 @@ export const Controlled: Story = {
     const name = canvas.getByRole('radio', { name: 'Name' });
     await userEvent.click(name);
     await expect(name).toHaveAttribute('aria-checked', 'true');
+  },
+};
+
+export const Matrix: Story = {
+  parameters: { layout: 'padded' },
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {(['md', 'sm'] as const).map((size) => (
+        <SegmentedControl
+          key={size}
+          size={size}
+          value="recent"
+          options={sortOptions}
+          aria-label={`Sort by (${size})`}
+          onValueChange={() => {}}
+        />
+      ))}
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('group')).toHaveLength(2);
   },
 };

--- a/src/components/ui/segmented-control.tsx
+++ b/src/components/ui/segmented-control.tsx
@@ -68,6 +68,10 @@ export interface SegmentedControlProps {
    * tech can announce what the segments represent (e.g., "Sort by").
    */
   'aria-label': string;
+
+  // Note: Radix ToggleGroup with type="single" emits an empty string
+  // when the user re-clicks the active segment. Consumers decide
+  // whether to allow deselection or guard with `if (next) ...`.
 }
 
 /**
@@ -104,12 +108,7 @@ export function SegmentedControl({
     <RadixToggleGroup.Root
       type="single"
       value={value}
-      onValueChange={(next) => {
-        // Radix emits an empty string when the user re-clicks the active
-        // segment. We forward that through — consumers decide whether
-        // to allow deselection or guard with `if (next) ...`.
-        onValueChange(next);
-      }}
+      onValueChange={onValueChange}
       aria-label={ariaLabel}
       className={groupRecipe()}
     >

--- a/src/components/ui/segmented-control.tsx
+++ b/src/components/ui/segmented-control.tsx
@@ -1,0 +1,128 @@
+import * as RadixToggleGroup from '@radix-ui/react-toggle-group';
+import { type ReactNode } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+/**
+ * Recipe for the SegmentedControl wrapper.
+ */
+const groupRecipe = tv({
+  base: [
+    'inline-flex items-center rounded-md border border-border bg-card p-0.5',
+    'focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background',
+  ],
+});
+
+/**
+ * Recipe for an individual segment inside the control.
+ */
+const itemRecipe = tv({
+  base: [
+    'inline-flex items-center justify-center whitespace-nowrap rounded-sm font-medium',
+    'transition-colors duration-150',
+    'text-muted-foreground hover:text-foreground',
+    'data-[state=on]:bg-accent data-[state=on]:text-accent-foreground',
+    'focus-visible:outline-none',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+  ],
+  variants: {
+    size: {
+      sm: 'h-6 px-2 text-xs',
+      md: 'h-8 px-3 text-sm',
+    },
+  },
+  defaultVariants: { size: 'md' },
+});
+
+type ItemRecipeProps = VariantProps<typeof itemRecipe>;
+
+/**
+ * One option inside a {@link SegmentedControl}.
+ */
+export interface SegmentedControlOption {
+  /** Submitted value. */
+  value: string;
+  /** Localized label rendered in the segment. */
+  label: ReactNode;
+  /** Disables this segment. */
+  disabled?: boolean;
+}
+
+/**
+ * Props accepted by {@link SegmentedControl}.
+ */
+export interface SegmentedControlProps {
+  /** Currently selected value. Controlled. Empty string means none. */
+  value: string;
+
+  /** Called when the user picks a segment. */
+  onValueChange: (value: string) => void;
+
+  /** Options to render. */
+  options: SegmentedControlOption[];
+
+  /** Visual size. Defaults to `"md"`. */
+  size?: ItemRecipeProps['size'];
+
+  /**
+   * Localized accessible name for the group. Required so assistive
+   * tech can announce what the segments represent (e.g., "Sort by").
+   */
+  'aria-label': string;
+}
+
+/**
+ * Single-selection segmented control built on Radix ToggleGroup.
+ *
+ * Use this for compact, inline pickers where the user is choosing
+ * between 2–4 short labels (sort orders, density toggles, theme
+ * pickers). For richer per-option layouts, prefer {@link OptionCard}
+ * with its grid of cards.
+ *
+ * Keyboard navigation (arrow keys), focus management, and roving
+ * tabindex are handled by Radix.
+ *
+ * @example
+ * <SegmentedControl
+ *   value={sort}
+ *   onValueChange={(v) => v && setSort(v)}
+ *   options={[
+ *     { value: 'recent', label: t('sort.recent') },
+ *     { value: 'name', label: t('sort.name') },
+ *     { value: 'size', label: t('sort.size') },
+ *   ]}
+ *   aria-label={t('sort.ariaLabel')}
+ * />
+ */
+export function SegmentedControl({
+  value,
+  onValueChange,
+  options,
+  size,
+  'aria-label': ariaLabel,
+}: SegmentedControlProps) {
+  return (
+    <RadixToggleGroup.Root
+      type="single"
+      value={value}
+      onValueChange={(next) => {
+        // Radix emits an empty string when the user re-clicks the active
+        // segment. We forward that through — consumers decide whether
+        // to allow deselection or guard with `if (next) ...`.
+        onValueChange(next);
+      }}
+      aria-label={ariaLabel}
+      className={groupRecipe()}
+    >
+      {options.map((option) => (
+        <RadixToggleGroup.Item
+          key={option.value}
+          value={option.value}
+          disabled={option.disabled}
+          className={itemRecipe({ size })}
+        >
+          {option.label}
+        </RadixToggleGroup.Item>
+      ))}
+    </RadixToggleGroup.Root>
+  );
+}

--- a/src/components/ui/segmented-control.tsx
+++ b/src/components/ui/segmented-control.tsx
@@ -21,7 +21,7 @@ const itemRecipe = tv({
     'transition-colors duration-150',
     'text-muted-foreground hover:text-foreground',
     'data-[state=on]:bg-accent data-[state=on]:text-accent-foreground',
-    'focus-visible:outline-none',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
     'disabled:cursor-not-allowed disabled:opacity-50',
   ],
   variants: {
@@ -103,7 +103,7 @@ export function SegmentedControl({
   options,
   size,
   'aria-label': ariaLabel,
-}: SegmentedControlProps) {
+}: SegmentedControlProps): JSX.Element {
   return (
     <RadixToggleGroup.Root
       type="single"

--- a/src/components/ui/select.stories.tsx
+++ b/src/components/ui/select.stories.tsx
@@ -16,7 +16,17 @@ const meta: Meta<SelectArgs> = {
   title: 'UI/Select',
   component: Select,
   tags: ['autodocs'],
-  parameters: { layout: 'centered' },
+  parameters: {
+    layout: 'centered',
+    a11y: {
+      // Radix's Select also renders focus-guard sentinels around its
+      // portalised listbox. See `dialog.stories.tsx` for the full
+      // rationale; suppress the same axe rule here.
+      config: {
+        rules: [{ id: 'aria-hidden-focus', enabled: false }],
+      },
+    },
+  },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },
     invalid: { control: 'boolean' },

--- a/src/components/ui/select.stories.tsx
+++ b/src/components/ui/select.stories.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useState, type ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { Select } from './select';
 
-type SelectArgs = React.ComponentProps<typeof Select>;
+type SelectArgs = ComponentProps<typeof Select>;
 
 const formatOptions = [
   { value: 'gedcom-5.5.1', label: 'GEDCOM 5.5.1' },

--- a/src/components/ui/select.stories.tsx
+++ b/src/components/ui/select.stories.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { Select } from './select';
+
+type SelectArgs = React.ComponentProps<typeof Select>;
+
+const formatOptions = [
+  { value: 'gedcom-5.5.1', label: 'GEDCOM 5.5.1' },
+  { value: 'gedcom-7.0', label: 'GEDCOM 7.0' },
+  { value: 'json', label: 'JSON' },
+];
+
+const meta: Meta<SelectArgs> = {
+  title: 'UI/Select',
+  component: Select,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    invalid: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+  },
+  args: {
+    value: undefined,
+    onValueChange: fn(),
+    options: formatOptions,
+    placeholder: 'Pick a format',
+    'aria-label': 'Export format',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-72">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<SelectArgs>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('combobox', { name: 'Export format' });
+    await expect(trigger).toBeInTheDocument();
+  },
+};
+
+export const OpenAndSelect: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('combobox', { name: 'Export format' });
+    await userEvent.click(trigger);
+    const body = canvasElement.ownerDocument.body;
+    const json = within(body).getByRole('option', { name: 'JSON' });
+    await userEvent.click(json);
+    await expect(args.onValueChange).toHaveBeenCalledWith('json');
+  },
+};
+
+export const WithDisabledOption: Story = {
+  args: {
+    options: [
+      { value: 'gedcom-5.5.1', label: 'GEDCOM 5.5.1' },
+      { value: 'gedcom-7.0', label: 'GEDCOM 7.0', disabled: true },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('combobox', { name: 'Export format' });
+    await userEvent.click(trigger);
+    const body = canvasElement.ownerDocument.body;
+    const disabledOption = within(body).getByRole('option', { name: 'GEDCOM 7.0' });
+    await expect(disabledOption).toHaveAttribute('aria-disabled', 'true');
+  },
+};
+
+export const Invalid: Story = {
+  args: { invalid: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('combobox', { name: 'Export format' });
+    await expect(trigger).toHaveAttribute('aria-invalid', 'true');
+  },
+};
+
+export const WithHint: Story = {
+  parameters: { layout: 'padded' },
+  args: { hint: 'GEDCOM 5.5.1 is the safest target for compatibility.' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('combobox', { name: 'Export format' });
+    const describedBy = trigger.getAttribute('aria-describedby');
+    await expect(describedBy).not.toBeNull();
+    const hint = canvas.getByText(/GEDCOM 5.5.1 is the safest/);
+    await expect(hint.id).toBe(describedBy);
+  },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('combobox', { name: 'Export format' });
+    await expect(trigger).toBeDisabled();
+  },
+};
+
+const sizes = ['sm', 'md', 'lg'] as const;
+
+export const Sizes: Story = {
+  parameters: { layout: 'padded' },
+  render: (args) => (
+    <div className="flex flex-col gap-3">
+      {sizes.map((size) => (
+        <Select key={size} {...args} size={size} aria-label={`Size ${size}`} />
+      ))}
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('combobox')).toHaveLength(sizes.length);
+  },
+};
+
+function ControlledSelect() {
+  const [value, setValue] = useState('json');
+  return (
+    <Select
+      value={value}
+      onValueChange={setValue}
+      options={formatOptions}
+      placeholder="Pick…"
+      aria-label="Format"
+    />
+  );
+}
+
+export const Controlled: Story = {
+  render: () => <ControlledSelect />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('combobox', { name: 'Format' });
+    await userEvent.click(trigger);
+    const body = canvasElement.ownerDocument.body;
+    const option = within(body).getByRole('option', { name: 'GEDCOM 5.5.1' });
+    await userEvent.click(option);
+    await expect(trigger).toHaveTextContent('GEDCOM 5.5.1');
+  },
+};

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,198 @@
+import * as RadixSelect from '@radix-ui/react-select';
+import { useId, type ReactNode } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+import { Icon } from './icon';
+
+/**
+ * Recipe for the Select trigger. Mirrors the Input wrapper's visual
+ * variants so a row mixing Inputs and Selects stays aligned.
+ */
+export const selectTriggerRecipe = tv({
+  base: [
+    'flex w-full items-center justify-between gap-2',
+    'bg-card text-foreground',
+    'rounded-md border',
+    'transition-colors duration-150',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    'data-[placeholder]:text-muted-foreground',
+  ],
+  variants: {
+    size: {
+      sm: 'h-7 px-2 text-xs',
+      md: 'h-9 px-3 text-sm',
+      lg: 'h-11 px-4 text-base',
+    },
+    state: {
+      default: 'border-input focus-visible:ring-ring',
+      error: 'border-destructive focus-visible:ring-destructive',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    state: 'default',
+  },
+});
+
+type SelectRecipeProps = VariantProps<typeof selectTriggerRecipe>;
+
+/**
+ * Shape of an option inside {@link SelectProps.options}.
+ */
+export interface SelectOption {
+  /** Submitted value. */
+  value: string;
+  /** Localized label rendered in the trigger and the listbox. */
+  label: ReactNode;
+  /** Disables this option. */
+  disabled?: boolean;
+}
+
+/**
+ * Props accepted by {@link Select}.
+ */
+export interface SelectProps {
+  /** Currently selected value. Controlled. */
+  value: string | undefined;
+
+  /** Called when the user selects an option. */
+  onValueChange: (value: string) => void;
+
+  /** Options to display. */
+  options: SelectOption[];
+
+  /**
+   * Localized placeholder shown while no value is selected. Required so
+   * the trigger has visible content even when empty.
+   */
+  placeholder: string;
+
+  /** Visual size of the trigger. Defaults to `"md"`. */
+  size?: SelectRecipeProps['size'];
+
+  /**
+   * Marks the field as invalid for both assistive tech (`aria-invalid`)
+   * and visuals (red border + red focus ring).
+   */
+  invalid?: boolean;
+
+  /** Disables the whole Select. */
+  disabled?: boolean;
+
+  /**
+   * Optional help text rendered below the trigger. Wired via
+   * `aria-describedby` so assistive tech announces it after the
+   * accessible name. Pass localized content from the consumer.
+   */
+  hint?: ReactNode;
+
+  /**
+   * Localized accessible name for the trigger. Required when no
+   * adjacent `<label htmlFor>` is associated with this Select. When a
+   * label is associated externally, you can omit this and pass the
+   * matching `id` instead.
+   */
+  'aria-label'?: string;
+
+  /** Optional id wired to the underlying trigger. */
+  id?: string;
+}
+
+/**
+ * Single-select dropdown built on `@radix-ui/react-select`.
+ *
+ * Renders a button trigger styled like {@link Input} and, when opened,
+ * a portalised listbox with keyboard navigation, type-ahead, and focus
+ * management — all delegated to Radix.
+ *
+ * The component is fully controlled. Pass an `aria-label` for the
+ * trigger when no adjacent `<label htmlFor>` covers it.
+ *
+ * @example
+ * <Select
+ *   value={format}
+ *   onValueChange={setFormat}
+ *   options={[
+ *     { value: 'gedcom-5.5.1', label: 'GEDCOM 5.5.1' },
+ *     { value: 'gedcom-7.0', label: 'GEDCOM 7.0', disabled: true },
+ *   ]}
+ *   placeholder={t('export.format.placeholder')}
+ *   aria-label={t('export.format.label')}
+ *   hint={t('export.format.hint')}
+ * />
+ */
+export function Select({
+  value,
+  onValueChange,
+  options,
+  placeholder,
+  size,
+  invalid = false,
+  disabled,
+  hint,
+  'aria-label': ariaLabel,
+  id,
+}: SelectProps) {
+  const reactId = useId();
+  const triggerId = id ?? `select-${reactId}`;
+  const hintId = hint ? `${triggerId}-hint` : undefined;
+
+  const trigger = (
+    <RadixSelect.Trigger
+      id={triggerId}
+      aria-label={ariaLabel}
+      aria-invalid={invalid || undefined}
+      aria-describedby={hintId}
+      className={selectTriggerRecipe({ size, state: invalid ? 'error' : 'default' })}
+    >
+      <RadixSelect.Value placeholder={placeholder} />
+      <RadixSelect.Icon asChild>
+        <Icon name="chevron-down" size={16} />
+      </RadixSelect.Icon>
+    </RadixSelect.Trigger>
+  );
+
+  const content = (
+    <RadixSelect.Portal>
+      <RadixSelect.Content
+        position="popper"
+        sideOffset={4}
+        className="z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-lg"
+      >
+        <RadixSelect.Viewport className="p-1">
+          {options.map((option) => (
+            <RadixSelect.Item
+              key={option.value}
+              value={option.value}
+              disabled={option.disabled}
+              className="relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
+            >
+              <RadixSelect.ItemText>{option.label}</RadixSelect.ItemText>
+            </RadixSelect.Item>
+          ))}
+        </RadixSelect.Viewport>
+      </RadixSelect.Content>
+    </RadixSelect.Portal>
+  );
+
+  const root = (
+    <RadixSelect.Root value={value} onValueChange={onValueChange} disabled={disabled}>
+      {trigger}
+      {content}
+    </RadixSelect.Root>
+  );
+
+  if (!hint) {
+    return root;
+  }
+
+  return (
+    <div className="block">
+      {root}
+      <p id={hintId} className="text-muted-foreground mt-1 text-xs">
+        {hint}
+      </p>
+    </div>
+  );
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,41 +1,19 @@
 import * as RadixSelect from '@radix-ui/react-select';
-import { useId, type ReactNode } from 'react';
-import { tv, type VariantProps } from 'tailwind-variants';
+import { type ReactNode } from 'react';
+import { tv } from 'tailwind-variants';
 
+import { fieldRecipe, FieldWithHint, useFieldHint, type FieldRecipeProps } from './field';
 import { Icon } from './icon';
 
 /**
- * Recipe for the Select trigger. Mirrors the Input wrapper's visual
- * variants so a row mixing Inputs and Selects stays aligned.
+ * Trigger-only additions on top of the shared {@link fieldRecipe}.
+ * The Select trigger needs a flex row (label + chevron) and the
+ * placeholder colour token; everything else inherits from the field
+ * tokens so a row mixing Inputs and Selects stays aligned.
  */
-export const selectTriggerRecipe = tv({
-  base: [
-    'flex w-full items-center justify-between gap-2',
-    'bg-card text-foreground',
-    'rounded-md border',
-    'transition-colors duration-150',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-    'disabled:cursor-not-allowed disabled:opacity-50',
-    'data-[placeholder]:text-muted-foreground',
-  ],
-  variants: {
-    size: {
-      sm: 'h-7 px-2 text-xs',
-      md: 'h-9 px-3 text-sm',
-      lg: 'h-11 px-4 text-base',
-    },
-    state: {
-      default: 'border-input focus-visible:ring-ring',
-      error: 'border-destructive focus-visible:ring-destructive',
-    },
-  },
-  defaultVariants: {
-    size: 'md',
-    state: 'default',
-  },
+const selectTriggerExtras = tv({
+  base: 'flex items-center justify-between gap-2 data-[placeholder]:text-muted-foreground',
 });
-
-type SelectRecipeProps = VariantProps<typeof selectTriggerRecipe>;
 
 /**
  * Shape of an option inside {@link SelectProps.options}.
@@ -69,7 +47,7 @@ export interface SelectProps {
   placeholder: string;
 
   /** Visual size of the trigger. Defaults to `"md"`. */
-  size?: SelectRecipeProps['size'];
+  size?: FieldRecipeProps['size'];
 
   /**
    * Marks the field as invalid for both assistive tech (`aria-invalid`)
@@ -95,6 +73,13 @@ export interface SelectProps {
    */
   'aria-label'?: string;
 
+  /**
+   * Optional additional `aria-describedby` ids. Merged with the
+   * generated hint id rather than overwritten, so callers can stack
+   * extra descriptions.
+   */
+  'aria-describedby'?: string;
+
   /** Optional id wired to the underlying trigger. */
   id?: string;
 }
@@ -102,9 +87,10 @@ export interface SelectProps {
 /**
  * Single-select dropdown built on `@radix-ui/react-select`.
  *
- * Renders a button trigger styled like {@link Input} and, when opened,
- * a portalised listbox with keyboard navigation, type-ahead, and focus
- * management — all delegated to Radix.
+ * Renders a button trigger styled with the shared {@link fieldRecipe}
+ * (so Input + Select rows stay aligned) and, when opened, a portalised
+ * listbox with keyboard navigation, type-ahead, and focus management
+ * — all delegated to Radix.
  *
  * The component is fully controlled. Pass an `aria-label` for the
  * trigger when no adjacent `<label htmlFor>` covers it.
@@ -132,67 +118,54 @@ export function Select({
   disabled,
   hint,
   'aria-label': ariaLabel,
+  'aria-describedby': ariaDescribedBy,
   id,
 }: SelectProps) {
-  const reactId = useId();
-  const triggerId = id ?? `select-${reactId}`;
-  const hintId = hint ? `${triggerId}-hint` : undefined;
+  const { fieldId, hintId, describedBy } = useFieldHint({
+    id,
+    hint,
+    ariaDescribedBy,
+    prefix: 'select',
+  });
 
-  const trigger = (
-    <RadixSelect.Trigger
-      id={triggerId}
-      aria-label={ariaLabel}
-      aria-invalid={invalid || undefined}
-      aria-describedby={hintId}
-      className={selectTriggerRecipe({ size, state: invalid ? 'error' : 'default' })}
-    >
-      <RadixSelect.Value placeholder={placeholder} />
-      <RadixSelect.Icon asChild>
-        <Icon name="chevron-down" size={16} />
-      </RadixSelect.Icon>
-    </RadixSelect.Trigger>
-  );
-
-  const content = (
-    <RadixSelect.Portal>
-      <RadixSelect.Content
-        position="popper"
-        sideOffset={4}
-        className="z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-lg"
-      >
-        <RadixSelect.Viewport className="p-1">
-          {options.map((option) => (
-            <RadixSelect.Item
-              key={option.value}
-              value={option.value}
-              disabled={option.disabled}
-              className="relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
-            >
-              <RadixSelect.ItemText>{option.label}</RadixSelect.ItemText>
-            </RadixSelect.Item>
-          ))}
-        </RadixSelect.Viewport>
-      </RadixSelect.Content>
-    </RadixSelect.Portal>
-  );
+  const triggerClass = `${fieldRecipe({ size, state: invalid ? 'error' : 'default' })} ${selectTriggerExtras()}`;
 
   const root = (
     <RadixSelect.Root value={value} onValueChange={onValueChange} disabled={disabled}>
-      {trigger}
-      {content}
+      <RadixSelect.Trigger
+        id={fieldId}
+        aria-label={ariaLabel}
+        aria-invalid={invalid || undefined}
+        aria-describedby={describedBy}
+        className={triggerClass}
+      >
+        <RadixSelect.Value placeholder={placeholder} />
+        <RadixSelect.Icon asChild>
+          <Icon name="chevron-down" size={16} />
+        </RadixSelect.Icon>
+      </RadixSelect.Trigger>
+      <RadixSelect.Portal>
+        <RadixSelect.Content
+          position="popper"
+          sideOffset={4}
+          className="z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-lg"
+        >
+          <RadixSelect.Viewport className="p-1">
+            {options.map((option) => (
+              <RadixSelect.Item
+                key={option.value}
+                value={option.value}
+                disabled={option.disabled}
+                className="relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
+              >
+                <RadixSelect.ItemText>{option.label}</RadixSelect.ItemText>
+              </RadixSelect.Item>
+            ))}
+          </RadixSelect.Viewport>
+        </RadixSelect.Content>
+      </RadixSelect.Portal>
     </RadixSelect.Root>
   );
 
-  if (!hint) {
-    return root;
-  }
-
-  return (
-    <div className="block">
-      {root}
-      <p id={hintId} className="text-muted-foreground mt-1 text-xs">
-        {hint}
-      </p>
-    </div>
-  );
+  return <FieldWithHint field={root} hint={hint} hintId={hintId} />;
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -120,7 +120,7 @@ export function Select({
   'aria-label': ariaLabel,
   'aria-describedby': ariaDescribedBy,
   id,
-}: SelectProps) {
+}: SelectProps): JSX.Element {
   const { fieldId, hintId, describedBy } = useFieldHint({
     id,
     hint,

--- a/src/components/ui/stat-grid.stories.tsx
+++ b/src/components/ui/stat-grid.stories.tsx
@@ -89,3 +89,61 @@ export const MixedAccents: Story = {
     await expect(canvas.getByText('Errors')).toBeInTheDocument();
   },
 };
+
+export const TwoColumns: Story = {
+  args: {
+    cols: 2,
+    items: [
+      { value: 142, label: 'Individuals' },
+      { value: 58, label: 'Families' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('142')).toBeInTheDocument();
+    await expect(canvas.getByText('58')).toBeInTheDocument();
+  },
+};
+
+export const SuccessAccent: Story = {
+  args: {
+    cols: 3,
+    items: [
+      { value: 142, label: 'Imported', accent: 'success' },
+      { value: 0, label: 'Errors', accent: 'success' },
+      { value: 12, label: 'Skipped', accent: 'success' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Imported')).toBeInTheDocument();
+  },
+};
+
+export const Matrix: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      {([2, 3, 4] as const).map((cols) => (
+        <StatGrid
+          key={cols}
+          cols={cols}
+          items={(
+            [
+              { value: 10, label: `cols ${cols} – default` },
+              { value: 20, label: 'destructive', accent: 'destructive' },
+              { value: 30, label: 'success', accent: 'success' },
+              { value: 40, label: 'warning', accent: 'warning' },
+            ] as const
+          ).slice(0, cols)}
+        />
+      ))}
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // 2 + 3 + 4 = 9 cells across the three grids.
+    await expect(
+      canvas.getAllByText(/^(default|destructive|success|warning|cols \d+ – default)$/i).length
+    ).toBeGreaterThanOrEqual(3);
+  },
+};

--- a/src/components/ui/stat-grid.stories.tsx
+++ b/src/components/ui/stat-grid.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+
+import { StatGrid } from './stat-grid';
+
+const meta = {
+  title: 'UI/StatGrid',
+  component: StatGrid,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  argTypes: {
+    cols: { control: 'select', options: [2, 3, 4] },
+  },
+  args: {
+    items: [
+      { value: 142, label: 'Individuals' },
+      { value: 58, label: 'Families' },
+      { value: 412, label: 'Events' },
+      { value: 23, label: 'Sources' },
+    ],
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[640px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof StatGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FourColumns: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Individuals')).toBeInTheDocument();
+    await expect(canvas.getByText('142')).toBeInTheDocument();
+    await expect(canvas.getByText('58')).toBeInTheDocument();
+  },
+};
+
+export const ThreeColumns: Story = {
+  args: {
+    cols: 3,
+    items: [
+      { value: 142, label: 'Individuals' },
+      { value: '2024-01-12', label: 'Created' },
+      { value: '2 hours ago', label: 'Last accessed' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('2 hours ago')).toBeInTheDocument();
+  },
+};
+
+export const WithDestructiveAccent: Story = {
+  args: {
+    cols: 3,
+    items: [
+      { value: 142, label: 'Individuals', accent: 'destructive' },
+      { value: 58, label: 'Families', accent: 'destructive' },
+      { value: 412, label: 'Events', accent: 'destructive' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // All three cells render their numeric value
+    await expect(canvas.getByText('142')).toBeInTheDocument();
+    await expect(canvas.getByText('58')).toBeInTheDocument();
+    await expect(canvas.getByText('412')).toBeInTheDocument();
+  },
+};
+
+export const MixedAccents: Story = {
+  args: {
+    cols: 4,
+    items: [
+      { value: 142, label: 'Individuals' },
+      { value: 58, label: 'Families' },
+      { value: 12, label: 'Pending', accent: 'warning' },
+      { value: 5, label: 'Errors', accent: 'destructive' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Pending')).toBeInTheDocument();
+    await expect(canvas.getByText('Errors')).toBeInTheDocument();
+  },
+};

--- a/src/components/ui/stat-grid.tsx
+++ b/src/components/ui/stat-grid.tsx
@@ -1,0 +1,109 @@
+import { type HTMLAttributes, type ReactNode } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+/**
+ * Recipe for the StatGrid container.
+ */
+const gridRecipe = tv({
+  base: 'grid gap-3',
+  variants: {
+    cols: {
+      2: 'grid-cols-2',
+      3: 'grid-cols-3',
+      4: 'grid-cols-2 sm:grid-cols-4',
+    },
+  },
+  defaultVariants: { cols: 4 },
+});
+
+/**
+ * Recipe for the value-text colour. Label colour is shared (always
+ * `muted-foreground`).
+ */
+const valueRecipe = tv({
+  base: 'font-mono text-2xl font-semibold leading-none tabular-nums',
+  variants: {
+    accent: {
+      default: 'text-foreground',
+      destructive: 'text-destructive',
+      success: 'text-success',
+      warning: 'text-warning',
+    },
+  },
+  defaultVariants: { accent: 'default' },
+});
+
+type GridRecipeProps = VariantProps<typeof gridRecipe>;
+type ValueRecipeProps = VariantProps<typeof valueRecipe>;
+
+/**
+ * One cell in a {@link StatGrid}.
+ */
+export interface StatGridItem {
+  /** Numeric or pre-formatted value rendered large in mono font. */
+  value: string | number;
+  /** Localized label rendered below the value. */
+  label: ReactNode;
+  /** Colour accent for the value. Defaults to `default` (foreground). */
+  accent?: ValueRecipeProps['accent'];
+}
+
+/**
+ * Props accepted by {@link StatGrid}.
+ */
+export interface StatGridProps extends HTMLAttributes<HTMLDivElement> {
+  /** Cells to render. */
+  items: StatGridItem[];
+
+  /**
+   * Number of columns. Defaults to `4`. With `4`, the grid collapses to
+   * 2 columns under the `sm` breakpoint.
+   */
+  cols?: GridRecipeProps['cols'];
+}
+
+/**
+ * Compact grid of metrics — used in:
+ * - Import GEDCOM modal (scan summary: Individuals / Families / Events / Sources)
+ * - Edit Tree modal (read-only stats)
+ * - Download Tree modal (file size + row counts)
+ * - Delete Tree modal (loss preview, accent="destructive")
+ *
+ * Each cell shows a large mono value above a small uppercase label.
+ * Colour accents are tokenised; the wrapper does not own copy.
+ *
+ * @example
+ * <StatGrid
+ *   items={[
+ *     { value: 142, label: t('stats.individuals') },
+ *     { value: 58, label: t('stats.families') },
+ *     { value: 412, label: t('stats.events') },
+ *     { value: 23, label: t('stats.sources') },
+ *   ]}
+ * />
+ *
+ * @example
+ * // Loss preview in Delete modal — destructive accent
+ * <StatGrid
+ *   cols={3}
+ *   items={[
+ *     { value: '142', label: t('delete.lossIndividuals'), accent: 'destructive' },
+ *     { value: '58', label: t('delete.lossFamilies'), accent: 'destructive' },
+ *     { value: '412', label: t('delete.lossEvents'), accent: 'destructive' },
+ *   ]}
+ * />
+ */
+export function StatGrid({ items, cols, className, ...props }: StatGridProps) {
+  return (
+    <div className={gridRecipe({ cols, className })} {...props}>
+      {items.map((item, idx) => (
+        <div key={idx} className="flex flex-col gap-1.5">
+          <span className={valueRecipe({ accent: item.accent })}>{item.value}</span>
+          <span className="text-muted-foreground text-[11px] uppercase tracking-widest">
+            {item.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/stat-grid.tsx
+++ b/src/components/ui/stat-grid.tsx
@@ -93,7 +93,7 @@ export interface StatGridProps extends HTMLAttributes<HTMLDivElement> {
  *   ]}
  * />
  */
-export function StatGrid({ items, cols, className, ...props }: StatGridProps) {
+export function StatGrid({ items, cols, className, ...props }: StatGridProps): JSX.Element {
   return (
     <div className={gridRecipe({ cols, className })} {...props}>
       {items.map((item, idx) => (

--- a/src/components/ui/switch.stories.tsx
+++ b/src/components/ui/switch.stories.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { Switch } from './switch';
+
+type SwitchArgs = React.ComponentProps<typeof Switch>;
+
+const meta: Meta<SwitchArgs> = {
+  title: 'UI/Switch',
+  component: Switch,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    disabled: { control: 'boolean' },
+  },
+  args: {
+    label: 'Preserve original dates',
+    checked: false,
+    onCheckedChange: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<SwitchArgs>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const switchEl = canvas.getByRole('switch', { name: 'Preserve original dates' });
+    await expect(switchEl).toBeInTheDocument();
+    await expect(switchEl).toHaveAttribute('aria-checked', 'false');
+  },
+};
+
+export const Checked: Story = {
+  args: { checked: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const switchEl = canvas.getByRole('switch');
+    await expect(switchEl).toHaveAttribute('aria-checked', 'true');
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    label: 'Detect duplicates',
+    description: 'Match individuals by name and birth date during import.',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const switchEl = canvas.getByRole('switch', { name: /Detect duplicates/ });
+    const describedBy = switchEl.getAttribute('aria-describedby');
+    await expect(describedBy).not.toBeNull();
+    const description = canvas.getByText(/Match individuals by name/);
+    await expect(description.id).toBe(describedBy);
+  },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, label: 'Disabled toggle' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const switchEl = canvas.getByRole('switch');
+    await expect(switchEl).toBeDisabled();
+  },
+};
+
+export const ClicksToggle: Story = {
+  args: { label: 'Click to toggle', checked: false },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const switchEl = canvas.getByRole('switch');
+    await userEvent.click(switchEl);
+    await expect(args.onCheckedChange).toHaveBeenCalledWith(true);
+  },
+};
+
+export const LabelClickToggles: Story = {
+  args: { label: 'Click anywhere on the row', checked: false },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const labelText = canvas.getByText('Click anywhere on the row');
+    await userEvent.click(labelText);
+    await expect(args.onCheckedChange).toHaveBeenCalledWith(true);
+  },
+};
+
+const sizes = ['sm', 'md', 'lg'] as const;
+
+export const Sizes: Story = {
+  parameters: { layout: 'padded' },
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      {sizes.map((size) => (
+        <Switch key={size} {...args} size={size} label={`Size: ${size}`} />
+      ))}
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('switch')).toHaveLength(sizes.length);
+  },
+};
+
+function ControlledSwitch() {
+  const [on, setOn] = useState(false);
+  return (
+    <Switch
+      checked={on}
+      onCheckedChange={setOn}
+      label="Controlled"
+      description={`Currently: ${on ? 'on' : 'off'}`}
+    />
+  );
+}
+
+export const Controlled: Story = {
+  render: () => <ControlledSwitch />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const switchEl = canvas.getByRole('switch', { name: 'Controlled' });
+    await userEvent.click(switchEl);
+    await expect(switchEl).toHaveAttribute('aria-checked', 'true');
+  },
+};

--- a/src/components/ui/switch.stories.tsx
+++ b/src/components/ui/switch.stories.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useState, type ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { Switch } from './switch';
 
-type SwitchArgs = React.ComponentProps<typeof Switch>;
+type SwitchArgs = ComponentProps<typeof Switch>;
 
 const meta: Meta<SwitchArgs> = {
   title: 'UI/Switch',

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,137 @@
+import * as RadixSwitch from '@radix-ui/react-switch';
+import { useId, type ReactNode } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+/**
+ * Recipe for the Switch's track and thumb dimensions.
+ *
+ * Sizes:
+ * - `sm` — dense rows (toolbars, tweak panels).
+ * - `md` — default — settings rows, modal toggles.
+ * - `lg` — hero settings, accessibility-focused surfaces.
+ */
+export const switchTrackRecipe = tv({
+  base: [
+    'relative inline-flex shrink-0 items-center rounded-full',
+    'bg-input data-[state=checked]:bg-primary',
+    'transition-colors duration-150',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+  ],
+  variants: {
+    size: {
+      sm: 'h-4 w-7',
+      md: 'h-5 w-9',
+      lg: 'h-6 w-11',
+    },
+  },
+  defaultVariants: { size: 'md' },
+});
+
+const switchThumbRecipe = tv({
+  base: [
+    'pointer-events-none block rounded-full bg-card shadow-sm',
+    'transition-transform duration-150',
+  ],
+  variants: {
+    size: {
+      sm: 'size-3 translate-x-0.5 data-[state=checked]:translate-x-3.5',
+      md: 'size-4 translate-x-0.5 data-[state=checked]:translate-x-[18px]',
+      lg: 'size-5 translate-x-0.5 data-[state=checked]:translate-x-[22px]',
+    },
+  },
+  defaultVariants: { size: 'md' },
+});
+
+type SwitchRecipeProps = VariantProps<typeof switchTrackRecipe>;
+
+/**
+ * Props accepted by {@link Switch}.
+ */
+export interface SwitchProps {
+  /** Whether the switch is on. Controlled value. */
+  checked: boolean;
+
+  /** Called when the user toggles the switch. */
+  onCheckedChange: (checked: boolean) => void;
+
+  /** Localized label rendered next to the track. */
+  label: ReactNode;
+
+  /**
+   * Optional localized description rendered under the label. Linked to
+   * the switch via `aria-describedby` for assistive tech.
+   */
+  description?: ReactNode;
+
+  /** Visual size of the switch. Defaults to `"md"`. */
+  size?: SwitchRecipeProps['size'];
+
+  /** Disables the switch. */
+  disabled?: boolean;
+
+  /** Optional id for the underlying button. Auto-generated if omitted. */
+  id?: string;
+}
+
+/**
+ * Toggle switch built on `@radix-ui/react-switch`.
+ *
+ * Renders a clickable row with the switch on the right and a label
+ * (and optional description) on the left. The whole row is a `<label>`
+ * so clicking anywhere toggles the control. Keyboard activation is
+ * handled by Radix (Space/Enter on the focused track).
+ *
+ * Always pass `label` — the wrapper enforces a visible accessible name.
+ *
+ * @example
+ * <Switch
+ *   checked={preserveDates}
+ *   onCheckedChange={setPreserveDates}
+ *   label={t('import.options.preserveDates.label')}
+ *   description={t('import.options.preserveDates.description')}
+ * />
+ */
+export function Switch({
+  checked,
+  onCheckedChange,
+  label,
+  description,
+  size,
+  disabled,
+  id,
+}: SwitchProps) {
+  const reactId = useId();
+  const switchId = id ?? `switch-${reactId}`;
+  const labelId = `${switchId}-label`;
+  const descriptionId = description ? `${switchId}-description` : undefined;
+
+  return (
+    <label
+      htmlFor={switchId}
+      className="flex w-full cursor-pointer items-start gap-3 py-1.5 has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50"
+    >
+      <div className="flex flex-1 flex-col gap-0.5">
+        <span id={labelId} className="text-foreground text-sm font-medium leading-tight">
+          {label}
+        </span>
+        {description && (
+          <span id={descriptionId} className="text-muted-foreground text-xs">
+            {description}
+          </span>
+        )}
+      </div>
+      <RadixSwitch.Root
+        id={switchId}
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        disabled={disabled}
+        aria-labelledby={labelId}
+        aria-describedby={descriptionId}
+        className={switchTrackRecipe({ size })}
+      >
+        <RadixSwitch.Thumb className={switchThumbRecipe({ size })} />
+      </RadixSwitch.Root>
+    </label>
+  );
+}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -108,7 +108,7 @@ export function Switch({
   disabled,
   id,
   'aria-describedby': ariaDescribedBy,
-}: SwitchProps) {
+}: SwitchProps): JSX.Element {
   const reactId = useId();
   const switchId = id ?? `switch-${reactId}`;
   const labelId = `${switchId}-label`;

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -72,6 +72,13 @@ export interface SwitchProps {
 
   /** Optional id for the underlying button. Auto-generated if omitted. */
   id?: string;
+
+  /**
+   * Optional additional `aria-describedby` ids. Merged with the
+   * generated description id rather than overwritten, so callers can
+   * stack extra descriptions.
+   */
+  'aria-describedby'?: string;
 }
 
 /**
@@ -100,11 +107,13 @@ export function Switch({
   size,
   disabled,
   id,
+  'aria-describedby': ariaDescribedBy,
 }: SwitchProps) {
   const reactId = useId();
   const switchId = id ?? `switch-${reactId}`;
   const labelId = `${switchId}-label`;
   const descriptionId = description ? `${switchId}-description` : undefined;
+  const describedBy = [ariaDescribedBy, descriptionId].filter(Boolean).join(' ') || undefined;
 
   return (
     <label
@@ -127,7 +136,7 @@ export function Switch({
         onCheckedChange={onCheckedChange}
         disabled={disabled}
         aria-labelledby={labelId}
-        aria-describedby={descriptionId}
+        aria-describedby={describedBy}
         className={switchTrackRecipe({ size })}
       >
         <RadixSwitch.Thumb className={switchThumbRecipe({ size })} />

--- a/src/components/ui/textarea.stories.tsx
+++ b/src/components/ui/textarea.stories.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { Textarea } from './textarea';
+
+const meta = {
+  title: 'UI/Textarea',
+  component: Textarea,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: { placeholder: 'Add a description…' },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    invalid: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByPlaceholderText('Add a description…')).toBeInTheDocument();
+  },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, value: 'Cannot edit', onChange: fn() },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByDisplayValue<HTMLTextAreaElement>('Cannot edit');
+    await expect(textarea).toBeDisabled();
+  },
+};
+
+export const Invalid: Story = {
+  args: { invalid: true, defaultValue: 'too short' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByDisplayValue('too short');
+    await expect(textarea).toHaveAttribute('aria-invalid', 'true');
+  },
+};
+
+export const WithHint: Story = {
+  parameters: { layout: 'padded' },
+  render: (args) => (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor="textarea-with-hint" className="text-foreground text-sm font-medium">
+        Bio
+      </label>
+      <Textarea
+        {...args}
+        id="textarea-with-hint"
+        hint="Plain text only — no formatting is preserved."
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByLabelText<HTMLTextAreaElement>('Bio');
+    const describedBy = textarea.getAttribute('aria-describedby');
+    await expect(describedBy).not.toBeNull();
+    const hint = canvas.getByText(/Plain text only/i);
+    await expect(hint.id).toBe(describedBy);
+  },
+};
+
+const sizes = ['sm', 'md', 'lg'] as const;
+
+export const Sizes: Story = {
+  parameters: { layout: 'padded' },
+  render: (args) => (
+    <div className="flex flex-col gap-3">
+      {sizes.map((size) => (
+        <Textarea key={size} {...args} size={size} placeholder={`Size: ${size}`} />
+      ))}
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('textbox')).toHaveLength(sizes.length);
+  },
+};
+
+function ControlledTextarea() {
+  const [value, setValue] = useState('');
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor="controlled-textarea" className="text-foreground text-sm font-medium">
+        Notes
+      </label>
+      <Textarea id="controlled-textarea" value={value} onChange={(e) => setValue(e.target.value)} />
+    </div>
+  );
+}
+
+export const Controlled: Story = {
+  parameters: { layout: 'padded' },
+  render: () => <ControlledTextarea />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByLabelText<HTMLTextAreaElement>('Notes');
+    await userEvent.type(textarea, 'Hello');
+    await expect(textarea.value).toBe('Hello');
+  },
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,19 +1,18 @@
-import { forwardRef, useId, type ReactNode, type TextareaHTMLAttributes } from 'react';
+import { forwardRef, type ReactNode, type TextareaHTMLAttributes } from 'react';
 import { tv, type VariantProps } from 'tailwind-variants';
 
+import { FieldWithHint, useFieldHint } from './field';
+
 /**
- * Recipe for the Textarea component's visual variants.
+ * Recipe for the Textarea. Mirrors `fieldRecipe` for colour/border/focus
+ * tokens and overrides only the size variant so multi-line fields use
+ * `min-h-` instead of a fixed `h-` (a textarea must be allowed to grow
+ * vertically while staying tall enough at rest).
  *
  * Sizes:
  * - `sm` — dense forms (inline notes, filters).
  * - `md` — default — standard form notes.
  * - `lg` — long-form descriptions, biographies.
- *
- * State:
- * - `default` — neutral border, accent ring on focus.
- * - `error` — red border + red focus ring; pair with `aria-invalid` and an
- *   adjacent error message. The {@link TextareaProps.invalid} shortcut
- *   handles both.
  */
 export const textareaRecipe = tv({
   base: [
@@ -92,15 +91,17 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
   { size, invalid = false, hint, className, id, 'aria-describedby': ariaDescribedBy, ...props },
   ref
 ) {
-  const reactId = useId();
-  const textareaId = id ?? (hint ? `textarea-${reactId}` : undefined);
-  const hintId = hint ? `${textareaId}-hint` : undefined;
-  const describedBy = [ariaDescribedBy, hintId].filter(Boolean).join(' ') || undefined;
+  const { fieldId, hintId, describedBy } = useFieldHint({
+    id,
+    hint,
+    ariaDescribedBy,
+    prefix: 'textarea',
+  });
 
   const textarea = (
     <textarea
       ref={ref}
-      id={textareaId}
+      id={fieldId}
       aria-invalid={invalid || undefined}
       aria-describedby={describedBy}
       className={textareaRecipe({ size, state: invalid ? 'error' : 'default', className })}
@@ -108,18 +109,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
     />
   );
 
-  if (!hint) {
-    return textarea;
-  }
-
-  return (
-    <div className="block">
-      {textarea}
-      <p id={hintId} className="text-muted-foreground mt-1 text-xs">
-        {hint}
-      </p>
-    </div>
-  );
+  return <FieldWithHint field={textarea} hint={hint} hintId={hintId} />;
 });
 
 Textarea.displayName = 'Textarea';

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,125 @@
+import { forwardRef, useId, type ReactNode, type TextareaHTMLAttributes } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+/**
+ * Recipe for the Textarea component's visual variants.
+ *
+ * Sizes:
+ * - `sm` — dense forms (inline notes, filters).
+ * - `md` — default — standard form notes.
+ * - `lg` — long-form descriptions, biographies.
+ *
+ * State:
+ * - `default` — neutral border, accent ring on focus.
+ * - `error` — red border + red focus ring; pair with `aria-invalid` and an
+ *   adjacent error message. The {@link TextareaProps.invalid} shortcut
+ *   handles both.
+ */
+export const textareaRecipe = tv({
+  base: [
+    'block w-full bg-card text-foreground placeholder:text-muted-foreground',
+    'rounded-md border resize-y',
+    'transition-colors duration-150',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+  ],
+  variants: {
+    size: {
+      sm: 'min-h-[64px] px-2 py-1.5 text-xs',
+      md: 'min-h-[88px] px-3 py-2 text-sm',
+      lg: 'min-h-[112px] px-4 py-2.5 text-base',
+    },
+    state: {
+      default: 'border-input focus-visible:ring-ring',
+      error: 'border-destructive focus-visible:ring-destructive',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    state: 'default',
+  },
+});
+
+type TextareaRecipeProps = VariantProps<typeof textareaRecipe>;
+
+/**
+ * Props accepted by {@link Textarea}. Extends the native `<textarea>` props
+ * minus `size` (which is reused for visual sizing here).
+ */
+export interface TextareaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'size'> {
+  /**
+   * Visual size of the textarea. Independent from the native `cols`/`rows`
+   * attributes. Defaults to `"md"`.
+   */
+  size?: TextareaRecipeProps['size'];
+
+  /**
+   * Marks the textarea as invalid for both assistive tech (`aria-invalid`)
+   * and visuals (red border + red focus ring).
+   */
+  invalid?: boolean;
+
+  /**
+   * Optional help text rendered below the field. When provided, the
+   * textarea is wrapped in a small block container and `aria-describedby`
+   * is wired so assistive tech announces the hint after the field's
+   * accessible name. Pass localized content from the consumer.
+   */
+  hint?: ReactNode;
+}
+
+/**
+ * Multi-line text input.
+ *
+ * Wraps a native `<textarea>` with the Vata visual system: tokenised
+ * colours, focus ring, error state. Accessibility is delegated to the
+ * native element — always associate the textarea with a `<label htmlFor>`
+ * (or wrap it in one).
+ *
+ * @example
+ * <label htmlFor="description">Description</label>
+ * <Textarea id="description" rows={4} value={value} onChange={(e) => setValue(e.target.value)} />
+ *
+ * @example
+ * // Long-form input with validation error
+ * <Textarea
+ *   size="lg"
+ *   invalid={!!error}
+ *   hint={t('individuals.description.hint')}
+ * />
+ */
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { size, invalid = false, hint, className, id, 'aria-describedby': ariaDescribedBy, ...props },
+  ref
+) {
+  const reactId = useId();
+  const textareaId = id ?? (hint ? `textarea-${reactId}` : undefined);
+  const hintId = hint ? `${textareaId}-hint` : undefined;
+  const describedBy = [ariaDescribedBy, hintId].filter(Boolean).join(' ') || undefined;
+
+  const textarea = (
+    <textarea
+      ref={ref}
+      id={textareaId}
+      aria-invalid={invalid || undefined}
+      aria-describedby={describedBy}
+      className={textareaRecipe({ size, state: invalid ? 'error' : 'default', className })}
+      {...props}
+    />
+  );
+
+  if (!hint) {
+    return textarea;
+  }
+
+  return (
+    <div className="block">
+      {textarea}
+      <p id={hintId} className="text-muted-foreground mt-1 text-xs">
+        {hint}
+      </p>
+    </div>
+  );
+});
+
+Textarea.displayName = 'Textarea';

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -61,13 +61,27 @@
   --color-destructive: oklch(0.555 0.195 27);
   --color-destructive-foreground: oklch(0.985 0.012 85);
 
+  /* Status — success/warning/info */
+  --color-success: oklch(0.74 0.18 145);
+  --color-success-foreground: oklch(0.985 0.012 85);
+  --color-warning: oklch(0.82 0.16 85);
+  --color-warning-foreground: oklch(0.22 0.028 45);
+  --color-info: oklch(0.69 0.16 245);
+  --color-info-foreground: oklch(0.985 0.012 85);
+
+  /* Popover surface — floating panels (Dialog content, Select listbox, etc.) */
+  --color-popover: oklch(1 0 0);
+  --color-popover-foreground: oklch(0.22 0.028 45);
+
   /* Borders, inputs, focus ring */
   --color-border: oklch(0.22 0.028 45 / 12%);
   --color-input: oklch(0.22 0.028 45 / 14%);
   --color-ring: oklch(0.54 0.13 32);
 
-  /* Typography */
+  /* Typography — `Fraunces` and `Geist Mono` will fall back until self-hosted in ./fonts/ */
   --font-sans: 'Geist', ui-sans-serif, system-ui, sans-serif;
+  --font-serif: 'Fraunces', ui-serif, Georgia, Cambria, 'Times New Roman', serif;
+  --font-mono: 'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 
   /* Radii */
   --radius: 0.5rem;
@@ -75,6 +89,12 @@
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) * 1.4);
+
+  /* Shadows */
+  --shadow-xs: 0 1px 2px 0 oklch(0 0 0 / 5%);
+  --shadow-sm: 0 1px 3px 0 oklch(0 0 0 / 10%), 0 1px 2px -1px oklch(0 0 0 / 10%);
+  --shadow-lg: 0 10px 15px -3px oklch(0 0 0 / 10%), 0 4px 6px -4px oklch(0 0 0 / 10%);
+  --shadow-inner: inset 0 2px 4px 0 oklch(0 0 0 / 5%);
 }
 
 /* ============================================================
@@ -100,6 +120,10 @@
     --dark-muted-foreground: oklch(0.78 0.042 70);
     --dark-accent: oklch(0.295 0.035 42);
     --dark-destructive: oklch(0.635 0.18 27);
+    --dark-success: oklch(0.7 0.18 145);
+    --dark-warning: oklch(0.78 0.16 85);
+    --dark-info: oklch(0.66 0.16 245);
+    --dark-popover: oklch(0.195 0.022 44);
     --dark-border: oklch(1 0 0 / 8%);
     --dark-input: oklch(1 0 0 / 12%);
   }
@@ -119,6 +143,14 @@
     --color-accent-foreground: oklch(0.985 0.012 85);
     --color-destructive: var(--dark-destructive);
     --color-destructive-foreground: oklch(0.985 0.012 85);
+    --color-success: var(--dark-success);
+    --color-success-foreground: oklch(0.155 0.02 42);
+    --color-warning: var(--dark-warning);
+    --color-warning-foreground: oklch(0.155 0.02 42);
+    --color-info: var(--dark-info);
+    --color-info-foreground: oklch(0.985 0.012 85);
+    --color-popover: var(--dark-popover);
+    --color-popover-foreground: var(--dark-foreground);
     --color-border: var(--dark-border);
     --color-input: var(--dark-input);
     --color-ring: var(--dark-primary);
@@ -140,6 +172,14 @@
       --color-accent-foreground: oklch(0.985 0.012 85);
       --color-destructive: var(--dark-destructive);
       --color-destructive-foreground: oklch(0.985 0.012 85);
+      --color-success: var(--dark-success);
+      --color-success-foreground: oklch(0.155 0.02 42);
+      --color-warning: var(--dark-warning);
+      --color-warning-foreground: oklch(0.155 0.02 42);
+      --color-info: var(--dark-info);
+      --color-info-foreground: oklch(0.985 0.012 85);
+      --color-popover: var(--dark-popover);
+      --color-popover-foreground: var(--dark-foreground);
       --color-border: var(--dark-border);
       --color-input: var(--dark-input);
       --color-ring: var(--dark-primary);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -61,12 +61,14 @@
   --color-destructive: oklch(0.555 0.195 27);
   --color-destructive-foreground: oklch(0.985 0.012 85);
 
-  /* Status — success/warning/info */
-  --color-success: oklch(0.74 0.18 145);
+  /* Status — success/warning/info. Tuned to pass WCAG AA (4.5:1) when used
+     as a background fill paired with the cream foreground, and 3:1 when
+     used as a text colour on the cream `bg-background` card. */
+  --color-success: oklch(0.5 0.15 145);
   --color-success-foreground: oklch(0.985 0.012 85);
-  --color-warning: oklch(0.82 0.16 85);
-  --color-warning-foreground: oklch(0.22 0.028 45);
-  --color-info: oklch(0.69 0.16 245);
+  --color-warning: oklch(0.55 0.16 75);
+  --color-warning-foreground: oklch(0.985 0.012 85);
+  --color-info: oklch(0.5 0.15 245);
   --color-info-foreground: oklch(0.985 0.012 85);
 
   /* Popover surface — floating panels (Dialog content, Select listbox, etc.) */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -179,7 +179,7 @@
       --color-warning: var(--dark-warning);
       --color-warning-foreground: oklch(0.155 0.02 42);
       --color-info: var(--dark-info);
-      --color-info-foreground: oklch(0.985 0.012 85);
+      --color-info-foreground: oklch(0.155 0.02 42);
       --color-popover: var(--dark-popover);
       --color-popover-foreground: var(--dark-foreground);
       --color-border: var(--dark-border);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -150,7 +150,7 @@
     --color-warning: var(--dark-warning);
     --color-warning-foreground: oklch(0.155 0.02 42);
     --color-info: var(--dark-info);
-    --color-info-foreground: oklch(0.985 0.012 85);
+    --color-info-foreground: oklch(0.155 0.02 42);
     --color-popover: var(--dark-popover);
     --color-popover-foreground: var(--dark-foreground);
     --color-border: var(--dark-border);


### PR DESCRIPTION
## Summary

Builds the design-system foundation needed by the upcoming "Trees Modals" features (New tree / Import GEDCOM / Edit tree / Download tree / Delete tree, plus the trees-list home page). Until now `src/components/ui/` only had `Button`, `Input`, `Icon` — the new modals would have hand-rolled chrome everywhere. This PR fills that gap with a coherent set of wrappers + tokens + one domain component.

### What's added

**Tokens (`src/styles/app.css`):**
- `--color-success` / `--color-warning` / `--color-info` (status), `--color-popover` (floating panels)
- `--shadow-xs` / `--shadow-sm` / `--shadow-lg` / `--shadow-inner`
- `--font-serif` (Fraunces fallback) / `--font-mono` (Geist Mono fallback)
- Light values map from the design-system doc hex (#40c057, #fab005, #339af0) converted to oklch; dark values follow the existing `:root` private-alias convention.

**New wrappers (`src/components/ui/`):**
- `Dialog` — `@radix-ui/react-dialog`, sizes sm/md/lg, slots for header/body/footer/footerNote, reuses `Button` for the close affordance
- `Textarea` — native `<textarea>` with the Vata visual system, mirrors `Input`'s API (size, invalid, hint)
- `Switch` — `@radix-ui/react-switch`, label + optional description in a clickable row
- `Badge` — custom, variants default/primary/success/warning/danger/info/outline/soon, optional `dot`
- `OptionCard` + `OptionCardGroup` — `@radix-ui/react-radio-group`, used for "Empty vs From me" and "GEDCOM/JSON/ZIP" pickers; `soon` is a discriminated prop so its label can never silently fall back to English
- `Select` — `@radix-ui/react-select`, trigger styled via the shared `fieldRecipe` so Input + Select rows stay aligned
- `StatGrid` — custom mono-value grid used in Import / Edit / Download / Delete modals (with optional destructive accent for the loss preview)
- `Dropzone` — Tauri `open()` dialog (lazy-imported so Storybook keeps rendering), states idle / selected / scanning / done / error
- `SegmentedControl` — `@radix-ui/react-toggle-group`, used for sort/density pickers
- `field.tsx` — extracted `fieldRecipe` (shared base/state/size for Input + Textarea + Select trigger) and `useFieldHint` / `<FieldWithHint>` helpers (consolidated ~60 lines of duplicated hint+aria-describedby wiring)

**Extensions:**
- `iconRegistry` += `download`, `upload`, `folder-open`
- `Input` — new `hint?: ReactNode` prop wired via `aria-describedby`

**Domain:**
- `TreeCard` (in `src/components/trees/`) and `TreeCardCta` — separate components (no discriminated union) for the home-page grid

### Hors-périmètre

- Recâbler `src/pages/Home.tsx` and implement the 5 modals as features. Each is a separate plan that consumes this DS.
- Self-hosting Fraunces and Geist Mono `.woff2` files. The tokens fall back to the system serif/mono until those files land.

### Conventions respectées

- Every wrapper has a colocated `*.stories.tsx` with `play()` tests (83 tests across 14 files, all passing). Tests assert on roles / accessible names / callbacks / aria attributes — never classes or `data-testid`.
- All client-facing strings are passed via props by the consumer; nothing hardcoded English in the wrappers (Dialog `closeLabel`, OptionCard `soonLabel`, Dropzone `formatName`/`idleLabel` are all required props).
- Tokens are consumed via Tailwind utilities or `var(--color-*)` — no hex/oklch in component code.
- `lucide-react` is only imported by `icon.tsx`; everything else goes through the curated `iconRegistry`.

### Reviews already applied locally

- `/simplify` 3-agent pass — extracted `fieldRecipe` + `useFieldHint`, split `TreeCard` from `TreeCardCta`, made i18n labels required, fixed `aria-describedby` merging, dropped redundant `role="button"`.
- `pnpm review:all` (CodeRabbit) — addressed both findings (removed `formatName` runtime default; made Dialog's `aria-describedby={undefined}` conditional so Radix's auto-wiring takes effect when a Description is present). Final pass: **No findings ✔**.

## Test plan

- [ ] `pnpm build` — clean
- [ ] `pnpm test` — 83 tests pass across 14 stories files
- [ ] `pnpm storybook` — every new story renders; toggle Locale toolbar to confirm i18n hooks work
- [ ] Visual diff: existing Button / Input / Icon stories unchanged after the token additions
- [ ] In `pnpm tauri:dev`, no regression in current pages (Home, TreeView, DataBrowser); the new wrappers aren't wired up yet but the app must still boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)