### PR TITLE
feat(trees): NewTreeModal triggered from home page CTA

### DIFF
--- a/src/components/trees/new-tree-modal.stories.tsx
+++ b/src/components/trees/new-tree-modal.stories.tsx
@@ -1,0 +1,138 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEffect, useState, type ComponentProps, type ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import { Button } from '$components/ui/button';
+import { NewTreeModal } from './new-tree-modal';
+
+type ModalArgs = ComponentProps<typeof NewTreeModal>;
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function QueryWrapper({ children }: { children: ReactNode }): JSX.Element {
+  const [client] = useState(makeQueryClient);
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function ModalHarness({ open: argOpen, onOpenChange, ...props }: ModalArgs): JSX.Element {
+  const [open, setOpen] = useState(Boolean(argOpen));
+  useEffect(() => {
+    setOpen(Boolean(argOpen));
+  }, [argOpen]);
+
+  return (
+    <QueryWrapper>
+      <Button onClick={() => setOpen(true)}>Open new-tree modal</Button>
+      <NewTreeModal
+        {...props}
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          onOpenChange?.(next);
+        }}
+      />
+    </QueryWrapper>
+  );
+}
+
+const meta: Meta<ModalArgs> = {
+  title: 'Trees/NewTreeModal',
+  component: NewTreeModal,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    a11y: {
+      // Radix focus-trap sentinels confuse axe's aria-hidden-focus rule
+      // — same exemption as the Dialog stories.
+      config: { rules: [{ id: 'aria-hidden-focus', enabled: false }] },
+    },
+  },
+  args: {
+    open: false,
+    onOpenChange: fn(),
+    onCreated: fn(),
+  },
+  render: (args) => <ModalHarness {...args} />,
+};
+
+export default meta;
+type Story = StoryObj<ModalArgs>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open new-tree modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    const dialog = await body.findByRole('dialog');
+    await expect(dialog).toBeInTheDocument();
+    await expect(dialog).toHaveAccessibleName('Start a new tree');
+
+    const radios = await body.findAllByRole('radio');
+    await expect(radios).toHaveLength(2);
+    const fromMe = await body.findByRole('radio', { name: /Tree from me/ });
+    await expect(fromMe).toHaveAttribute('aria-disabled', 'true');
+  },
+};
+
+export const SubmitDisabledWithEmptyName: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open new-tree modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    const submit = await body.findByRole('button', { name: 'Create tree' });
+    await expect(submit).toBeDisabled();
+  },
+};
+
+export const SubmitCreatesTree: Story = {
+  args: {
+    createTree: fn(async () => 'tree-42'),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open new-tree modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+
+    const nameInput = await body.findByLabelText('Name');
+    await userEvent.type(nameInput, 'Bourgoin family');
+
+    const descriptionInput = await body.findByLabelText(/Description/);
+    await userEvent.type(descriptionInput, "Started from grandpa's notebook");
+
+    await userEvent.click(body.getByRole('button', { name: 'Create tree' }));
+
+    await waitFor(() => {
+      expect(args.createTree).toHaveBeenCalledWith({
+        name: 'Bourgoin family',
+        description: "Started from grandpa's notebook",
+      });
+    });
+    await waitFor(() => expect(args.onCreated).toHaveBeenCalledWith('tree-42'));
+    await waitFor(() => expect(args.onOpenChange).toHaveBeenCalledWith(false));
+  },
+};
+
+export const CancelClosesWithoutCreating: Story = {
+  args: {
+    createTree: fn(async () => 'never'),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open new-tree modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    const cancel = await body.findByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancel);
+
+    await waitFor(() => expect(args.onOpenChange).toHaveBeenCalledWith(false));
+    expect(args.createTree).not.toHaveBeenCalled();
+  },
+};

--- a/src/components/trees/new-tree-modal.stories.tsx
+++ b/src/components/trees/new-tree-modal.stories.tsx
@@ -76,7 +76,7 @@ export const Default: Story = {
     const radios = await body.findAllByRole('radio');
     await expect(radios).toHaveLength(2);
     const fromMe = await body.findByRole('radio', { name: /Tree from me/ });
-    await expect(fromMe).toHaveAttribute('aria-disabled', 'true');
+    await expect(fromMe).toBeDisabled();
   },
 };
 

--- a/src/components/trees/new-tree-modal.tsx
+++ b/src/components/trees/new-tree-modal.tsx
@@ -59,13 +59,6 @@ export function NewTreeModal({
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
 
-  useEffect(() => {
-    if (!open) {
-      setName('');
-      setDescription('');
-    }
-  }, [open]);
-
   const mutation = useMutation({
     mutationFn: (input: CreateTreeInput) => createTree(input),
     onSuccess: async (treeId) => {
@@ -80,6 +73,13 @@ export function NewTreeModal({
     },
   });
 
+  useEffect(() => {
+    if (!open) {
+      setName('');
+      setDescription('');
+    }
+  }, [open]);
+
   const trimmedName = name.trim();
   const canSubmit = trimmedName.length > 0 && !mutation.isPending;
 
@@ -92,12 +92,21 @@ export function NewTreeModal({
     });
   };
 
+  const closeModal = (): void => {
+    if (mutation.isPending) return;
+    mutation.reset();
+    onOpenChange(false);
+  };
+
   return (
     <Dialog
       open={open}
       onOpenChange={(next) => {
-        if (!next && mutation.isPending) return;
-        onOpenChange(next);
+        if (next) {
+          onOpenChange(true);
+          return;
+        }
+        closeModal();
       }}
       size="md"
       title={<span className="font-serif italic">{t('newTree.title')}</span>}
@@ -105,7 +114,7 @@ export function NewTreeModal({
       closeLabel={t('newTree.closeLabel')}
       footer={
         <>
-          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={mutation.isPending}>
+          <Button variant="ghost" onClick={closeModal} disabled={mutation.isPending}>
             {t('newTree.cancel')}
           </Button>
           <Button type="submit" form={formId} disabled={!canSubmit}>

--- a/src/components/trees/new-tree-modal.tsx
+++ b/src/components/trees/new-tree-modal.tsx
@@ -1,0 +1,182 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '$components/ui/button';
+import { Dialog } from '$components/ui/dialog';
+import { Input } from '$components/ui/input';
+import { OptionCard, OptionCardGroup } from '$components/ui/option-card';
+import { Textarea } from '$components/ui/textarea';
+import { TreeManager } from '$/managers/TreeManager';
+import { queryKeys } from '$lib/query-keys';
+
+interface CreateTreeInput {
+  name: string;
+  description?: string;
+}
+
+/**
+ * Props accepted by {@link NewTreeModal}.
+ */
+export interface NewTreeModalProps {
+  /** Whether the modal is open. Controlled by the parent. */
+  open: boolean;
+
+  /** Called when the modal should open or close. */
+  onOpenChange: (open: boolean) => void;
+
+  /** Called with the new tree's id after a successful creation. */
+  onCreated?: (treeId: string) => void;
+
+  /**
+   * Override the create function. Defaults to {@link TreeManager.create}.
+   * Tests/stories inject a spy here so the flow can be exercised without
+   * hitting Tauri SQL.
+   */
+  createTree?: (input: CreateTreeInput) => Promise<string>;
+}
+
+const defaultCreateTree = (input: CreateTreeInput): Promise<string> => TreeManager.create(input);
+
+/**
+ * Form host for creating a blank tree. Calls `TreeManager.create` and
+ * invalidates the `trees` query on success. The "From me" starting
+ * point renders a `Soon` badge and is disabled until pre-population
+ * lands.
+ */
+export function NewTreeModal({
+  open,
+  onOpenChange,
+  onCreated,
+  createTree = defaultCreateTree,
+}: NewTreeModalProps): JSX.Element {
+  const { t } = useTranslation('trees');
+  const queryClient = useQueryClient();
+  const formId = useId();
+  const nameId = useId();
+  const descriptionId = useId();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    if (!open) {
+      setName('');
+      setDescription('');
+    }
+  }, [open]);
+
+  const mutation = useMutation({
+    mutationFn: (input: CreateTreeInput) => createTree(input),
+    onSuccess: async (treeId) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.trees });
+      onCreated?.(treeId);
+      onOpenChange(false);
+    },
+    onError: (err) => {
+      // Raw DB/Tauri errors are not translated — log them, surface a
+      // generic localized message in the UI instead.
+      console.error('Failed to create tree:', err);
+    },
+  });
+
+  const trimmedName = name.trim();
+  const canSubmit = trimmedName.length > 0 && !mutation.isPending;
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    mutation.mutate({
+      name: trimmedName,
+      description: description.trim() || undefined,
+    });
+  };
+  mutation.error instanceof Error ? mutation.error.message : t('newTree.errorGeneric');
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && mutation.isPending) return;
+        onOpenChange(next);
+      }}
+      size="md"
+      title={<span className="font-serif italic">{t('newTree.title')}</span>}
+      description={t('newTree.subtitle')}
+      closeLabel={t('newTree.closeLabel')}
+      footer={
+        <>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={mutation.isPending}>
+            {t('newTree.cancel')}
+          </Button>
+          <Button type="submit" form={formId} disabled={!canSubmit}>
+            {t('newTree.submit')}
+          </Button>
+        </>
+      }
+    >
+      <form id={formId} onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor={nameId} className="text-foreground text-sm font-medium">
+            {t('newTree.nameLabel')}
+          </label>
+          <Input
+            id={nameId}
+            required
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder={t('newTree.namePlaceholder')}
+            disabled={mutation.isPending}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor={descriptionId} className="text-foreground text-sm font-medium">
+            {t('newTree.descriptionLabel')}{' '}
+            <span className="text-muted-foreground font-normal">
+              ({t('newTree.descriptionOptional')})
+            </span>
+          </label>
+          <Textarea
+            id={descriptionId}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder={t('newTree.descriptionPlaceholder')}
+            disabled={mutation.isPending}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <span className="text-foreground text-sm font-medium">
+            {t('newTree.startingPointLabel')}
+          </span>
+          <OptionCardGroup
+            value="blank"
+            onValueChange={() => undefined}
+            aria-label={t('newTree.startingPointLabel')}
+            cols={2}
+          >
+            <OptionCard
+              value="blank"
+              label={t('newTree.blankLabel')}
+              description={t('newTree.blankDescription')}
+            />
+            <OptionCard
+              value="from-me"
+              label={t('newTree.fromMeLabel')}
+              description={t('newTree.fromMeDescription')}
+              soon
+              soonLabel={t('newTree.soonLabel')}
+            />
+          </OptionCardGroup>
+        </div>
+
+        {mutation.isError && (
+          <p role="alert" className="text-destructive text-sm">
+            {t('newTree.errorGeneric')}
+          </p>
+        )}
+      </form>
+    </Dialog>
+  );
+}

--- a/src/components/trees/new-tree-modal.tsx
+++ b/src/components/trees/new-tree-modal.tsx
@@ -91,7 +91,6 @@ export function NewTreeModal({
       description: description.trim() || undefined,
     });
   };
-  mutation.error instanceof Error ? mutation.error.message : t('newTree.errorGeneric');
 
   return (
     <Dialog

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -137,7 +137,7 @@ export function Dialog({
   return (
     <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
       <RadixDialog.Portal>
-        <RadixDialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+        <RadixDialog.Overlay className="fixed inset-0 z-40 bg-overlay/60 backdrop-blur-sm" />
         <RadixDialog.Content
           className={dialogContentRecipe({ size })}
           // Only override Radix's auto-wiring when there is no Description

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -137,7 +137,7 @@ export function Dialog({
   return (
     <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
       <RadixDialog.Portal>
-        <RadixDialog.Overlay className="fixed inset-0 z-40 bg-foreground/40 backdrop-blur-sm" />
+        <RadixDialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
         <RadixDialog.Content
           className={dialogContentRecipe({ size })}
           // Only override Radix's auto-wiring when there is no Description

--- a/src/db/system/trees.ts
+++ b/src/db/system/trees.ts
@@ -49,11 +49,11 @@ export async function getTreeById(id: string): Promise<Tree | null> {
 
 export async function treeExistsAtPath(path: string): Promise<boolean> {
   const db = await getSystemDb();
-  const rows = await db.select<{ count: number }[]>(
-    `SELECT COUNT(*) AS count FROM trees WHERE path = $1`,
+  const rows = await db.select<{ exists_flag: number }[]>(
+    `SELECT EXISTS(SELECT 1 FROM trees WHERE path = $1) AS exists_flag`,
     [path]
   );
-  return (rows[0]?.count ?? 0) > 0;
+  return rows[0]?.exists_flag === 1;
 }
 
 export async function createTree(

--- a/src/db/system/trees.ts
+++ b/src/db/system/trees.ts
@@ -47,6 +47,15 @@ export async function getTreeById(id: string): Promise<Tree | null> {
   return rows[0] ? mapToTree(rows[0]) : null;
 }
 
+export async function treeExistsAtPath(path: string): Promise<boolean> {
+  const db = await getSystemDb();
+  const rows = await db.select<{ count: number }[]>(
+    `SELECT COUNT(*) AS count FROM trees WHERE path = $1`,
+    [path]
+  );
+  return (rows[0]?.count ?? 0) > 0;
+}
+
 export async function createTree(
   data: { name: string; path: string; description?: string },
   dbOverride?: Database

--- a/src/i18n/locales/en/trees.json
+++ b/src/i18n/locales/en/trees.json
@@ -5,7 +5,6 @@
   "loadingOne": "Loading tree...",
   "notFound": "Tree not found.",
   "openingDb": "Opening database...",
-  "newTree": "New tree",
   "search": "Search trees",
   "searchPlaceholder": "Filter by name",
   "home": {
@@ -33,6 +32,25 @@
   "cta": {
     "title": "Start a new tree",
     "subtitle": "Or drop a .ged file"
+  },
+  "newTree": {
+    "title": "Start a new tree",
+    "subtitle": "Give your tree a name and choose how to begin.",
+    "nameLabel": "Name",
+    "namePlaceholder": "e.g., Bourgoin family",
+    "descriptionLabel": "Description",
+    "descriptionOptional": "Optional",
+    "descriptionPlaceholder": "What is this tree about?",
+    "startingPointLabel": "Starting point",
+    "blankLabel": "Blank tree",
+    "blankDescription": "Start from a blank canvas — no individuals, no families.",
+    "fromMeLabel": "Tree from me",
+    "fromMeDescription": "Pre-fill with you as the starting individual.",
+    "soonLabel": "Soon",
+    "cancel": "Cancel",
+    "submit": "Create tree",
+    "closeLabel": "Close",
+    "errorGeneric": "Failed to create tree."
   },
   "actions": {
     "comingSoon": "Coming soon."

--- a/src/i18n/locales/fr/trees.json
+++ b/src/i18n/locales/fr/trees.json
@@ -5,7 +5,6 @@
   "loadingOne": "Chargement de l'arbre...",
   "notFound": "Arbre introuvable.",
   "openingDb": "Ouverture de la base de données...",
-  "newTree": "Nouvel arbre",
   "search": "Rechercher des arbres",
   "searchPlaceholder": "Filtrer par nom",
   "home": {
@@ -33,6 +32,25 @@
   "cta": {
     "title": "Démarrer un nouvel arbre",
     "subtitle": "Ou glissez-déposez un fichier .ged"
+  },
+  "newTree": {
+    "title": "Démarrer un nouvel arbre",
+    "subtitle": "Donnez un nom à votre arbre et choisissez un point de départ.",
+    "nameLabel": "Nom",
+    "namePlaceholder": "ex. Famille Bourgoin",
+    "descriptionLabel": "Description",
+    "descriptionOptional": "Optionnel",
+    "descriptionPlaceholder": "À propos de cet arbre",
+    "startingPointLabel": "Point de départ",
+    "blankLabel": "Arbre vide",
+    "blankDescription": "Partir d'une toile vierge — aucun individu, aucune famille.",
+    "fromMeLabel": "Arbre à partir de moi",
+    "fromMeDescription": "Pré-remplir avec vous comme individu de départ.",
+    "soonLabel": "Bientôt",
+    "cancel": "Annuler",
+    "submit": "Créer l'arbre",
+    "closeLabel": "Fermer",
+    "errorGeneric": "Échec de la création de l'arbre."
   },
   "actions": {
     "comingSoon": "Bientôt."

--- a/src/managers/TreeManager.ts
+++ b/src/managers/TreeManager.ts
@@ -1,5 +1,11 @@
 import { openTreeDb, closeTreeDb } from '$/db/connection';
-import { createTree, getTreeById, updateTreeStats, markTreeOpened } from '$/db/system/trees';
+import {
+  createTree,
+  getTreeById,
+  treeExistsAtPath,
+  updateTreeStats,
+  markTreeOpened,
+} from '$/db/system/trees';
 import { countIndividuals } from '$db-tree/individuals';
 import { countFamilies } from '$db-tree/families';
 import { useAppStore } from '$/store/app-store';
@@ -14,11 +20,14 @@ export class TreeManager {
   /**
    * Create a new tree and open its database.
    * Trees are stored in the app data directory under trees/<slug>/.
+   * Tree names are not unique — when two trees share a slug, a `-2`,
+   * `-3`, ... suffix is appended to the path so the underlying paths
+   * stay unique while the user-visible name is preserved verbatim.
    * @returns The ID of the created tree
    */
   static async create(data: CreateTreeData): Promise<string> {
-    const slug = slugifyTreeName(data.name) || crypto.randomUUID();
-    const treePath = await getTreePathForSlug(slug);
+    const baseSlug = slugifyTreeName(data.name) || crypto.randomUUID();
+    const treePath = await TreeManager.resolveAvailablePath(baseSlug);
 
     const treeId = await createTree({
       name: data.name,
@@ -29,6 +38,16 @@ export class TreeManager {
     await openTreeDb(treePath);
 
     return treeId;
+  }
+
+  private static async resolveAvailablePath(baseSlug: string): Promise<string> {
+    let suffix = 0;
+    while (true) {
+      const slug = suffix === 0 ? baseSlug : `${baseSlug}-${suffix + 1}`;
+      const candidate = await getTreePathForSlug(slug);
+      if (!(await treeExistsAtPath(candidate))) return candidate;
+      suffix++;
+    }
   }
 
   /**

--- a/src/managers/TreeManager.ts
+++ b/src/managers/TreeManager.ts
@@ -41,13 +41,15 @@ export class TreeManager {
   }
 
   private static async resolveAvailablePath(baseSlug: string): Promise<string> {
-    let suffix = 0;
-    while (true) {
+    const MAX_ATTEMPTS = 100;
+    for (let suffix = 0; suffix < MAX_ATTEMPTS; suffix++) {
       const slug = suffix === 0 ? baseSlug : `${baseSlug}-${suffix + 1}`;
       const candidate = await getTreePathForSlug(slug);
       if (!(await treeExistsAtPath(candidate))) return candidate;
-      suffix++;
     }
+    throw new Error(
+      `Unable to find an available path for slug "${baseSlug}" after ${MAX_ATTEMPTS} attempts`
+    );
   }
 
   /**

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import packageJson from '../../package.json';
 import { AppStatusBar } from '$components/app-status-bar';
 import { PreferencesPopover } from '$components/preferences-popover';
+import { NewTreeModal } from '$components/trees/new-tree-modal';
 import { TreeCard, type TreeCardLabels } from '$components/trees/tree-card';
 import { TreeCardCta } from '$components/trees/tree-card-cta';
 import { TreeSectionDivider } from '$components/trees/tree-section-divider';
@@ -41,6 +42,7 @@ export function HomePage(): JSX.Element {
   const queryClient = useQueryClient();
   const [sort, setSort] = useState<SortKey>('recent');
   const [importError, setImportError] = useState<string | null>(null);
+  const [newTreeOpen, setNewTreeOpen] = useState(false);
 
   const {
     data: trees,
@@ -140,7 +142,7 @@ export function HomePage(): JSX.Element {
           <TreeCardCta
             title={t('trees:cta.title')}
             subtitle={t('trees:cta.subtitle')}
-            onClick={comingSoon}
+            onClick={() => setNewTreeOpen(true)}
           />
         </div>
       </>
@@ -157,7 +159,7 @@ export function HomePage(): JSX.Element {
               <span className="text-primary italic">{t('trees:home.titleAccent')}</span>
             </h1>
             <div className="mt-5 flex items-center gap-2.5">
-              <Button leadingIcon="plus" onClick={comingSoon}>
+              <Button leadingIcon="plus" onClick={() => setNewTreeOpen(true)}>
                 {t('trees:home.heroNew')}
               </Button>
               <Button
@@ -196,6 +198,8 @@ export function HomePage(): JSX.Element {
           </PreferencesPopover>
         }
       />
+
+      <NewTreeModal open={newTreeOpen} onOpenChange={setNewTreeOpen} />
     </div>
   );
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -80,6 +80,11 @@
   --color-input: oklch(0.22 0.028 45 / 14%);
   --color-ring: oklch(0.54 0.13 32);
 
+  /* Modal/dialog backdrop — always dark in both themes so the underlying
+     page recedes behind the floating surface. Pair with an opacity utility
+     (e.g., `bg-overlay/60`) at the call site. */
+  --color-overlay: oklch(0 0 0);
+
   /* Typography — `Fraunces` and `Geist Mono` will fall back until self-hosted in ./fonts/ */
   --font-sans: 'Geist', ui-sans-serif, system-ui, sans-serif;
   --font-serif: 'Fraunces', ui-serif, Georgia, Cambria, 'Times New Roman', serif;


### PR DESCRIPTION
## Summary

- Adds `NewTreeModal` ($components/trees/new-tree-modal.tsx) — controlled `Dialog` form that creates a blank tree via `TreeManager.create` and invalidates `queryKeys.trees` on success.
- Wires the home-page hero "New tree" button and the dashed `TreeCardCta` tile to open the modal (replacing the `comingSoon` alert).
- Adds `trees:newTree.*` i18n block (en + fr); reuses existing `Dialog`, `Input`, `Textarea`, `OptionCardGroup`, `OptionCard`, `Button` primitives.
- "From me" starting point renders a `Soon` badge per the issue spec; only the **Blank** path is functional this iteration.

Out of scope per the issue (icebox): path picker, "From me" pre-population, auto-navigation into the created tree.

Closes #92

## Test plan

- [ ] Hero "New tree" button opens the modal
- [ ] `TreeCardCta` (dashed tile) opens the same modal
- [ ] Submit disabled while name is empty; trims whitespace
- [ ] Cancel / Escape / X close without creating a tree
- [ ] Submit creates the tree, modal closes, new card appears in the grid
- [ ] "From me" card is non-selectable and shows the `Soon` badge
- [ ] Strings flip between en/fr via the preferences popover (no hardcoded text)
- [ ] Storybook play() tests pass (`Default`, `SubmitDisabledWithEmptyName`, `SubmitCreatesTree`, `CancelClosesWithoutCreating`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)