### PR TITLE
feat(home): redesign tree picker with hero, status bar, preferences popover

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,18 @@
     <title>Vata</title>
   </head>
   <body>
+    <script>
+      // Pre-paint theme: avoids a light flash when the persisted preference
+      // is 'dark'. Mirrors src/hooks/useApplyAppPreferences.ts; 'system'
+      // intentionally clears both classes so the CSS prefers-color-scheme
+      // rule in app.css takes over.
+      try {
+        var stored = JSON.parse(localStorage.getItem('vata-app-storage') || 'null');
+        var theme = stored && stored.state && stored.state.theme;
+        if (theme === 'light') document.documentElement.classList.add('light');
+        else if (theme === 'dark') document.documentElement.classList.add('dark');
+      } catch (e) {}
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-radio-group':
         specifier: ^1.3.8
         version: 1.3.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -953,6 +956,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-popper@1.2.8':
@@ -4773,6 +4789,29 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
   '@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/src/components/app-status-bar.stories.tsx
+++ b/src/components/app-status-bar.stories.tsx
@@ -4,6 +4,8 @@ import { expect, fn, userEvent, within } from 'storybook/test';
 import { AppStatusBar } from './app-status-bar';
 import { Button } from './ui/button';
 
+const onDebugClick = fn();
+
 const meta = {
   title: 'App/AppStatusBar',
   component: AppStatusBar,
@@ -12,8 +14,7 @@ const meta = {
   args: {
     brandLabel: 'Vata',
     version: '0.1.0',
-    debugLabel: 'Debug',
-    onDebugClick: fn(),
+    debug: { label: 'Debug', onClick: onDebugClick },
     preferencesTrigger: (
       <Button variant="outline" size="sm" leadingIcon="settings" className="font-mono">
         Preferences
@@ -37,7 +38,7 @@ export const Default: Story = {
 
 export const WithShortcut: Story = {
   args: {
-    debugShortcut: '⌘D',
+    debug: { label: 'Debug', shortcut: '⌘D', onClick: onDebugClick },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -47,11 +48,23 @@ export const WithShortcut: Story = {
 
 export const DebugFires: Story = {
   args: {
-    debugShortcut: '⌘D',
+    debug: { label: 'Debug', shortcut: '⌘D', onClick: onDebugClick },
   },
-  play: async ({ args, canvasElement }) => {
+  play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    onDebugClick.mockClear();
     await userEvent.click(canvas.getByRole('button', { name: /Debug/ }));
-    await expect(args.onDebugClick).toHaveBeenCalledTimes(1);
+    await expect(onDebugClick).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const NoDebug: Story = {
+  args: {
+    debug: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('button', { name: /Debug/ })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /Preferences/ })).toBeInTheDocument();
   },
 };

--- a/src/components/app-status-bar.stories.tsx
+++ b/src/components/app-status-bar.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { AppStatusBar } from './app-status-bar';
+
+const meta = {
+  title: 'App/AppStatusBar',
+  component: AppStatusBar,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  args: {
+    brandLabel: 'Vata',
+    version: '0.1.0',
+    debugLabel: 'Debug',
+    preferencesLabel: 'Preferences',
+    onDebugClick: fn(),
+    onPreferencesClick: fn(),
+  },
+} satisfies Meta<typeof AppStatusBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Vata')).toBeInTheDocument();
+    await expect(canvas.getByText('v 0.1.0')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /Debug/ })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /Preferences/ })).toBeInTheDocument();
+  },
+};
+
+export const WithShortcut: Story = {
+  args: {
+    debugShortcut: '⌘D',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('⌘D')).toBeInTheDocument();
+  },
+};
+
+export const ButtonsFire: Story = {
+  args: {
+    debugShortcut: '⌘D',
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /Debug/ }));
+    await userEvent.click(canvas.getByRole('button', { name: /Preferences/ }));
+    await expect(args.onDebugClick).toHaveBeenCalledTimes(1);
+    await expect(args.onPreferencesClick).toHaveBeenCalledTimes(1);
+  },
+};

--- a/src/components/app-status-bar.stories.tsx
+++ b/src/components/app-status-bar.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { AppStatusBar } from './app-status-bar';
+import { Button } from './ui/button';
 
 const meta = {
   title: 'App/AppStatusBar',
@@ -12,9 +13,12 @@ const meta = {
     brandLabel: 'Vata',
     version: '0.1.0',
     debugLabel: 'Debug',
-    preferencesLabel: 'Preferences',
     onDebugClick: fn(),
-    onPreferencesClick: fn(),
+    preferencesTrigger: (
+      <Button variant="outline" size="sm" leadingIcon="settings" className="font-mono">
+        Preferences
+      </Button>
+    ),
   },
 } satisfies Meta<typeof AppStatusBar>;
 
@@ -41,15 +45,13 @@ export const WithShortcut: Story = {
   },
 };
 
-export const ButtonsFire: Story = {
+export const DebugFires: Story = {
   args: {
     debugShortcut: '⌘D',
   },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('button', { name: /Debug/ }));
-    await userEvent.click(canvas.getByRole('button', { name: /Preferences/ }));
     await expect(args.onDebugClick).toHaveBeenCalledTimes(1);
-    await expect(args.onPreferencesClick).toHaveBeenCalledTimes(1);
   },
 };

--- a/src/components/app-status-bar.tsx
+++ b/src/components/app-status-bar.tsx
@@ -3,6 +3,22 @@ import { type ReactNode } from 'react';
 import { Button } from '$components/ui/button';
 
 /**
+ * Optional debug action rendered between the version and the
+ * preferences trigger.
+ */
+export interface AppStatusBarDebugAction {
+  /** Localized label rendered inside the button. */
+  label: string;
+  /**
+   * Optional keyboard shortcut chip rendered after the label. Visual
+   * only — registering the shortcut is the caller's responsibility.
+   */
+  shortcut?: ReactNode;
+  /** Called when the button is clicked. */
+  onClick: () => void;
+}
+
+/**
  * Props accepted by {@link AppStatusBar}.
  */
 export interface AppStatusBarProps {
@@ -11,18 +27,11 @@ export interface AppStatusBarProps {
   /** Version string shown after the brand label (rendered as `v {version}`). */
   version: ReactNode;
   /**
-   * Localized label for the debug button. The button is always
-   * tree-shaken from production builds — even when this prop is
-   * supplied — via an `import.meta.env.DEV` guard inside the component.
+   * Optional debug action. Omit to hide the button entirely. Callers
+   * typically gate this with `import.meta.env.DEV` so production builds
+   * tree-shake the dev-only chrome.
    */
-  debugLabel?: string;
-  /**
-   * Optional keyboard shortcut chip rendered inside the debug button.
-   * Visual only — registering the shortcut is the caller's responsibility.
-   */
-  debugShortcut?: ReactNode;
-  /** Called when the debug button is clicked. */
-  onDebugClick?: () => void;
+  debug?: AppStatusBarDebugAction;
   /**
    * Slot rendered in place of a default Preferences button. Typically
    * a `Popover.Trigger` wrapping a Button so the caller can fully
@@ -34,9 +43,8 @@ export interface AppStatusBarProps {
 
 /**
  * Horizontal status bar pinned at the bottom of the app shell. Shows
- * the brand + version on the left, a Debug button (with optional
- * keyboard chip) and a caller-provided preferences trigger on the
- * right.
+ * the brand + version on the left, an optional Debug button, and a
+ * caller-provided preferences trigger on the right.
  *
  * Owns no copy — every label is supplied by the caller. The
  * preferences slot is fully delegated so the caller controls the
@@ -46,9 +54,11 @@ export interface AppStatusBarProps {
  * <AppStatusBar
  *   brandLabel="Vata"
  *   version={packageJson.version}
- *   debugLabel={t('common:statusBar.debug')}
- *   debugShortcut="⌘D"
- *   onDebugClick={openDebugPanel}
+ *   debug={import.meta.env.DEV ? {
+ *     label: t('common:statusBar.debug'),
+ *     shortcut: '⌘D',
+ *     onClick: openDebugPanel,
+ *   } : undefined}
  *   preferencesTrigger={
  *     <PreferencesPopover>
  *       <Button variant="outline" size="sm" leadingIcon="settings">
@@ -61,9 +71,7 @@ export interface AppStatusBarProps {
 export function AppStatusBar({
   brandLabel,
   version,
-  debugLabel,
-  debugShortcut,
-  onDebugClick,
+  debug,
   preferencesTrigger,
 }: AppStatusBarProps): JSX.Element {
   return (
@@ -72,19 +80,19 @@ export function AppStatusBar({
       <span aria-hidden>·</span>
       <span className="tabular-nums">v {version}</span>
       <span className="flex-1" aria-hidden />
-      {import.meta.env.DEV && debugLabel && onDebugClick && (
+      {debug && (
         <>
           <Button
             variant="outline"
             size="sm"
             leadingIcon="bug"
-            onClick={onDebugClick}
+            onClick={debug.onClick}
             className="font-mono"
           >
-            {debugLabel}
-            {debugShortcut && (
+            {debug.label}
+            {debug.shortcut && (
               <span className="border-border bg-foreground/5 text-muted-foreground ml-1 rounded border px-1.5 py-px font-mono text-[10px] leading-none">
-                {debugShortcut}
+                {debug.shortcut}
               </span>
             )}
           </Button>

--- a/src/components/app-status-bar.tsx
+++ b/src/components/app-status-bar.tsx
@@ -17,22 +17,26 @@ export interface AppStatusBarProps {
    * Visual only — registering the shortcut is the caller's responsibility.
    */
   debugShortcut?: ReactNode;
-  /** Localized label for the preferences button. */
-  preferencesLabel: string;
   /** Called when the debug button is clicked. */
   onDebugClick: () => void;
-  /** Called when the preferences button is clicked. */
-  onPreferencesClick: () => void;
+  /**
+   * Slot rendered in place of a default Preferences button. Typically
+   * a `Popover.Trigger` wrapping a Button so the caller can fully
+   * compose the popover behavior. Required so this wrapper does not
+   * own the preferences UI.
+   */
+  preferencesTrigger: ReactNode;
 }
 
 /**
  * Horizontal status bar pinned at the bottom of the app shell. Shows
- * the brand + version on the left and Debug / Preferences buttons on
- * the right. Owns no copy — every label is supplied by the caller.
+ * the brand + version on the left, a Debug button (with optional
+ * keyboard chip) and a caller-provided preferences trigger on the
+ * right.
  *
- * Composes {@link Button} (outline, sm) so the buttons stay consistent
- * with the rest of the design system. The debug button accepts an
- * optional keyboard-shortcut chip rendered after the label.
+ * Owns no copy — every label is supplied by the caller. The
+ * preferences slot is fully delegated so the caller controls the
+ * popover/dropdown/dialog that opens on click.
  *
  * @example
  * <AppStatusBar
@@ -40,9 +44,14 @@ export interface AppStatusBarProps {
  *   version={packageJson.version}
  *   debugLabel={t('common:statusBar.debug')}
  *   debugShortcut="⌘D"
- *   preferencesLabel={t('common:statusBar.preferences')}
  *   onDebugClick={openDebugPanel}
- *   onPreferencesClick={openPreferences}
+ *   preferencesTrigger={
+ *     <PreferencesPopover>
+ *       <Button variant="outline" size="sm" leadingIcon="settings">
+ *         {t('common:statusBar.preferences')}
+ *       </Button>
+ *     </PreferencesPopover>
+ *   }
  * />
  */
 export function AppStatusBar({
@@ -50,9 +59,8 @@ export function AppStatusBar({
   version,
   debugLabel,
   debugShortcut,
-  preferencesLabel,
   onDebugClick,
-  onPreferencesClick,
+  preferencesTrigger,
 }: AppStatusBarProps): JSX.Element {
   return (
     <footer className="border-border bg-background text-muted-foreground flex h-[52px] items-center gap-3.5 border-t px-[18px] font-mono text-[11px]">
@@ -75,15 +83,7 @@ export function AppStatusBar({
         )}
       </Button>
       <span aria-hidden>·</span>
-      <Button
-        variant="outline"
-        size="sm"
-        leadingIcon="settings"
-        onClick={onPreferencesClick}
-        className="font-mono"
-      >
-        {preferencesLabel}
-      </Button>
+      {preferencesTrigger}
     </footer>
   );
 }

--- a/src/components/app-status-bar.tsx
+++ b/src/components/app-status-bar.tsx
@@ -10,15 +10,19 @@ export interface AppStatusBarProps {
   brandLabel: ReactNode;
   /** Version string shown after the brand label (rendered as `v {version}`). */
   version: ReactNode;
-  /** Localized label for the debug button. */
-  debugLabel: string;
+  /**
+   * Localized label for the debug button. The button is always
+   * tree-shaken from production builds — even when this prop is
+   * supplied — via an `import.meta.env.DEV` guard inside the component.
+   */
+  debugLabel?: string;
   /**
    * Optional keyboard shortcut chip rendered inside the debug button.
    * Visual only — registering the shortcut is the caller's responsibility.
    */
   debugShortcut?: ReactNode;
   /** Called when the debug button is clicked. */
-  onDebugClick: () => void;
+  onDebugClick?: () => void;
   /**
    * Slot rendered in place of a default Preferences button. Typically
    * a `Popover.Trigger` wrapping a Button so the caller can fully
@@ -68,21 +72,25 @@ export function AppStatusBar({
       <span aria-hidden>·</span>
       <span className="tabular-nums">v {version}</span>
       <span className="flex-1" aria-hidden />
-      <Button
-        variant="outline"
-        size="sm"
-        leadingIcon="bug"
-        onClick={onDebugClick}
-        className="font-mono"
-      >
-        {debugLabel}
-        {debugShortcut && (
-          <span className="border-border bg-foreground/5 text-muted-foreground ml-1 rounded border px-1.5 py-px font-mono text-[10px] leading-none">
-            {debugShortcut}
-          </span>
-        )}
-      </Button>
-      <span aria-hidden>·</span>
+      {import.meta.env.DEV && debugLabel && onDebugClick && (
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            leadingIcon="bug"
+            onClick={onDebugClick}
+            className="font-mono"
+          >
+            {debugLabel}
+            {debugShortcut && (
+              <span className="border-border bg-foreground/5 text-muted-foreground ml-1 rounded border px-1.5 py-px font-mono text-[10px] leading-none">
+                {debugShortcut}
+              </span>
+            )}
+          </Button>
+          <span aria-hidden>·</span>
+        </>
+      )}
       {preferencesTrigger}
     </footer>
   );

--- a/src/components/app-status-bar.tsx
+++ b/src/components/app-status-bar.tsx
@@ -1,0 +1,89 @@
+import { type ReactNode } from 'react';
+
+import { Button } from '$components/ui/button';
+
+/**
+ * Props accepted by {@link AppStatusBar}.
+ */
+export interface AppStatusBarProps {
+  /** Brand or product name shown on the left (e.g., "Vata"). */
+  brandLabel: ReactNode;
+  /** Version string shown after the brand label (rendered as `v {version}`). */
+  version: ReactNode;
+  /** Localized label for the debug button. */
+  debugLabel: string;
+  /**
+   * Optional keyboard shortcut chip rendered inside the debug button.
+   * Visual only — registering the shortcut is the caller's responsibility.
+   */
+  debugShortcut?: ReactNode;
+  /** Localized label for the preferences button. */
+  preferencesLabel: string;
+  /** Called when the debug button is clicked. */
+  onDebugClick: () => void;
+  /** Called when the preferences button is clicked. */
+  onPreferencesClick: () => void;
+}
+
+/**
+ * Horizontal status bar pinned at the bottom of the app shell. Shows
+ * the brand + version on the left and Debug / Preferences buttons on
+ * the right. Owns no copy — every label is supplied by the caller.
+ *
+ * Composes {@link Button} (outline, sm) so the buttons stay consistent
+ * with the rest of the design system. The debug button accepts an
+ * optional keyboard-shortcut chip rendered after the label.
+ *
+ * @example
+ * <AppStatusBar
+ *   brandLabel="Vata"
+ *   version={packageJson.version}
+ *   debugLabel={t('common:statusBar.debug')}
+ *   debugShortcut="⌘D"
+ *   preferencesLabel={t('common:statusBar.preferences')}
+ *   onDebugClick={openDebugPanel}
+ *   onPreferencesClick={openPreferences}
+ * />
+ */
+export function AppStatusBar({
+  brandLabel,
+  version,
+  debugLabel,
+  debugShortcut,
+  preferencesLabel,
+  onDebugClick,
+  onPreferencesClick,
+}: AppStatusBarProps): JSX.Element {
+  return (
+    <footer className="border-border bg-background text-muted-foreground flex h-[52px] items-center gap-3.5 border-t px-[18px] font-mono text-[11px]">
+      <span>{brandLabel}</span>
+      <span aria-hidden>·</span>
+      <span className="tabular-nums">v {version}</span>
+      <span className="flex-1" aria-hidden />
+      <Button
+        variant="outline"
+        size="sm"
+        leadingIcon="bug"
+        onClick={onDebugClick}
+        className="font-mono"
+      >
+        {debugLabel}
+        {debugShortcut && (
+          <span className="border-border bg-foreground/5 text-muted-foreground ml-1 rounded border px-1.5 py-px font-mono text-[10px] leading-none">
+            {debugShortcut}
+          </span>
+        )}
+      </Button>
+      <span aria-hidden>·</span>
+      <Button
+        variant="outline"
+        size="sm"
+        leadingIcon="settings"
+        onClick={onPreferencesClick}
+        className="font-mono"
+      >
+        {preferencesLabel}
+      </Button>
+    </footer>
+  );
+}

--- a/src/components/preferences-popover.stories.tsx
+++ b/src/components/preferences-popover.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { useAppStore } from '$/store/app-store';
+import { PreferencesPopover } from './preferences-popover';
+import { Button } from './ui/button';
+
+const meta = {
+  title: 'App/PreferencesPopover',
+  component: PreferencesPopover,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    children: null,
+  },
+  render: () => (
+    <PreferencesPopover>
+      <Button variant="outline" size="sm" leadingIcon="settings">
+        Preferences
+      </Button>
+    </PreferencesPopover>
+  ),
+} satisfies Meta<typeof PreferencesPopover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    useAppStore.setState({ theme: 'system' });
+    document.documentElement.classList.remove('light', 'dark');
+
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /Preferences/ }));
+
+    const body = within(document.body);
+    await waitFor(async () => {
+      await expect(body.getByText('Theme')).toBeInTheDocument();
+      await expect(body.getByText('Language')).toBeInTheDocument();
+    });
+  },
+};
+
+export const SwitchTheme: Story = {
+  play: async ({ canvasElement }) => {
+    useAppStore.setState({ theme: 'system' });
+    document.documentElement.classList.remove('light', 'dark');
+
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /Preferences/ }));
+
+    const body = within(document.body);
+    await waitFor(async () => {
+      await expect(body.getByText('Dark')).toBeInTheDocument();
+    });
+
+    await userEvent.click(body.getByRole('radio', { name: 'Dark' }));
+    await expect(useAppStore.getState().theme).toBe('dark');
+  },
+};

--- a/src/components/preferences-popover.tsx
+++ b/src/components/preferences-popover.tsx
@@ -3,13 +3,14 @@ import { useTranslation } from 'react-i18next';
 
 import { Popover, PopoverContent, PopoverTrigger } from '$components/ui/popover';
 import { SegmentedControl } from '$components/ui/segmented-control';
+import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '$/i18n/config';
 import { useAppStore, type Theme } from '$/store/app-store';
 
-type Language = 'en' | 'fr';
-
-function normalizeLanguage(raw: string): Language {
+function normalizeLanguage(raw: string): SupportedLanguage {
   const base = raw.split('-')[0]?.toLowerCase();
-  return base === 'fr' ? 'fr' : 'en';
+  return SUPPORTED_LANGUAGES.includes(base as SupportedLanguage)
+    ? (base as SupportedLanguage)
+    : 'en';
 }
 
 /**

--- a/src/components/preferences-popover.tsx
+++ b/src/components/preferences-popover.tsx
@@ -62,7 +62,7 @@ export function PreferencesPopover({ children }: PreferencesPopoverProps): JSX.E
           {t('preferences.title')}
         </h2>
 
-        <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col items-start gap-1.5">
           <span className="text-muted-foreground font-mono text-[10.5px] tracking-wider uppercase">
             {t('preferences.themeLabel')}
           </span>
@@ -77,7 +77,7 @@ export function PreferencesPopover({ children }: PreferencesPopoverProps): JSX.E
           />
         </div>
 
-        <div className="mt-4 flex flex-col gap-1.5">
+        <div className="mt-4 flex flex-col items-start gap-1.5">
           <span className="text-muted-foreground font-mono text-[10.5px] tracking-wider uppercase">
             {t('preferences.languageLabel')}
           </span>

--- a/src/components/preferences-popover.tsx
+++ b/src/components/preferences-popover.tsx
@@ -1,0 +1,97 @@
+import { type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Popover, PopoverContent, PopoverTrigger } from '$components/ui/popover';
+import { SegmentedControl } from '$components/ui/segmented-control';
+import { useAppStore, type Theme } from '$/store/app-store';
+
+type Language = 'en' | 'fr';
+
+function normalizeLanguage(raw: string): Language {
+  const base = raw.split('-')[0]?.toLowerCase();
+  return base === 'fr' ? 'fr' : 'en';
+}
+
+/**
+ * Props accepted by {@link PreferencesPopover}.
+ */
+export interface PreferencesPopoverProps {
+  /** The trigger element wrapped by `Popover.Trigger`. */
+  children: ReactNode;
+}
+
+/**
+ * Floating preferences panel anchored to a trigger. Lets the user
+ * change the **theme** (light / dark / system) and the **UI language**
+ * (en / fr) and persists both selections — theme via the Zustand store,
+ * language via i18next's localStorage detector.
+ *
+ * Owns all preference-related copy via `useTranslation('common')`. The
+ * caller only provides the trigger element.
+ *
+ * @example
+ * <PreferencesPopover>
+ *   <Button variant="outline" size="sm" leadingIcon="settings">
+ *     {t('common:statusBar.preferences')}
+ *   </Button>
+ * </PreferencesPopover>
+ */
+export function PreferencesPopover({ children }: PreferencesPopoverProps): JSX.Element {
+  const { t, i18n } = useTranslation('common');
+  const theme = useAppStore((state) => state.theme);
+  const setTheme = useAppStore((state) => state.setTheme);
+
+  const language = normalizeLanguage(i18n.language);
+
+  const themeOptions = [
+    { value: 'light', label: t('preferences.themeLight') },
+    { value: 'dark', label: t('preferences.themeDark') },
+    { value: 'system', label: t('preferences.themeSystem') },
+  ];
+
+  const languageOptions = [
+    { value: 'en', label: t('preferences.languageEn') },
+    { value: 'fr', label: t('preferences.languageFr') },
+  ];
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent side="top" align="end" className="w-[280px] p-4">
+        <h2 className="text-foreground mb-3 font-serif text-base leading-none font-medium tracking-tight italic">
+          {t('preferences.title')}
+        </h2>
+
+        <div className="flex flex-col gap-1.5">
+          <span className="text-muted-foreground font-mono text-[10.5px] tracking-wider uppercase">
+            {t('preferences.themeLabel')}
+          </span>
+          <SegmentedControl
+            size="sm"
+            options={themeOptions}
+            value={theme}
+            onValueChange={(next) => {
+              if (next) setTheme(next as Theme);
+            }}
+            aria-label={t('preferences.themeAriaLabel')}
+          />
+        </div>
+
+        <div className="mt-4 flex flex-col gap-1.5">
+          <span className="text-muted-foreground font-mono text-[10.5px] tracking-wider uppercase">
+            {t('preferences.languageLabel')}
+          </span>
+          <SegmentedControl
+            size="sm"
+            options={languageOptions}
+            value={language}
+            onValueChange={(next) => {
+              if (next) void i18n.changeLanguage(next);
+            }}
+            aria-label={t('preferences.languageAriaLabel')}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/trees/tree-card-cta.stories.tsx
+++ b/src/components/trees/tree-card-cta.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
-import { TreeCardCta } from './tree-card';
+import { TreeCardCta } from './tree-card-cta';
 
 const meta = {
   title: 'Trees/TreeCardCta',
@@ -16,7 +16,7 @@ const meta = {
     ),
   ],
   args: {
-    label: 'Add a new tree',
+    title: 'Start a new tree',
     onClick: fn(),
   },
 } satisfies Meta<typeof TreeCardCta>;
@@ -27,8 +27,20 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
-    const button = canvas.getByRole('button', { name: /Add a new tree/ });
+    const button = canvas.getByRole('button', { name: /Start a new tree/ });
     await userEvent.click(button);
     await expect(args.onClick).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const WithSubtitle: Story = {
+  args: {
+    title: 'Start a new tree',
+    subtitle: 'Or drop a .ged file',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Start a new tree')).toBeInTheDocument();
+    await expect(canvas.getByText('Or drop a .ged file')).toBeInTheDocument();
   },
 };

--- a/src/components/trees/tree-card-cta.tsx
+++ b/src/components/trees/tree-card-cta.tsx
@@ -1,0 +1,64 @@
+import { type ReactNode } from 'react';
+import { tv } from 'tailwind-variants';
+
+import { Icon } from '$components/ui/icon';
+
+const ctaBase = tv({
+  base: [
+    'group relative flex min-h-[220px] flex-col items-center justify-center gap-3.5 rounded-xl border border-dashed border-foreground/15 bg-transparent p-7 text-center',
+    'cursor-pointer transition-colors duration-150',
+    'hover:border-primary hover:bg-primary/5',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+  ],
+});
+
+const ctaCircle = tv({
+  base: [
+    'flex h-11 w-11 items-center justify-center rounded-full border border-dashed border-foreground/20 text-muted-foreground',
+    'transition-colors duration-150',
+    'group-hover:border-primary group-hover:text-primary',
+  ],
+});
+
+/**
+ * Props accepted by {@link TreeCardCta}.
+ */
+export interface TreeCardCtaProps {
+  /** Localized title rendered below the plus icon. */
+  title: ReactNode;
+  /** Optional localized subtitle (e.g., "Or drop a .ged file"). */
+  subtitle?: ReactNode;
+  /** Called when the tile is clicked. */
+  onClick: () => void;
+}
+
+/**
+ * Dashed CTA tile used as the trailing cell of the trees grid to
+ * trigger "Add a new tree". Renders as a `<button>` so it is
+ * keyboard-focusable and announced as a button by screen readers.
+ *
+ * Visual: dashed-border tile holding a circular dashed-border plus
+ * icon, a primary title, and an optional muted subtitle. Hover
+ * promotes both borders to the primary colour and tints the
+ * background with `primary/5`.
+ *
+ * @example
+ * <TreeCardCta
+ *   title={t('cta.title')}
+ *   subtitle={t('cta.subtitle')}
+ *   onClick={() => openCreateDialog()}
+ * />
+ */
+export function TreeCardCta({ title, subtitle, onClick }: TreeCardCtaProps): JSX.Element {
+  return (
+    <button type="button" onClick={onClick} className={ctaBase()}>
+      <span className={ctaCircle()}>
+        <Icon name="plus" size={20} />
+      </span>
+      <span className="flex flex-col items-center gap-1">
+        <span className="text-foreground text-sm font-medium">{title}</span>
+        {subtitle && <span className="text-muted-foreground text-xs">{subtitle}</span>}
+      </span>
+    </button>
+  );
+}

--- a/src/components/trees/tree-card.stories.tsx
+++ b/src/components/trees/tree-card.stories.tsx
@@ -3,7 +3,7 @@ import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { TreeCard, type TreeCardProps } from './tree-card';
 
-const labels = {
+const labels: TreeCardProps['labels'] = {
   open: 'Open',
   export: 'Export',
   edit: 'Rename',
@@ -11,6 +11,8 @@ const labels = {
   individuals: 'Individuals',
   families: 'Families',
   generations: 'Generations',
+  createdAt: 'Created',
+  lastAccessedAt: 'Last opened',
 };
 
 const meta = {
@@ -34,7 +36,7 @@ const defaultArgs: TreeCardProps = {
   name: 'Bourgoin family',
   description: "Started from grandpa's notebook in 2024.",
   stats: { individuals: 142, families: 58 },
-  meta: { createdAt: 'Created Jan 12, 2024', lastAccessedAt: 'Last opened 2h ago' },
+  meta: { createdAt: '2024-01-12', lastAccessedAt: '2026-04-11' },
   labels,
   onOpen: fn(),
   onExport: fn(),
@@ -47,6 +49,10 @@ export const Default: Story = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('Bourgoin family')).toBeInTheDocument();
+    await expect(canvas.getByText('Individuals')).toBeInTheDocument();
+    await expect(canvas.getByText('Families')).toBeInTheDocument();
+    await expect(canvas.getByText('Created')).toBeInTheDocument();
+    await expect(canvas.getByText('Last opened')).toBeInTheDocument();
     await userEvent.click(canvas.getByRole('button', { name: 'Open' }));
     await expect(args.onOpen).toHaveBeenCalledTimes(1);
   },

--- a/src/components/trees/tree-card.tsx
+++ b/src/components/trees/tree-card.tsx
@@ -2,18 +2,12 @@ import { type ReactNode } from 'react';
 import { tv } from 'tailwind-variants';
 
 import { Button } from '$components/ui/button';
-import { Icon } from '$components/ui/icon';
-import { StatGrid } from '$components/ui/stat-grid';
 
 const cardBase = tv({
-  base: ['flex flex-col gap-3 rounded-lg border bg-card p-4 transition-colors duration-150'],
-});
-
-const ctaCardBase = tv({
   base: [
-    'flex min-h-[200px] cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border border-dashed bg-card p-4 text-center',
-    'text-muted-foreground transition-colors duration-150',
-    'hover:border-primary/40 hover:text-foreground',
+    'relative flex min-h-[220px] flex-col gap-3.5 rounded-xl border border-border bg-card p-[18px] pb-4',
+    'transition-colors duration-150',
+    'hover:border-foreground/20 hover:shadow-sm',
   ],
 });
 
@@ -28,18 +22,18 @@ export interface TreeCardStats {
 }
 
 /**
- * Metadata shown at the bottom of the card.
+ * Metadata shown in the card body. Values are pre-formatted by the caller.
  */
 export interface TreeCardMeta {
-  /** Localized "created at" caption (already formatted). */
+  /** Formatted "created at" value (e.g., a localised date string). */
   createdAt: ReactNode;
-  /** Localized "last accessed" caption (already formatted). */
+  /** Formatted "last accessed" value. */
   lastAccessedAt: ReactNode;
 }
 
 /**
- * Localized labels rendered as button accessible names. Required so
- * the wrapper does not own copy.
+ * Localized labels rendered inside the card. Required so the wrapper
+ * does not own copy.
  */
 export interface TreeCardLabels {
   open: string;
@@ -49,6 +43,8 @@ export interface TreeCardLabels {
   individuals: string;
   families: string;
   generations: string;
+  createdAt: string;
+  lastAccessedAt: string;
 }
 
 /**
@@ -59,11 +55,11 @@ export interface TreeCardProps {
   name: ReactNode;
   /** Optional tree description. */
   description?: ReactNode;
-  /** Counts displayed in the StatGrid. */
+  /** Counts displayed in the stats row. */
   stats: TreeCardStats;
   /** Created/last-accessed metadata. */
   meta: TreeCardMeta;
-  /** Localized accessible names for the action buttons and stat labels. */
+  /** Localized labels for stats, metadata keys, and action buttons. */
   labels: TreeCardLabels;
   /** Called when the user clicks "Open". */
   onOpen: () => void;
@@ -75,17 +71,59 @@ export interface TreeCardProps {
   onDelete: () => void;
 }
 
+interface StatProps {
+  value: ReactNode;
+  label: ReactNode;
+}
+
+function Stat({ value, label }: StatProps): JSX.Element {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="font-mono text-lg leading-none font-medium tabular-nums tracking-tight">
+        {value}
+      </span>
+      <span className="text-muted-foreground font-mono text-[10px] leading-none tracking-wider uppercase">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function StatDivider(): JSX.Element {
+  return <span aria-hidden className="bg-border h-6 w-px flex-none" />;
+}
+
+interface MetaRowProps {
+  label: ReactNode;
+  value: ReactNode;
+}
+
+function MetaRow({ label, value }: MetaRowProps): JSX.Element {
+  return (
+    <div className="flex items-center gap-2 font-mono text-[11.5px] leading-snug">
+      <span className="text-muted-foreground w-[120px] flex-none whitespace-nowrap">{label}</span>
+      <span className="text-foreground tabular-nums">{value}</span>
+    </div>
+  );
+}
+
 /**
  * Domain card representing one family tree on the home page.
  *
  * Lives outside `src/components/ui/` because it is genealogy-domain
- * specific — it composes generic UI primitives (Button, Icon, StatGrid)
- * but has its own data shape and call sites. For the "Add a new tree"
- * tile, use the dedicated {@link TreeCardCta} component instead — they
- * share no real runtime code, only family resemblance.
+ * specific — it composes generic UI primitives (Button) but has its
+ * own data shape and call sites. For the "Add a new tree" tile, use
+ * the dedicated `TreeCardCta` component instead — they share no real
+ * runtime code, only family resemblance.
  *
  * All textual content (name, description, button labels, meta) must be
  * localized by the caller; this component does not own copy.
+ *
+ * Visual layout (top-to-bottom):
+ * 1. Title row — serif italic name + 2-line clamped description.
+ * 2. Stats row — inline figures (individuals, families, optional generations) separated by vertical rules.
+ * 3. Meta block — dashed top border, mono key/value rows (created, last opened).
+ * 4. Action row — outline "Open" button (flex-1) followed by ghost icon-only buttons (export, edit, delete).
  *
  * @example
  * <TreeCard
@@ -94,13 +132,15 @@ export interface TreeCardProps {
  *   stats={{ individuals: 142, families: 58 }}
  *   meta={{ createdAt: '2024-01-12', lastAccessedAt: '2 hours ago' }}
  *   labels={{
- *     open: t('trees.open'),
- *     export: t('trees.export'),
- *     edit: t('trees.edit'),
- *     delete: t('trees.delete'),
- *     individuals: t('trees.stats.individuals'),
- *     families: t('trees.stats.families'),
- *     generations: t('trees.stats.generations'),
+ *     open: t('card.open'),
+ *     export: t('card.export'),
+ *     edit: t('card.edit'),
+ *     delete: t('card.delete'),
+ *     individuals: t('card.individuals'),
+ *     families: t('card.families'),
+ *     generations: t('card.generations'),
+ *     createdAt: t('card.createdAt'),
+ *     lastAccessedAt: t('card.lastAccessedAt'),
  *   }}
  *   onOpen={...} onExport={...} onEdit={...} onDelete={...}
  * />
@@ -116,74 +156,57 @@ export function TreeCard({
   onEdit,
   onDelete,
 }: TreeCardProps): JSX.Element {
-  const items = [
-    { value: stats.individuals, label: labels.individuals },
-    { value: stats.families, label: labels.families },
-  ];
-  if (stats.generations != null) {
-    items.push({ value: stats.generations, label: labels.generations });
-  }
-
   return (
-    <article className={`${cardBase()} border-border hover:border-primary/40`}>
-      <header className="flex items-start justify-between gap-2">
-        <div className="flex flex-col gap-0.5">
-          <h3 className="text-foreground text-base font-semibold leading-tight">{name}</h3>
-          {description && (
-            <p className="text-muted-foreground text-xs leading-snug">{description}</p>
-          )}
-        </div>
-        <div className="flex items-center gap-1">
-          <Button variant="ghost" size="sm" hideLabel leadingIcon="download" onClick={onExport}>
-            {labels.export}
-          </Button>
-          <Button variant="ghost" size="sm" hideLabel leadingIcon="pencil" onClick={onEdit}>
-            {labels.edit}
-          </Button>
-          <Button variant="ghost" size="sm" hideLabel leadingIcon="trash" onClick={onDelete}>
-            {labels.delete}
-          </Button>
-        </div>
-      </header>
+    <article className={cardBase()}>
+      <div className="flex min-w-0 flex-col gap-1">
+        <h3 className="text-foreground truncate font-serif text-[19px] leading-tight font-medium tracking-tight italic">
+          {name}
+        </h3>
+        {description && (
+          <p className="text-muted-foreground line-clamp-2 text-[13px] leading-snug">
+            {description}
+          </p>
+        )}
+      </div>
 
-      <StatGrid items={items} cols={items.length === 3 ? 3 : 2} />
+      <div className="flex items-center gap-2.5">
+        <Stat value={stats.individuals} label={labels.individuals} />
+        <StatDivider />
+        <Stat value={stats.families} label={labels.families} />
+        {stats.generations != null && (
+          <>
+            <StatDivider />
+            <Stat value={stats.generations} label={labels.generations} />
+          </>
+        )}
+      </div>
 
-      <footer className="flex items-center justify-between gap-2 border-t border-border pt-3">
-        <div className="flex flex-col gap-0.5 text-xs">
-          <span className="text-muted-foreground">{meta.createdAt}</span>
-          <span className="text-muted-foreground">{meta.lastAccessedAt}</span>
-        </div>
-        <Button variant="outline" size="sm" trailingIcon="arrow-right" onClick={onOpen}>
+      <div className="border-border flex flex-col gap-1 border-t border-dashed pt-2.5">
+        <MetaRow label={labels.createdAt} value={meta.createdAt} />
+        <MetaRow label={labels.lastAccessedAt} value={meta.lastAccessedAt} />
+      </div>
+
+      <div className="mt-auto flex items-center gap-1.5 pt-2.5">
+        <Button
+          variant="outline"
+          size="sm"
+          leadingIcon="folder-open"
+          trailingIcon="arrow-right"
+          onClick={onOpen}
+          className="flex-1"
+        >
           {labels.open}
         </Button>
-      </footer>
+        <Button variant="ghost" size="sm" hideLabel leadingIcon="download" onClick={onExport}>
+          {labels.export}
+        </Button>
+        <Button variant="ghost" size="sm" hideLabel leadingIcon="pencil" onClick={onEdit}>
+          {labels.edit}
+        </Button>
+        <Button variant="ghost" size="sm" hideLabel leadingIcon="trash" onClick={onDelete}>
+          {labels.delete}
+        </Button>
+      </div>
     </article>
-  );
-}
-
-/**
- * Props accepted by {@link TreeCardCta}.
- */
-export interface TreeCardCtaProps {
-  /** Localized label for the CTA tile. */
-  label: ReactNode;
-  /** Called when the CTA is clicked. */
-  onClick: () => void;
-}
-
-/**
- * Dashed CTA tile used as the last cell of the trees grid to trigger
- * "Add a new tree". Renders as a `<button>` so it is keyboard-focusable
- * and announced as a button by screen readers.
- *
- * @example
- * <TreeCardCta label={t('trees.new')} onClick={() => navigate('/new')} />
- */
-export function TreeCardCta({ label, onClick }: TreeCardCtaProps): JSX.Element {
-  return (
-    <button type="button" onClick={onClick} className={ctaCardBase()}>
-      <Icon name="plus" size={24} />
-      <span className="text-sm font-medium">{label}</span>
-    </button>
   );
 }

--- a/src/components/trees/tree-section-divider.stories.tsx
+++ b/src/components/trees/tree-section-divider.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { TreeSectionDivider, type TreeSectionDividerProps } from './tree-section-divider';
+
+const sortOptions = [
+  { value: 'recent', label: 'Recent' },
+  { value: 'name', label: 'Name' },
+  { value: 'size', label: 'Size' },
+];
+
+function Wrapper(args: Omit<TreeSectionDividerProps, 'sortValue' | 'onSortChange'>): JSX.Element {
+  const [sort, setSort] = useState('recent');
+  return <TreeSectionDivider {...args} sortValue={sort} onSortChange={setSort} />;
+}
+
+const meta = {
+  title: 'Trees/TreeSectionDivider',
+  component: Wrapper,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <div className="w-[720px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    label: 'Your trees',
+    count: 4,
+    sortOptions,
+    sortAriaLabel: 'Sort trees',
+  },
+} satisfies Meta<typeof Wrapper>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Your trees')).toBeInTheDocument();
+    await expect(canvas.getByText('4')).toBeInTheDocument();
+    const recent = canvas.getByRole('radio', { name: 'Recent' });
+    await expect(recent).toHaveAttribute('data-state', 'on');
+  },
+};
+
+export const SwitchSort: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const name = canvas.getByRole('radio', { name: 'Name' });
+    await userEvent.click(name);
+    await expect(name).toHaveAttribute('data-state', 'on');
+  },
+};
+
+export const EmptyCount: Story = {
+  args: { count: 0 },
+};

--- a/src/components/trees/tree-section-divider.tsx
+++ b/src/components/trees/tree-section-divider.tsx
@@ -1,0 +1,74 @@
+import { type ReactNode } from 'react';
+
+import { Badge } from '$components/ui/badge';
+import { SegmentedControl, type SegmentedControlOption } from '$components/ui/segmented-control';
+
+/**
+ * Props accepted by {@link TreeSectionDivider}.
+ */
+export interface TreeSectionDividerProps {
+  /** Localized section label (mono uppercase, e.g., "Your trees"). */
+  label: ReactNode;
+  /** Item count rendered in an outline badge next to the label. */
+  count: number;
+  /** Sort options rendered as a segmented control on the right. */
+  sortOptions: SegmentedControlOption[];
+  /** Currently selected sort value. */
+  sortValue: string;
+  /** Called when the user picks a different sort option. */
+  onSortChange: (value: string) => void;
+  /** Localized accessible name for the sort segmented control. */
+  sortAriaLabel: string;
+}
+
+/**
+ * Section header for the trees grid: a mono uppercase label, a count
+ * badge, a thin horizontal rule that fills the available space, and a
+ * segmented control bound to a sort selection.
+ *
+ * Composes existing primitives ({@link Badge}, {@link SegmentedControl})
+ * and owns no copy — every label is supplied by the caller.
+ *
+ * @example
+ * <TreeSectionDivider
+ *   label={t('home.sectionLabel')}
+ *   count={trees.length}
+ *   sortOptions={[
+ *     { value: 'recent', label: t('home.sortRecent') },
+ *     { value: 'name', label: t('home.sortName') },
+ *     { value: 'size', label: t('home.sortSize') },
+ *   ]}
+ *   sortValue={sort}
+ *   onSortChange={setSort}
+ *   sortAriaLabel={t('home.sortAriaLabel')}
+ * />
+ */
+export function TreeSectionDivider({
+  label,
+  count,
+  sortOptions,
+  sortValue,
+  onSortChange,
+  sortAriaLabel,
+}: TreeSectionDividerProps): JSX.Element {
+  return (
+    <div className="flex items-center gap-3.5">
+      <span className="text-muted-foreground font-mono text-[10.5px] tracking-wider uppercase">
+        {label}
+      </span>
+      <Badge variant="outline" size="sm" className="font-mono">
+        {count}
+      </Badge>
+      <span aria-hidden className="bg-border h-px flex-1" />
+      <SegmentedControl
+        size="sm"
+        options={sortOptions}
+        value={sortValue}
+        onValueChange={(next) => {
+          if (next) onSortChange(next);
+        }}
+        aria-label={sortAriaLabel}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowLeft,
   ArrowRight,
+  Bug,
   ChevronDown,
   ChevronRight,
   Download,
@@ -8,6 +9,7 @@ import {
   Pencil,
   Plus,
   Search,
+  Settings,
   Trash2,
   Upload,
   X,
@@ -28,6 +30,7 @@ import { forwardRef, type ComponentType } from 'react';
 export const iconRegistry = {
   'arrow-left': ArrowLeft,
   'arrow-right': ArrowRight,
+  bug: Bug,
   'chevron-down': ChevronDown,
   'chevron-right': ChevronRight,
   download: Download,
@@ -35,6 +38,7 @@ export const iconRegistry = {
   pencil: Pencil,
   plus: Plus,
   search: Search,
+  settings: Settings,
   trash: Trash2,
   upload: Upload,
   x: X,

--- a/src/components/ui/popover.stories.tsx
+++ b/src/components/ui/popover.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { Button } from './button';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+
+const meta = {
+  title: 'UI/Popover',
+  component: Popover,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm">
+          Open popover
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent side="top" align="center" className="p-3 text-sm">
+        <p>Inside the popover</p>
+      </PopoverContent>
+    </Popover>
+  ),
+} satisfies Meta<typeof Popover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Open popover' });
+    await userEvent.click(trigger);
+    await waitFor(async () => {
+      const body = within(document.body);
+      await expect(body.getByText('Inside the popover')).toBeInTheDocument();
+    });
+  },
+};
+
+export const ClosesOnEscape: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Open popover' });
+    await userEvent.click(trigger);
+    const body = within(document.body);
+    await waitFor(async () => {
+      await expect(body.getByText('Inside the popover')).toBeInTheDocument();
+    });
+    await userEvent.keyboard('{Escape}');
+    await waitFor(async () => {
+      await expect(body.queryByText('Inside the popover')).not.toBeInTheDocument();
+    });
+  },
+};

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,52 @@
+import * as RadixPopover from '@radix-ui/react-popover';
+import { forwardRef, type ComponentPropsWithoutRef, type ReactNode } from 'react';
+import { tv } from 'tailwind-variants';
+
+const contentRecipe = tv({
+  base: [
+    'bg-popover text-popover-foreground shadow-lg',
+    'rounded-lg border border-border',
+    'z-50 overflow-hidden',
+    'focus:outline-none',
+  ],
+});
+
+/**
+ * Root provider — same API as `@radix-ui/react-popover`'s `Root`. Wraps
+ * the trigger and the content in a controlled or uncontrolled open
+ * state.
+ */
+export const Popover = RadixPopover.Root;
+
+/**
+ * Trigger — wrap your button to open/close the popover. Use `asChild`
+ * so the underlying Button (or other element) receives the click +
+ * keyboard handlers and refs.
+ */
+export const PopoverTrigger = RadixPopover.Trigger;
+
+/**
+ * Floating panel anchored to the trigger. Defaults: `side="top"`,
+ * `align="end"`, `sideOffset=6`. Override per call when needed.
+ *
+ * The panel renders inside a portal, traps Tab navigation, closes on
+ * Escape and on outside click. All ARIA wiring is handled by Radix.
+ */
+export const PopoverContent = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<typeof RadixPopover.Content> & { children: ReactNode }
+>(function PopoverContent({ className, children, sideOffset = 6, ...props }, ref) {
+  return (
+    <RadixPopover.Portal>
+      <RadixPopover.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={contentRecipe({ className })}
+        {...props}
+      >
+        {children}
+      </RadixPopover.Content>
+    </RadixPopover.Portal>
+  );
+});
+PopoverContent.displayName = 'PopoverContent';

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -26,8 +26,10 @@ export const Popover = RadixPopover.Root;
 export const PopoverTrigger = RadixPopover.Trigger;
 
 /**
- * Floating panel anchored to the trigger. Defaults: `side="top"`,
- * `align="end"`, `sideOffset=6`. Override per call when needed.
+ * Floating panel anchored to the trigger. Only `sideOffset` is
+ * defaulted to `6`; `side` and `align` are not set by this wrapper
+ * and fall through to Radix's own defaults (`"bottom"` / `"center"`).
+ * Override per call when needed.
  *
  * The panel renders inside a portal, traps Tab navigation, closes on
  * Escape and on outside click. All ARIA wiring is handled by Radix.

--- a/src/hooks/useApplyAppPreferences.ts
+++ b/src/hooks/useApplyAppPreferences.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+import { useAppStore } from '$/store/app-store';
+
+/**
+ * Subscribes to user-facing app preferences (theme today; future
+ * settings can be added here) and applies them to the document.
+ *
+ * Theme: when set to `light` or `dark`, the matching class is applied
+ * to `<html>` (and the other one removed). When set to `system`, both
+ * classes are removed and the CSS `@media (prefers-color-scheme:
+ * dark)` rule in `app.css` takes over.
+ *
+ * Call once near the root of the React tree (see `__root.tsx`).
+ */
+export function useApplyAppPreferences(): void {
+  const theme = useAppStore((state) => state.theme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    if (theme === 'light') root.classList.add('light');
+    else if (theme === 'dark') root.classList.add('dark');
+  }, [theme]);
+}

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -2,6 +2,9 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
+export const SUPPORTED_LANGUAGES = ['en', 'fr'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
 import enCommon from './locales/en/common.json';
 import enTrees from './locales/en/trees.json';
 import enIndividuals from './locales/en/individuals.json';

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -16,7 +16,7 @@
     "generic": "Something went wrong",
     "loadFailed": "Failed to load data.",
     "reload": "Reload",
-    "failedToOpenDatabase": "Failed to open database",
+    "failedToOpenDatabase": "Failed to open database.",
     "importFailed": "GEDCOM import failed."
   },
   "statusBar": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -16,7 +16,8 @@
     "generic": "Something went wrong",
     "loadFailed": "Failed to load data.",
     "reload": "Reload",
-    "failedToOpenDatabase": "Failed to open database"
+    "failedToOpenDatabase": "Failed to open database",
+    "importFailed": "GEDCOM import failed."
   },
   "statusBar": {
     "debug": "Debug",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -21,5 +21,17 @@
   "statusBar": {
     "debug": "Debug",
     "preferences": "Preferences"
+  },
+  "preferences": {
+    "title": "Preferences",
+    "themeLabel": "Theme",
+    "themeLight": "Light",
+    "themeDark": "Dark",
+    "themeSystem": "System",
+    "themeAriaLabel": "Choose theme",
+    "languageLabel": "Language",
+    "languageEn": "English",
+    "languageFr": "Français",
+    "languageAriaLabel": "Choose language"
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -17,5 +17,9 @@
     "loadFailed": "Failed to load data.",
     "reload": "Reload",
     "failedToOpenDatabase": "Failed to open database"
+  },
+  "statusBar": {
+    "debug": "Debug",
+    "preferences": "Preferences"
   }
 }

--- a/src/i18n/locales/en/trees.json
+++ b/src/i18n/locales/en/trees.json
@@ -7,5 +7,34 @@
   "openingDb": "Opening database...",
   "newTree": "New tree",
   "search": "Search trees",
-  "searchPlaceholder": "Filter by name"
+  "searchPlaceholder": "Filter by name",
+  "home": {
+    "title": "Your",
+    "titleAccent": "family trees",
+    "heroNew": "New tree",
+    "heroImport": "Import GEDCOM",
+    "sectionLabel": "Your trees",
+    "sortAriaLabel": "Sort trees",
+    "sortRecent": "Recent",
+    "sortName": "Name",
+    "sortSize": "Size"
+  },
+  "card": {
+    "open": "Open",
+    "export": "Export",
+    "edit": "Rename",
+    "delete": "Delete",
+    "individuals": "Individuals",
+    "families": "Families",
+    "generations": "Generations",
+    "createdAt": "Created",
+    "lastAccessedAt": "Last opened"
+  },
+  "cta": {
+    "title": "Start a new tree",
+    "subtitle": "Or drop a .ged file"
+  },
+  "actions": {
+    "comingSoon": "Coming soon."
+  }
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -17,5 +17,9 @@
     "loadFailed": "Échec du chargement des données.",
     "reload": "Recharger",
     "failedToOpenDatabase": "Échec de l'ouverture de la base de données"
+  },
+  "statusBar": {
+    "debug": "Débogage",
+    "preferences": "Préférences"
   }
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -16,7 +16,7 @@
     "generic": "Une erreur est survenue",
     "loadFailed": "Échec du chargement des données.",
     "reload": "Recharger",
-    "failedToOpenDatabase": "Échec de l'ouverture de la base de données",
+    "failedToOpenDatabase": "Échec de l'ouverture de la base de données.",
     "importFailed": "Échec de l'import GEDCOM."
   },
   "statusBar": {

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -21,5 +21,17 @@
   "statusBar": {
     "debug": "Débogage",
     "preferences": "Préférences"
+  },
+  "preferences": {
+    "title": "Préférences",
+    "themeLabel": "Thème",
+    "themeLight": "Clair",
+    "themeDark": "Sombre",
+    "themeSystem": "Système",
+    "themeAriaLabel": "Choisir le thème",
+    "languageLabel": "Langue",
+    "languageEn": "English",
+    "languageFr": "Français",
+    "languageAriaLabel": "Choisir la langue"
   }
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -16,7 +16,8 @@
     "generic": "Une erreur est survenue",
     "loadFailed": "Échec du chargement des données.",
     "reload": "Recharger",
-    "failedToOpenDatabase": "Échec de l'ouverture de la base de données"
+    "failedToOpenDatabase": "Échec de l'ouverture de la base de données",
+    "importFailed": "Échec de l'import GEDCOM."
   },
   "statusBar": {
     "debug": "Débogage",

--- a/src/i18n/locales/fr/trees.json
+++ b/src/i18n/locales/fr/trees.json
@@ -7,5 +7,34 @@
   "openingDb": "Ouverture de la base de données...",
   "newTree": "Nouvel arbre",
   "search": "Rechercher des arbres",
-  "searchPlaceholder": "Filtrer par nom"
+  "searchPlaceholder": "Filtrer par nom",
+  "home": {
+    "title": "Vos arbres",
+    "titleAccent": "généalogiques",
+    "heroNew": "Nouvel arbre",
+    "heroImport": "Importer GEDCOM",
+    "sectionLabel": "Vos arbres",
+    "sortAriaLabel": "Trier les arbres",
+    "sortRecent": "Récent",
+    "sortName": "Nom",
+    "sortSize": "Taille"
+  },
+  "card": {
+    "open": "Ouvrir",
+    "export": "Exporter",
+    "edit": "Renommer",
+    "delete": "Supprimer",
+    "individuals": "Individus",
+    "families": "Familles",
+    "generations": "Générations",
+    "createdAt": "Créé",
+    "lastAccessedAt": "Dernier accès"
+  },
+  "cta": {
+    "title": "Démarrer un nouvel arbre",
+    "subtitle": "Ou glissez-déposez un fichier .ged"
+  },
+  "actions": {
+    "comingSoon": "Bientôt."
+  }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import packageJson from '../../package.json';
 import { AppStatusBar } from '$components/app-status-bar';
+import { PreferencesPopover } from '$components/preferences-popover';
 import { TreeCard, type TreeCardLabels } from '$components/trees/tree-card';
 import { TreeCardCta } from '$components/trees/tree-card-cta';
 import { TreeSectionDivider } from '$components/trees/tree-section-divider';
@@ -175,9 +176,14 @@ export function HomePage(): JSX.Element {
         version={packageJson.version}
         debugLabel={t('common:statusBar.debug')}
         debugShortcut="⌘D"
-        preferencesLabel={t('common:statusBar.preferences')}
         onDebugClick={comingSoon}
-        onPreferencesClick={comingSoon}
+        preferencesTrigger={
+          <PreferencesPopover>
+            <Button variant="outline" size="sm" leadingIcon="settings" className="font-mono">
+              {t('common:statusBar.preferences')}
+            </Button>
+          </PreferencesPopover>
+        }
       />
     </div>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,6 +13,7 @@ import { Button } from '$components/ui/button';
 import { getAllTrees } from '$/db/system/trees';
 import { GedcomManager } from '$/managers/GedcomManager';
 import { TreeManager } from '$/managers/TreeManager';
+import { formatIsoDate } from '$lib/format';
 import { queryKeys } from '$lib/query-keys';
 import type { Tree } from '$/types/database';
 
@@ -32,11 +33,6 @@ function sortTrees(trees: Tree[], key: SortKey): Tree[] {
     });
   }
   return copy;
-}
-
-function formatIsoDate(value: string | null | undefined): string {
-  if (!value) return '—';
-  return value.slice(0, 10);
 }
 
 export function HomePage(): JSX.Element {
@@ -98,6 +94,56 @@ export function HomePage(): JSX.Element {
     }
   };
 
+  let treesContent: JSX.Element;
+  if (error) {
+    treesContent = <p className="text-muted-foreground">{t('common:errors.loadFailed')}</p>;
+  } else if (isLoading) {
+    treesContent = <p className="text-muted-foreground">{t('trees:loading')}</p>;
+  } else {
+    treesContent = (
+      <>
+        <div className="mt-9 mb-[18px]">
+          <TreeSectionDivider
+            label={t('trees:home.sectionLabel')}
+            count={sortedTrees.length}
+            sortOptions={sortOptions}
+            sortValue={sort}
+            onSortChange={(next) => setSort(next as SortKey)}
+            sortAriaLabel={t('trees:home.sortAriaLabel')}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-[18px] sm:grid-cols-2 lg:grid-cols-3">
+          {sortedTrees.map((tree) => (
+            <TreeCard
+              key={tree.id}
+              name={tree.name}
+              description={tree.description ?? undefined}
+              stats={{
+                individuals: tree.individualCount,
+                families: tree.familyCount,
+              }}
+              meta={{
+                createdAt: formatIsoDate(tree.createdAt),
+                lastAccessedAt: formatIsoDate(tree.lastOpenedAt),
+              }}
+              labels={cardLabels}
+              onOpen={() => void handleOpen(tree.id)}
+              onExport={comingSoon}
+              onEdit={comingSoon}
+              onDelete={comingSoon}
+            />
+          ))}
+          <TreeCardCta
+            title={t('trees:cta.title')}
+            subtitle={t('trees:cta.subtitle')}
+            onClick={comingSoon}
+          />
+        </div>
+      </>
+    );
+  }
+
   return (
     <div className="bg-background flex h-screen flex-col">
       <div className="flex-1 overflow-auto">
@@ -122,52 +168,7 @@ export function HomePage(): JSX.Element {
             </div>
           </section>
 
-          {error ? (
-            <p className="text-muted-foreground">{t('common:errors.loadFailed')}</p>
-          ) : isLoading ? (
-            <p className="text-muted-foreground">{t('trees:loading')}</p>
-          ) : (
-            <>
-              <div className="mt-9 mb-[18px]">
-                <TreeSectionDivider
-                  label={t('trees:home.sectionLabel')}
-                  count={sortedTrees.length}
-                  sortOptions={sortOptions}
-                  sortValue={sort}
-                  onSortChange={(next) => setSort(next as SortKey)}
-                  sortAriaLabel={t('trees:home.sortAriaLabel')}
-                />
-              </div>
-
-              <div className="grid grid-cols-1 gap-[18px] sm:grid-cols-2 lg:grid-cols-3">
-                {sortedTrees.map((tree) => (
-                  <TreeCard
-                    key={tree.id}
-                    name={tree.name}
-                    description={tree.description ?? undefined}
-                    stats={{
-                      individuals: tree.individualCount,
-                      families: tree.familyCount,
-                    }}
-                    meta={{
-                      createdAt: formatIsoDate(tree.createdAt),
-                      lastAccessedAt: formatIsoDate(tree.lastOpenedAt),
-                    }}
-                    labels={cardLabels}
-                    onOpen={() => void handleOpen(tree.id)}
-                    onExport={comingSoon}
-                    onEdit={comingSoon}
-                    onDelete={comingSoon}
-                  />
-                ))}
-                <TreeCardCta
-                  title={t('trees:cta.title')}
-                  subtitle={t('trees:cta.subtitle')}
-                  onClick={comingSoon}
-                />
-              </div>
-            </>
-          )}
+          {treesContent}
         </div>
       </div>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,13 +1,47 @@
-import { useQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getAllTrees } from '$/db/system/trees';
+
+import { TreeCard, type TreeCardLabels } from '$components/trees/tree-card';
+import { TreeCardCta } from '$components/trees/tree-card-cta';
+import { TreeSectionDivider } from '$components/trees/tree-section-divider';
 import { Button } from '$components/ui/button';
-import { Input } from '$components/ui/input';
+import { getAllTrees } from '$/db/system/trees';
+import { GedcomManager } from '$/managers/GedcomManager';
+import { TreeManager } from '$/managers/TreeManager';
 import { queryKeys } from '$lib/query-keys';
+import type { Tree } from '$/types/database';
+
+type SortKey = 'recent' | 'name' | 'size';
+
+function sortTrees(trees: Tree[], key: SortKey): Tree[] {
+  const copy = [...trees];
+  if (key === 'name') {
+    copy.sort((a, b) => a.name.localeCompare(b.name));
+  } else if (key === 'size') {
+    copy.sort((a, b) => b.individualCount - a.individualCount);
+  } else {
+    copy.sort((a, b) => {
+      const aTime = a.lastOpenedAt ?? a.createdAt;
+      const bTime = b.lastOpenedAt ?? b.createdAt;
+      return bTime.localeCompare(aTime);
+    });
+  }
+  return copy;
+}
+
+function formatIsoDate(value: string | null | undefined): string {
+  if (!value) return '—';
+  return value.slice(0, 10);
+}
 
 export function HomePage(): JSX.Element {
   const { t } = useTranslation(['common', 'trees']);
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [sort, setSort] = useState<SortKey>('recent');
+
   const {
     data: trees,
     isLoading,
@@ -17,38 +51,120 @@ export function HomePage(): JSX.Element {
     queryFn: getAllTrees,
   });
 
-  if (isLoading) return <p>{t('trees:loading')}</p>;
-  if (error) {
-    console.error('Failed to load trees:', error);
-    return <p>{t('common:errors.loadFailed')}</p>;
-  }
+  const importMutation = useMutation({
+    mutationFn: () => GedcomManager.importFromFile(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.trees });
+    },
+    onError: (err) => {
+      console.error('GEDCOM import failed:', err);
+    },
+  });
+
+  const sortedTrees = useMemo<Tree[]>(() => (trees ? sortTrees(trees, sort) : []), [trees, sort]);
+
+  const cardLabels: TreeCardLabels = {
+    open: t('trees:card.open'),
+    export: t('trees:card.export'),
+    edit: t('trees:card.edit'),
+    delete: t('trees:card.delete'),
+    individuals: t('trees:card.individuals'),
+    families: t('trees:card.families'),
+    generations: t('trees:card.generations'),
+    createdAt: t('trees:card.createdAt'),
+    lastAccessedAt: t('trees:card.lastAccessedAt'),
+  };
+
+  const sortOptions = [
+    { value: 'recent', label: t('trees:home.sortRecent') },
+    { value: 'name', label: t('trees:home.sortName') },
+    { value: 'size', label: t('trees:home.sortSize') },
+  ];
+
+  const comingSoon = (): void => {
+    window.alert(t('trees:actions.comingSoon'));
+  };
+
+  const handleOpen = async (treeId: string): Promise<void> => {
+    try {
+      await TreeManager.open(treeId);
+      void navigate({ to: '/tree/$treeId', params: { treeId } });
+    } catch (err) {
+      console.error('Failed to open tree:', err);
+      window.alert(t('common:errors.failedToOpenDatabase'));
+    }
+  };
 
   return (
-    <div>
-      <h1>{t('common:app.title')}</h1>
-      <div>
-        <Input
-          type="search"
-          aria-label={t('trees:search')}
-          placeholder={t('trees:searchPlaceholder')}
-        />
-        <Button>{t('trees:newTree')}</Button>
+    <div className="bg-background min-h-full">
+      <div className="mx-auto max-w-[1080px] px-14 pt-14 pb-10">
+        <section className="mb-9 flex flex-col gap-1.5">
+          <h1 className="text-foreground font-serif text-[56px] leading-none font-medium tracking-tight italic">
+            {t('trees:home.title')}{' '}
+            <span className="text-primary italic">{t('trees:home.titleAccent')}</span>
+          </h1>
+          <div className="mt-5 flex items-center gap-2.5">
+            <Button leadingIcon="plus" onClick={comingSoon}>
+              {t('trees:home.heroNew')}
+            </Button>
+            <Button
+              variant="outline"
+              leadingIcon="download"
+              onClick={() => importMutation.mutate()}
+              disabled={importMutation.isPending}
+            >
+              {t('trees:home.heroImport')}
+            </Button>
+          </div>
+        </section>
+
+        {error ? (
+          <p className="text-muted-foreground">{t('common:errors.loadFailed')}</p>
+        ) : isLoading ? (
+          <p className="text-muted-foreground">{t('trees:loading')}</p>
+        ) : (
+          <>
+            <div className="mt-9 mb-[18px]">
+              <TreeSectionDivider
+                label={t('trees:home.sectionLabel')}
+                count={sortedTrees.length}
+                sortOptions={sortOptions}
+                sortValue={sort}
+                onSortChange={(next) => setSort(next as SortKey)}
+                sortAriaLabel={t('trees:home.sortAriaLabel')}
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-[18px] sm:grid-cols-2 lg:grid-cols-3">
+              {sortedTrees.map((tree) => (
+                <TreeCard
+                  key={tree.id}
+                  name={tree.name}
+                  description={tree.description ?? undefined}
+                  stats={{
+                    individuals: tree.individualCount,
+                    families: tree.familyCount,
+                  }}
+                  meta={{
+                    createdAt: formatIsoDate(tree.createdAt),
+                    lastAccessedAt: formatIsoDate(tree.lastOpenedAt),
+                  }}
+                  labels={cardLabels}
+                  onOpen={() => void handleOpen(tree.id)}
+                  onExport={comingSoon}
+                  onEdit={comingSoon}
+                  onDelete={comingSoon}
+                />
+              ))}
+              <TreeCardCta
+                title={t('trees:cta.title')}
+                subtitle={t('trees:cta.subtitle')}
+                onClick={comingSoon}
+              />
+            </div>
+          </>
+        )}
       </div>
-      {!trees || trees.length === 0 ? (
-        <p>{t('trees:empty')}</p>
-      ) : (
-        <ul>
-          {trees.map((tree) => (
-            <li key={tree.id}>
-              <Link to="/tree/$treeId" params={{ treeId: tree.id }}>
-                {tree.name}
-              </Link>
-              {' — '}
-              <span>{tree.path}</span>
-            </li>
-          ))}
-        </ul>
-      )}
     </div>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,7 +10,7 @@ import { TreeCard, type TreeCardLabels } from '$components/trees/tree-card';
 import { TreeCardCta } from '$components/trees/tree-card-cta';
 import { TreeSectionDivider } from '$components/trees/tree-section-divider';
 import { Button } from '$components/ui/button';
-import { getAllTrees } from '$/db/system/trees';
+import { getAllTrees } from '$db-system/trees';
 import { GedcomManager } from '$/managers/GedcomManager';
 import { TreeManager } from '$/managers/TreeManager';
 import { formatIsoDate } from '$lib/format';
@@ -40,6 +40,7 @@ export function HomePage(): JSX.Element {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [sort, setSort] = useState<SortKey>('recent');
+  const [importError, setImportError] = useState<string | null>(null);
 
   const {
     data: trees,
@@ -53,10 +54,12 @@ export function HomePage(): JSX.Element {
   const importMutation = useMutation({
     mutationFn: () => GedcomManager.importFromFile(),
     onSuccess: () => {
+      setImportError(null);
       void queryClient.invalidateQueries({ queryKey: queryKeys.trees });
     },
     onError: (err) => {
       console.error('GEDCOM import failed:', err);
+      setImportError(err instanceof Error ? err.message : t('common:errors.importFailed'));
     },
   });
 
@@ -166,6 +169,11 @@ export function HomePage(): JSX.Element {
                 {t('trees:home.heroImport')}
               </Button>
             </div>
+            {importError && (
+              <p role="alert" className="text-destructive mt-2 text-sm">
+                {importError}
+              </p>
+            )}
           </section>
 
           {treesContent}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from '@tanstack/react-router';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import packageJson from '../../package.json';
+import { AppStatusBar } from '$components/app-status-bar';
 import { TreeCard, type TreeCardLabels } from '$components/trees/tree-card';
 import { TreeCardCta } from '$components/trees/tree-card-cta';
 import { TreeSectionDivider } from '$components/trees/tree-section-divider';
@@ -96,75 +98,87 @@ export function HomePage(): JSX.Element {
   };
 
   return (
-    <div className="bg-background min-h-full">
-      <div className="mx-auto max-w-[1080px] px-14 pt-14 pb-10">
-        <section className="mb-9 flex flex-col gap-1.5">
-          <h1 className="text-foreground font-serif text-[56px] leading-none font-medium tracking-tight italic">
-            {t('trees:home.title')}{' '}
-            <span className="text-primary italic">{t('trees:home.titleAccent')}</span>
-          </h1>
-          <div className="mt-5 flex items-center gap-2.5">
-            <Button leadingIcon="plus" onClick={comingSoon}>
-              {t('trees:home.heroNew')}
-            </Button>
-            <Button
-              variant="outline"
-              leadingIcon="download"
-              onClick={() => importMutation.mutate()}
-              disabled={importMutation.isPending}
-            >
-              {t('trees:home.heroImport')}
-            </Button>
-          </div>
-        </section>
-
-        {error ? (
-          <p className="text-muted-foreground">{t('common:errors.loadFailed')}</p>
-        ) : isLoading ? (
-          <p className="text-muted-foreground">{t('trees:loading')}</p>
-        ) : (
-          <>
-            <div className="mt-9 mb-[18px]">
-              <TreeSectionDivider
-                label={t('trees:home.sectionLabel')}
-                count={sortedTrees.length}
-                sortOptions={sortOptions}
-                sortValue={sort}
-                onSortChange={(next) => setSort(next as SortKey)}
-                sortAriaLabel={t('trees:home.sortAriaLabel')}
-              />
+    <div className="bg-background flex h-screen flex-col">
+      <div className="flex-1 overflow-auto">
+        <div className="mx-auto max-w-[1080px] px-14 pt-14 pb-10">
+          <section className="mb-9 flex flex-col gap-1.5">
+            <h1 className="text-foreground font-serif text-[56px] leading-none font-medium tracking-tight italic">
+              {t('trees:home.title')}{' '}
+              <span className="text-primary italic">{t('trees:home.titleAccent')}</span>
+            </h1>
+            <div className="mt-5 flex items-center gap-2.5">
+              <Button leadingIcon="plus" onClick={comingSoon}>
+                {t('trees:home.heroNew')}
+              </Button>
+              <Button
+                variant="outline"
+                leadingIcon="download"
+                onClick={() => importMutation.mutate()}
+                disabled={importMutation.isPending}
+              >
+                {t('trees:home.heroImport')}
+              </Button>
             </div>
+          </section>
 
-            <div className="grid grid-cols-1 gap-[18px] sm:grid-cols-2 lg:grid-cols-3">
-              {sortedTrees.map((tree) => (
-                <TreeCard
-                  key={tree.id}
-                  name={tree.name}
-                  description={tree.description ?? undefined}
-                  stats={{
-                    individuals: tree.individualCount,
-                    families: tree.familyCount,
-                  }}
-                  meta={{
-                    createdAt: formatIsoDate(tree.createdAt),
-                    lastAccessedAt: formatIsoDate(tree.lastOpenedAt),
-                  }}
-                  labels={cardLabels}
-                  onOpen={() => void handleOpen(tree.id)}
-                  onExport={comingSoon}
-                  onEdit={comingSoon}
-                  onDelete={comingSoon}
+          {error ? (
+            <p className="text-muted-foreground">{t('common:errors.loadFailed')}</p>
+          ) : isLoading ? (
+            <p className="text-muted-foreground">{t('trees:loading')}</p>
+          ) : (
+            <>
+              <div className="mt-9 mb-[18px]">
+                <TreeSectionDivider
+                  label={t('trees:home.sectionLabel')}
+                  count={sortedTrees.length}
+                  sortOptions={sortOptions}
+                  sortValue={sort}
+                  onSortChange={(next) => setSort(next as SortKey)}
+                  sortAriaLabel={t('trees:home.sortAriaLabel')}
                 />
-              ))}
-              <TreeCardCta
-                title={t('trees:cta.title')}
-                subtitle={t('trees:cta.subtitle')}
-                onClick={comingSoon}
-              />
-            </div>
-          </>
-        )}
+              </div>
+
+              <div className="grid grid-cols-1 gap-[18px] sm:grid-cols-2 lg:grid-cols-3">
+                {sortedTrees.map((tree) => (
+                  <TreeCard
+                    key={tree.id}
+                    name={tree.name}
+                    description={tree.description ?? undefined}
+                    stats={{
+                      individuals: tree.individualCount,
+                      families: tree.familyCount,
+                    }}
+                    meta={{
+                      createdAt: formatIsoDate(tree.createdAt),
+                      lastAccessedAt: formatIsoDate(tree.lastOpenedAt),
+                    }}
+                    labels={cardLabels}
+                    onOpen={() => void handleOpen(tree.id)}
+                    onExport={comingSoon}
+                    onEdit={comingSoon}
+                    onDelete={comingSoon}
+                  />
+                ))}
+                <TreeCardCta
+                  title={t('trees:cta.title')}
+                  subtitle={t('trees:cta.subtitle')}
+                  onClick={comingSoon}
+                />
+              </div>
+            </>
+          )}
+        </div>
       </div>
+
+      <AppStatusBar
+        brandLabel={t('common:app.title')}
+        version={packageJson.version}
+        debugLabel={t('common:statusBar.debug')}
+        debugShortcut="⌘D"
+        preferencesLabel={t('common:statusBar.preferences')}
+        onDebugClick={comingSoon}
+        onPreferencesClick={comingSoon}
+      />
     </div>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -183,9 +183,11 @@ export function HomePage(): JSX.Element {
       <AppStatusBar
         brandLabel={t('common:app.title')}
         version={packageJson.version}
-        debugLabel={t('common:statusBar.debug')}
-        debugShortcut="⌘D"
-        onDebugClick={comingSoon}
+        debug={
+          import.meta.env.DEV
+            ? { label: t('common:statusBar.debug'), shortcut: '⌘D', onClick: comingSoon }
+            : undefined
+        }
         preferencesTrigger={
           <PreferencesPopover>
             <Button variant="outline" size="sm" leadingIcon="settings" className="font-mono">

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,6 +1,8 @@
 import { createRootRoute, Outlet, type ErrorComponentProps } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
+import { useApplyAppPreferences } from '$hooks/useApplyAppPreferences';
+
 function RootErrorComponent({ error }: ErrorComponentProps): JSX.Element {
   const { t } = useTranslation('common');
   return (
@@ -13,6 +15,7 @@ function RootErrorComponent({ error }: ErrorComponentProps): JSX.Element {
 }
 
 function RootComponent(): JSX.Element {
+  useApplyAppPreferences();
   return <Outlet />;
 }
 

--- a/src/store/app-store.test.ts
+++ b/src/store/app-store.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useAppStore } from './app-store';
 
 beforeEach(() => {
-  useAppStore.setState({ currentTreeId: null });
+  useAppStore.setState({ currentTreeId: null, theme: 'system' });
 });
 
 describe('app store — active tree', () => {
@@ -25,5 +25,18 @@ describe('app store — active tree', () => {
     useAppStore.getState().setCurrentTree('5');
     useAppStore.getState().setCurrentTree(null);
     expect(useAppStore.getState().currentTreeId).toBeNull();
+  });
+});
+
+describe('app store — theme', () => {
+  it("defaults to 'system'", () => {
+    expect(useAppStore.getState().theme).toBe('system');
+  });
+
+  it('updates when setTheme is called', () => {
+    useAppStore.getState().setTheme('dark');
+    expect(useAppStore.getState().theme).toBe('dark');
+    useAppStore.getState().setTheme('light');
+    expect(useAppStore.getState().theme).toBe('light');
   });
 });

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -1,11 +1,13 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+export type Theme = 'light' | 'dark' | 'system';
+
 interface AppState {
   currentTreeId: string | null;
   setCurrentTree: (id: string | null) => void;
-  language: string;
-  setLanguage: (language: string) => void;
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
 }
 
 export const useAppStore = create<AppState>()(
@@ -13,8 +15,8 @@ export const useAppStore = create<AppState>()(
     (set) => ({
       currentTreeId: null,
       setCurrentTree: (id) => set({ currentTreeId: id }),
-      language: 'en',
-      setLanguage: (language) => set({ language }),
+      theme: 'system',
+      setTheme: (theme) => set({ theme }),
     }),
     {
       name: 'vata-app-storage',


### PR DESCRIPTION
## Summary

Phase 1 of the new home / tree picker, based on the **Vata - Trees - Modals** Claude Design file.

- New visual layout: serif-italic hero (`Your *family trees*`), primary "New tree" + outline "Import GEDCOM" buttons, sortable section divider, 3-column responsive grid of redesigned `TreeCard`s + a dashed-border `TreeCardCta` tile.
- `TreeCard` rebuilt to match the design: serif italic title, inline stats with vrules, dashed-border meta block, footer actions (Open + 3 ghost icon buttons).
- New `AppStatusBar` pinned at the bottom (brand + version, Debug button with `⌘D` chip, Preferences trigger slot).
- Working `PreferencesPopover` (theme: light / dark / system; language: en / fr) backed by Zustand (theme) and i18next (language). FOUC-safe via a pre-paint script in `index.html`.

## What is wired vs stubbed

| Action                              | Status                                                       |
| ----------------------------------- | ------------------------------------------------------------ |
| Open a tree                         | ✅ `TreeManager.open` + router push                          |
| Import GEDCOM                       | ✅ existing `GedcomManager.importFromFile`                   |
| Theme + Language switch             | ✅ persisted, applied live                                   |
| New tree / Edit / Delete / Export   | ⏳ surface a "Coming soon" alert until the modals land       |
| Debug                               | ⏳ "Coming soon" alert                                        |

## What's missing (follow-up PRs)

1. Five modals from the design (NewTree, ImportGedcom, Edit, Download, Delete).
2. Path picker + "Depuis moi" pre-population for tree creation.
3. GEDCOM scan/preview before import.
4. Generations stat (no DB counter today).
5. Sources/Médias counters in the Delete modal (tables absent).
6. Extended download options (sources/private toggles, format alternatives, GEDCOM 7.0).

## DS additions

- New UI wrapper: Popover (Radix).
- New domain wrappers: TreeSectionDivider, TreeCardCta (split from tree-card.tsx), AppStatusBar, PreferencesPopover.
- Icon registry: bug, settings.
- All wrappers ship with colocated *.stories.tsx + play() tests.

## Test plan

- [x] pnpm build (Vite + tsc) clean
- [x] pnpm lint clean
- [x] pnpm vitest run — 644 tests pass (incl. new story play tests)
- [x] Manual check in pnpm tauri:dev:
  - [x] grid renders correctly with real trees + CTA tile
  - [x] sort segments (Recent / Name / Size) reorder live
  - [x] Import GEDCOM opens file dialog and the new tree appears in the grid after invalidate
  - [x] Open navigates to /tree/\$treeId
  - [x] Preferences popover opens above the button, anchored right
  - [x] Theme switch toggles \<html\> class instantly; reload preserves the choice (no FOUC thanks to pre-paint script)
  - [x] Language switch swaps every UI string; reload preserves the choice
  - [ ] Reviewer manual check: light/dark theme parity for each card state

## Pre-PR review

Ran /simplify (3-agent reuse / quality / efficiency review) and applied the real fixes:

- Reuse existing formatIsoDate from \$lib/format instead of a local copy
- Flatten the loading/error/grid ternary into an if/else cascade
- Derive SupportedLanguage from src/i18n/config.ts instead of duplicating the union locally
- Pre-paint script for theme to avoid FOUC

Skipped (deemed nits or premature): generic SegmentedControl<T> plumbing, comingSoon overload (will be replaced by real modals), JSDoc trims, JSX wrapper consolidation around StatGrid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)