### PR TITLE
feat(trees): EditTreeModal — rename + adjust description

### DIFF
--- a/src/components/trees/edit-tree-modal.stories.tsx
+++ b/src/components/trees/edit-tree-modal.stories.tsx
@@ -1,0 +1,165 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEffect, useState, type ComponentProps, type ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import { Button } from '$components/ui/button';
+import { EditTreeModal } from './edit-tree-modal';
+import type { Tree } from '$/types/database';
+
+type ModalArgs = ComponentProps<typeof EditTreeModal>;
+
+const sampleTree: Tree = {
+  id: '7',
+  name: 'GRAMPS-Bourgoin-Aubé',
+  path: '/Users/demo/trees/gramps-bourgoin-aube.db',
+  description: 'Imported from GEDCOM · Lignée maternelle, Normandie',
+  individualCount: 75,
+  familyCount: 28,
+  lastOpenedAt: '2026-04-11T10:00:00.000Z',
+  createdAt: '2026-02-28T08:30:00.000Z',
+  updatedAt: '2026-04-11T10:00:00.000Z',
+};
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function QueryWrapper({ children }: { children: ReactNode }): JSX.Element {
+  const [client] = useState(makeQueryClient);
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function ModalHarness({ open: argOpen, onOpenChange, ...props }: ModalArgs): JSX.Element {
+  const [open, setOpen] = useState(Boolean(argOpen));
+  useEffect(() => {
+    setOpen(Boolean(argOpen));
+  }, [argOpen]);
+
+  return (
+    <QueryWrapper>
+      <Button onClick={() => setOpen(true)}>Open edit-tree modal</Button>
+      <EditTreeModal
+        {...props}
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          onOpenChange?.(next);
+        }}
+      />
+    </QueryWrapper>
+  );
+}
+
+const meta: Meta<ModalArgs> = {
+  title: 'Trees/EditTreeModal',
+  component: EditTreeModal,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    a11y: {
+      // Radix focus-trap sentinels confuse axe's aria-hidden-focus rule
+      // — same exemption as the Dialog stories.
+      config: { rules: [{ id: 'aria-hidden-focus', enabled: false }] },
+    },
+  },
+  args: {
+    tree: sampleTree,
+    open: false,
+    onOpenChange: fn(),
+    onUpdated: fn(),
+  },
+  render: (args) => <ModalHarness {...args} />,
+};
+
+export default meta;
+type Story = StoryObj<ModalArgs>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open edit-tree modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    const dialog = await body.findByRole('dialog');
+    await expect(dialog).toBeInTheDocument();
+    await expect(dialog).toHaveAccessibleName('Edit tree');
+
+    const nameInput = (await body.findByLabelText(/Tree name/)) as HTMLInputElement;
+    await expect(nameInput.value).toBe(sampleTree.name);
+
+    const descriptionInput = (await body.findByLabelText(/Description/)) as HTMLTextAreaElement;
+    await expect(descriptionInput.value).toBe(sampleTree.description);
+
+    // Summary card values — count + both ISO dates.
+    await expect(body.getByText('75')).toBeInTheDocument();
+    await expect(body.getByText('2026-02-28')).toBeInTheDocument();
+    await expect(body.getByText('2026-04-11')).toBeInTheDocument();
+  },
+};
+
+export const SubmitDisabledWhenUnchanged: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open edit-tree modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    const submit = await body.findByRole('button', { name: 'Save' });
+    await expect(submit).toBeDisabled();
+
+    // Clearing the name keeps it disabled.
+    const nameInput = await body.findByLabelText(/Tree name/);
+    await userEvent.clear(nameInput);
+    await expect(submit).toBeDisabled();
+  },
+};
+
+export const SubmitUpdatesTree: Story = {
+  args: {
+    updateTree: fn(async () => undefined),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open edit-tree modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+
+    const nameInput = await body.findByLabelText(/Tree name/);
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Bourgoin family — Normandie');
+
+    const descriptionInput = await body.findByLabelText(/Description/);
+    await userEvent.clear(descriptionInput);
+    await userEvent.type(descriptionInput, 'Cleaned-up after first review.');
+
+    await userEvent.click(body.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(args.updateTree).toHaveBeenCalledWith(sampleTree.id, {
+        name: 'Bourgoin family — Normandie',
+        description: 'Cleaned-up after first review.',
+      });
+    });
+    await waitFor(() => expect(args.onUpdated).toHaveBeenCalledWith(sampleTree.id));
+    await waitFor(() => expect(args.onOpenChange).toHaveBeenCalledWith(false));
+  },
+};
+
+export const CancelClosesWithoutUpdating: Story = {
+  args: {
+    updateTree: fn(async () => undefined),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open edit-tree modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    const cancel = await body.findByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancel);
+
+    await waitFor(() => expect(args.onOpenChange).toHaveBeenCalledWith(false));
+    expect(args.updateTree).not.toHaveBeenCalled();
+  },
+};

--- a/src/components/trees/edit-tree-modal.stories.tsx
+++ b/src/components/trees/edit-tree-modal.stories.tsx
@@ -93,7 +93,6 @@ export const Default: Story = {
     const descriptionInput = (await body.findByLabelText(/Description/)) as HTMLTextAreaElement;
     await expect(descriptionInput.value).toBe(sampleTree.description);
 
-    // Summary card values — count + both ISO dates.
     await expect(body.getByText('75')).toBeInTheDocument();
     await expect(body.getByText('2026-02-28')).toBeInTheDocument();
     await expect(body.getByText('2026-04-11')).toBeInTheDocument();

--- a/src/components/trees/edit-tree-modal.tsx
+++ b/src/components/trees/edit-tree-modal.tsx
@@ -62,9 +62,8 @@ export function EditTreeModal({
   const nameId = useId();
   const descriptionId = useId();
 
-  const initialDescription = tree.description ?? '';
   const [name, setName] = useState(tree.name);
-  const [description, setDescription] = useState(initialDescription);
+  const [description, setDescription] = useState(tree.description ?? '');
 
   const mutation = useMutation({
     mutationFn: (input: UpdateTreeInput) => updateTree(tree.id, input),
@@ -83,8 +82,6 @@ export function EditTreeModal({
     },
   });
 
-  // Reset to the latest tree values whenever the modal closes or the
-  // tree prop swaps out (e.g., user edits tree A, closes, opens tree B).
   useEffect(() => {
     if (!open) {
       setName(tree.name);
@@ -92,12 +89,12 @@ export function EditTreeModal({
       mutation.reset();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, tree.id, tree.name, tree.description]);
+  }, [open, tree.id]);
 
   const trimmedName = name.trim();
   const trimmedDescription = description.trim();
   const nameChanged = trimmedName !== tree.name;
-  const descriptionChanged = trimmedDescription !== initialDescription.trim();
+  const descriptionChanged = trimmedDescription !== (tree.description ?? '').trim();
   const hasChanges = nameChanged || descriptionChanged;
   const canSubmit = trimmedName.length > 0 && hasChanges && !mutation.isPending;
 

--- a/src/components/trees/edit-tree-modal.tsx
+++ b/src/components/trees/edit-tree-modal.tsx
@@ -1,0 +1,213 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { type ReactNode, useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '$components/ui/button';
+import { Dialog } from '$components/ui/dialog';
+import { Input } from '$components/ui/input';
+import { Textarea } from '$components/ui/textarea';
+import { updateTree as defaultUpdateTree } from '$db-system/trees';
+import { formatIsoDate } from '$lib/format';
+import { queryKeys } from '$lib/query-keys';
+import type { Tree } from '$/types/database';
+
+interface UpdateTreeInput {
+  name: string;
+  description: string | null;
+}
+
+/**
+ * Props accepted by {@link EditTreeModal}.
+ */
+export interface EditTreeModalProps {
+  /** The tree being edited. Drives pre-fill values and the read-only summary. */
+  tree: Tree;
+
+  /** Whether the modal is open. Controlled by the parent. */
+  open: boolean;
+
+  /** Called when the modal should open or close. */
+  onOpenChange: (open: boolean) => void;
+
+  /** Called with the tree id after a successful update. */
+  onUpdated?: (treeId: string) => void;
+
+  /**
+   * Override the update function. Defaults to the DB-layer `updateTree`.
+   * Tests/stories inject a spy here so the flow can be exercised without
+   * hitting Tauri SQL.
+   */
+  updateTree?: (id: string, input: UpdateTreeInput) => Promise<void>;
+}
+
+/**
+ * Form host for renaming a tree and adjusting its description. Calls
+ * `updateTree` and invalidates both `queryKeys.trees` and
+ * `queryKeys.tree(id)` on success so the home grid and the tree shell
+ * pick up the new values.
+ *
+ * The Save button stays disabled until something actually changes — there
+ * is no value in submitting a no-op.
+ */
+export function EditTreeModal({
+  tree,
+  open,
+  onOpenChange,
+  onUpdated,
+  updateTree = defaultUpdateTree,
+}: EditTreeModalProps): JSX.Element {
+  const { t } = useTranslation('trees');
+  const queryClient = useQueryClient();
+  const formId = useId();
+  const nameId = useId();
+  const descriptionId = useId();
+
+  const initialDescription = tree.description ?? '';
+  const [name, setName] = useState(tree.name);
+  const [description, setDescription] = useState(initialDescription);
+
+  const mutation = useMutation({
+    mutationFn: (input: UpdateTreeInput) => updateTree(tree.id, input),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.trees }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.tree(tree.id) }),
+      ]);
+      onUpdated?.(tree.id);
+      onOpenChange(false);
+    },
+    onError: (err) => {
+      // Raw DB/Tauri errors are not translated — log them, surface a
+      // generic localized message in the UI instead.
+      console.error('Failed to update tree:', err);
+    },
+  });
+
+  // Reset to the latest tree values whenever the modal closes or the
+  // tree prop swaps out (e.g., user edits tree A, closes, opens tree B).
+  useEffect(() => {
+    if (!open) {
+      setName(tree.name);
+      setDescription(tree.description ?? '');
+      mutation.reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, tree.id, tree.name, tree.description]);
+
+  const trimmedName = name.trim();
+  const trimmedDescription = description.trim();
+  const nameChanged = trimmedName !== tree.name;
+  const descriptionChanged = trimmedDescription !== initialDescription.trim();
+  const hasChanges = nameChanged || descriptionChanged;
+  const canSubmit = trimmedName.length > 0 && hasChanges && !mutation.isPending;
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    mutation.mutate({
+      name: trimmedName,
+      description: trimmedDescription.length > 0 ? trimmedDescription : null,
+    });
+  };
+
+  const closeModal = (): void => {
+    if (mutation.isPending) return;
+    mutation.reset();
+    onOpenChange(false);
+  };
+
+  const lastOpenedDisplay: ReactNode = tree.lastOpenedAt
+    ? formatIsoDate(tree.lastOpenedAt)
+    : t('editTree.summaryNever');
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (next) {
+          onOpenChange(true);
+          return;
+        }
+        closeModal();
+      }}
+      size="md"
+      title={<span className="font-serif italic">{t('editTree.title')}</span>}
+      description={t('editTree.subtitle')}
+      closeLabel={t('editTree.closeLabel')}
+      footer={
+        <>
+          <Button variant="ghost" onClick={closeModal} disabled={mutation.isPending}>
+            {t('editTree.cancel')}
+          </Button>
+          <Button type="submit" form={formId} disabled={!canSubmit}>
+            {t('editTree.submit')}
+          </Button>
+        </>
+      }
+    >
+      <form id={formId} onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor={nameId} className="text-foreground text-sm font-medium">
+            {t('editTree.nameLabel')}{' '}
+            <span aria-hidden className="text-primary font-normal">
+              {t('editTree.nameRequired')}
+            </span>
+          </label>
+          <Input
+            id={nameId}
+            required
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            disabled={mutation.isPending}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor={descriptionId} className="text-foreground text-sm font-medium">
+            {t('editTree.descriptionLabel')}{' '}
+            <span className="text-muted-foreground font-normal">
+              — {t('editTree.descriptionOptional')}
+            </span>
+          </label>
+          <Textarea
+            id={descriptionId}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            disabled={mutation.isPending}
+          />
+        </div>
+
+        <div className="border-border bg-muted/30 grid grid-cols-3 gap-4 rounded-lg border p-4">
+          <SummaryStat
+            label={t('editTree.summaryIndividuals')}
+            value={tree.individualCount.toLocaleString()}
+          />
+          <SummaryStat label={t('editTree.summaryCreated')} value={formatIsoDate(tree.createdAt)} />
+          <SummaryStat label={t('editTree.summaryLastOpened')} value={lastOpenedDisplay} />
+        </div>
+
+        {mutation.isError && (
+          <p role="alert" className="text-destructive text-sm">
+            {t('editTree.errorGeneric')}
+          </p>
+        )}
+      </form>
+    </Dialog>
+  );
+}
+
+interface SummaryStatProps {
+  label: ReactNode;
+  value: ReactNode;
+}
+
+function SummaryStat({ label, value }: SummaryStatProps): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-muted-foreground font-mono text-[10px] leading-none tracking-wider uppercase">
+        {label}
+      </span>
+      <span className="text-foreground font-mono text-base leading-none tabular-nums">{value}</span>
+    </div>
+  );
+}

--- a/src/db/system/trees.ts
+++ b/src/db/system/trees.ts
@@ -70,7 +70,7 @@ export async function createTree(
 
 export async function updateTree(
   id: string,
-  data: { name?: string; description?: string }
+  data: { name?: string; description?: string | null }
 ): Promise<void> {
   const db = await getSystemDb();
   const sets: string[] = [];

--- a/src/i18n/locales/en/trees.json
+++ b/src/i18n/locales/en/trees.json
@@ -52,6 +52,22 @@
     "closeLabel": "Close",
     "errorGeneric": "Failed to create tree."
   },
+  "editTree": {
+    "title": "Edit tree",
+    "subtitle": "Rename the tree and adjust its description. Records and sources remain unchanged.",
+    "nameLabel": "Tree name",
+    "nameRequired": "*",
+    "descriptionLabel": "Description",
+    "descriptionOptional": "optional",
+    "summaryIndividuals": "Individuals",
+    "summaryCreated": "Created",
+    "summaryLastOpened": "Last opened",
+    "summaryNever": "Never",
+    "cancel": "Cancel",
+    "submit": "Save",
+    "closeLabel": "Close",
+    "errorGeneric": "Failed to update tree."
+  },
   "actions": {
     "comingSoon": "Coming soon."
   }

--- a/src/i18n/locales/fr/trees.json
+++ b/src/i18n/locales/fr/trees.json
@@ -52,6 +52,22 @@
     "closeLabel": "Fermer",
     "errorGeneric": "Échec de la création de l'arbre."
   },
+  "editTree": {
+    "title": "Modifier l'arbre",
+    "subtitle": "Renommez l'arbre et ajustez sa description. Les fiches et sources restent inchangées.",
+    "nameLabel": "Nom de l'arbre",
+    "nameRequired": "*",
+    "descriptionLabel": "Description",
+    "descriptionOptional": "facultatif",
+    "summaryIndividuals": "Individus",
+    "summaryCreated": "Créé",
+    "summaryLastOpened": "Dernier accès",
+    "summaryNever": "Jamais",
+    "cancel": "Annuler",
+    "submit": "Enregistrer",
+    "closeLabel": "Fermer",
+    "errorGeneric": "Échec de la mise à jour de l'arbre."
+  },
   "actions": {
     "comingSoon": "Bientôt."
   }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import packageJson from '../../package.json';
 import { AppStatusBar } from '$components/app-status-bar';
 import { PreferencesPopover } from '$components/preferences-popover';
+import { EditTreeModal } from '$components/trees/edit-tree-modal';
 import { NewTreeModal } from '$components/trees/new-tree-modal';
 import { TreeCard, type TreeCardLabels } from '$components/trees/tree-card';
 import { TreeCardCta } from '$components/trees/tree-card-cta';
@@ -43,6 +44,7 @@ export function HomePage(): JSX.Element {
   const [sort, setSort] = useState<SortKey>('recent');
   const [importError, setImportError] = useState<string | null>(null);
   const [newTreeOpen, setNewTreeOpen] = useState(false);
+  const [editingTree, setEditingTree] = useState<Tree | null>(null);
 
   const {
     data: trees,
@@ -135,7 +137,7 @@ export function HomePage(): JSX.Element {
               labels={cardLabels}
               onOpen={() => void handleOpen(tree.id)}
               onExport={comingSoon}
-              onEdit={comingSoon}
+              onEdit={() => setEditingTree(tree)}
               onDelete={comingSoon}
             />
           ))}
@@ -200,6 +202,15 @@ export function HomePage(): JSX.Element {
       />
 
       <NewTreeModal open={newTreeOpen} onOpenChange={setNewTreeOpen} />
+      {editingTree && (
+        <EditTreeModal
+          tree={editingTree}
+          open={true}
+          onOpenChange={(next) => {
+            if (!next) setEditingTree(null);
+          }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `EditTreeModal` triggered by the pencil icon on each `TreeCard`. Mirrors the structure of `NewTreeModal`: serif italic title, controlled `Dialog`, `useMutation`, override-able update prop for tests.
- Pre-fills name + description from the selected `Tree`, shows a 3-column read-only summary (Individuals / Created / Last opened) styled with the same mono / muted-uppercase idiom as the home cards.
- Save is disabled until something actually changes; clearing the description writes `NULL` to the column.
- Invalidates both `queryKeys.trees` and `queryKeys.tree(id)` on success so the home grid and any open tree shell pick up the new values.
- Adds `editTree.*` i18n keys for `en` and `fr` matching the design mockup.
- Widens the DB-layer `updateTree` `description` to `string | null` so the modal can clear the field.

Closes #94

## Test plan

- [ ] `pnpm tauri:dev` → click the pencil on a tree card → modal opens with current values pre-filled.
- [ ] Edit the name and/or description, click Save → grid refreshes; reopening the same tree shows the new values.
- [ ] Open the modal, clear the description, Save → description column reads `NULL`.
- [ ] Open the modal, change nothing → Save stays disabled. Clear the name → Save stays disabled.
- [ ] Toggle the FR locale → all modal copy is localised; no missing-key warnings.
- [ ] Storybook → `Trees/EditTreeModal` renders all 4 stories; play() tests pass.
- [ ] `pnpm lint && pnpm format:check && pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)