### PR TITLE
feat(trees): ImportGedcomModal — drag/drop, scan preview, options, submit

### DIFF
--- a/src/components/trees/import-gedcom-modal.stories.tsx
+++ b/src/components/trees/import-gedcom-modal.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import { Button } from '$components/ui/button';
+import type { ImportResult } from '$/managers/GedcomManager';
 import { ImportGedcomModal } from './import-gedcom-modal';
 
 type ModalArgs = ComponentProps<typeof ImportGedcomModal>;
@@ -46,7 +47,7 @@ const sampleSelection = {
   path: '/tmp/family.ged',
   name: 'family.ged',
   content: SAMPLE_CONTENT,
-  size: SAMPLE_CONTENT.length,
+  size: new TextEncoder().encode(SAMPLE_CONTENT).length,
   scan: {
     individuals: 142,
     families: 58,
@@ -173,10 +174,12 @@ export const ErrorsBlockSubmit: Story = {
 export const SubmitCallsImport: Story = {
   args: {
     initialSelection: sampleSelection,
-    importTree: fn(async () => ({
-      treeId: 'tree-42',
-      stats: { individuals: 142, families: 58, places: 0, events: 200, errors: [] },
-    })),
+    importTree: fn(
+      async (): Promise<ImportResult> => ({
+        treeId: 'tree-42',
+        stats: { individuals: 142, families: 58, places: 0, events: 200, errors: [] },
+      })
+    ),
   },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
@@ -202,10 +205,12 @@ export const SubmitCallsImport: Story = {
 
 export const CancelClosesWithoutImport: Story = {
   args: {
-    importTree: fn(async () => ({
-      treeId: 'never',
-      stats: { individuals: 0, families: 0, places: 0, events: 0, errors: [] },
-    })),
+    importTree: fn(
+      async (): Promise<ImportResult> => ({
+        treeId: 'never',
+        stats: { individuals: 0, families: 0, places: 0, events: 0, errors: [] },
+      })
+    ),
   },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);

--- a/src/components/trees/import-gedcom-modal.stories.tsx
+++ b/src/components/trees/import-gedcom-modal.stories.tsx
@@ -1,0 +1,221 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEffect, useState, type ComponentProps, type ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import { Button } from '$components/ui/button';
+import { ImportGedcomModal } from './import-gedcom-modal';
+
+type ModalArgs = ComponentProps<typeof ImportGedcomModal>;
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function QueryWrapper({ children }: { children: ReactNode }): JSX.Element {
+  const [client] = useState(makeQueryClient);
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function ModalHarness({ open: argOpen, onOpenChange, ...props }: ModalArgs): JSX.Element {
+  const [open, setOpen] = useState(Boolean(argOpen));
+  useEffect(() => {
+    setOpen(Boolean(argOpen));
+  }, [argOpen]);
+
+  return (
+    <QueryWrapper>
+      <Button onClick={() => setOpen(true)}>Open import-gedcom modal</Button>
+      <ImportGedcomModal
+        {...props}
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          onOpenChange?.(next);
+        }}
+      />
+    </QueryWrapper>
+  );
+}
+
+const SAMPLE_CONTENT = '0 HEAD\n1 SOUR Vata\n0 @I1@ INDI\n1 NAME John /Doe/\n0 TRLR\n';
+
+const sampleSelection = {
+  path: '/tmp/family.ged',
+  name: 'family.ged',
+  content: SAMPLE_CONTENT,
+  size: SAMPLE_CONTENT.length,
+  scan: {
+    individuals: 142,
+    families: 58,
+    places: 0,
+    sources: 23,
+    repositories: 4,
+    errors: [],
+    warnings: [],
+  },
+};
+
+const meta: Meta<ModalArgs> = {
+  title: 'Trees/ImportGedcomModal',
+  component: ImportGedcomModal,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    a11y: {
+      // Radix focus-trap sentinels confuse axe's aria-hidden-focus rule
+      // — same exemption as the Dialog stories.
+      config: { rules: [{ id: 'aria-hidden-focus', enabled: false }] },
+    },
+  },
+  args: {
+    open: false,
+    onOpenChange: fn(),
+    onImported: fn(),
+  },
+  render: (args) => <ModalHarness {...args} />,
+};
+
+export default meta;
+type Story = StoryObj<ModalArgs>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open import-gedcom modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    const dialog = await body.findByRole('dialog');
+    await expect(dialog).toBeInTheDocument();
+    await expect(dialog).toHaveAccessibleName('Import GEDCOM');
+
+    // Pre-selection state — dropzone visible, no stat grid yet.
+    await expect(body.getByText('Drop a .ged file here, or click to browse')).toBeInTheDocument();
+    const submit = body.getByRole('button', { name: 'Import tree' });
+    await expect(submit).toBeDisabled();
+  },
+};
+
+export const PostSelectionShowsScan: Story = {
+  args: {
+    initialSelection: sampleSelection,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open import-gedcom modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    await body.findByRole('dialog');
+
+    // File row + 4 stat cells.
+    await expect(body.getByText('family.ged')).toBeInTheDocument();
+    await expect(body.getByText('142')).toBeInTheDocument();
+    await expect(body.getByText('58')).toBeInTheDocument();
+    await expect(body.getByText('23')).toBeInTheDocument();
+
+    // Tree name pre-filled from filename without extension.
+    const nameInput = await body.findByLabelText('Tree name');
+    await expect(nameInput).toHaveValue('family');
+
+    // Submit enabled because there are no errors and the name is filled.
+    const submit = body.getByRole('button', { name: 'Import tree' });
+    await expect(submit).toBeEnabled();
+  },
+};
+
+export const WarningsRendered: Story = {
+  args: {
+    initialSelection: {
+      ...sampleSelection,
+      scan: {
+        ...sampleSelection.scan,
+        warnings: ['Reference to undefined XREF: @MISSING@', 'Missing TRLR (trailer) record'],
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open import-gedcom modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    await body.findByRole('dialog');
+
+    // Warnings collapsed inside <details>; assert the summary label.
+    await expect(body.getByText('2 warnings')).toBeInTheDocument();
+  },
+};
+
+export const ErrorsBlockSubmit: Story = {
+  args: {
+    initialSelection: {
+      ...sampleSelection,
+      scan: {
+        ...sampleSelection.scan,
+        errors: ['INDI record missing XREF'],
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open import-gedcom modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    await body.findByRole('dialog');
+
+    await expect(body.getByText('Errors')).toBeInTheDocument();
+    const submit = body.getByRole('button', { name: 'Import tree' });
+    await expect(submit).toBeDisabled();
+  },
+};
+
+export const SubmitCallsImport: Story = {
+  args: {
+    initialSelection: sampleSelection,
+    importTree: fn(async () => ({
+      treeId: 'tree-42',
+      stats: { individuals: 142, families: 58, places: 0, events: 200, errors: [] },
+    })),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open import-gedcom modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    await body.findByRole('dialog');
+
+    await userEvent.click(body.getByRole('button', { name: 'Import tree' }));
+
+    await waitFor(() => {
+      expect(args.importTree).toHaveBeenCalledWith(SAMPLE_CONTENT, 'family');
+    });
+    await waitFor(() =>
+      expect(args.onImported).toHaveBeenCalledWith({
+        treeId: 'tree-42',
+        stats: { individuals: 142, families: 58, places: 0, events: 200, errors: [] },
+      })
+    );
+    await waitFor(() => expect(args.onOpenChange).toHaveBeenCalledWith(false));
+  },
+};
+
+export const CancelClosesWithoutImport: Story = {
+  args: {
+    importTree: fn(async () => ({
+      treeId: 'never',
+      stats: { individuals: 0, families: 0, places: 0, events: 0, errors: [] },
+    })),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Open import-gedcom modal' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    const cancel = await body.findByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancel);
+
+    await waitFor(() => expect(args.onOpenChange).toHaveBeenCalledWith(false));
+    expect(args.importTree).not.toHaveBeenCalled();
+  },
+};

--- a/src/components/trees/import-gedcom-modal.stories.tsx
+++ b/src/components/trees/import-gedcom-modal.stories.tsx
@@ -9,17 +9,23 @@ import { ImportGedcomModal } from './import-gedcom-modal';
 
 type ModalArgs = ComponentProps<typeof ImportGedcomModal>;
 
+/** Build a fresh QueryClient that doesn't retry — keeps stories deterministic. */
 function makeQueryClient(): QueryClient {
   return new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
 }
 
+/** Provides a per-story QueryClient so `useMutation` works inside the modal. */
 function QueryWrapper({ children }: { children: ReactNode }): JSX.Element {
   const [client] = useState(makeQueryClient);
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
+/**
+ * Renders an "Open" button alongside the modal so each play() can
+ * exercise the open transition like a real user would.
+ */
 function ModalHarness({ open: argOpen, onOpenChange, ...props }: ModalArgs): JSX.Element {
   const [open, setOpen] = useState(Boolean(argOpen));
   useEffect(() => {

--- a/src/components/trees/import-gedcom-modal.tsx
+++ b/src/components/trees/import-gedcom-modal.tsx
@@ -1,0 +1,393 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Badge } from '$components/ui/badge';
+import { Button } from '$components/ui/button';
+import { Dialog } from '$components/ui/dialog';
+import { Dropzone } from '$components/ui/dropzone';
+import { Input } from '$components/ui/input';
+import { StatGrid, type StatGridItem } from '$components/ui/stat-grid';
+import { Switch } from '$components/ui/switch';
+import { GedcomManager, type ImportResult, type ScanResult } from '$/managers/GedcomManager';
+import { queryKeys } from '$lib/query-keys';
+
+/**
+ * In-memory description of the user's GEDCOM selection. Lives only
+ * inside the modal — the file path is captured for the Tauri-side
+ * import flow but the file is never re-read.
+ */
+interface SelectedFile {
+  /** Absolute path returned by Tauri's open dialog. */
+  path: string;
+  /** Filename with extension (e.g. `tree.ged`). */
+  name: string;
+  /** Full UTF-8 content read once at selection time. */
+  content: string;
+  /** Byte length of the content in UTF-8. */
+  size: number;
+  /** Result of `GedcomManager.scan(content)`. */
+  scan: ScanResult;
+}
+
+/**
+ * Props accepted by {@link ImportGedcomModal}.
+ */
+export interface ImportGedcomModalProps {
+  /** Whether the modal is open. Controlled by the parent. */
+  open: boolean;
+
+  /** Called when the modal should open or close. */
+  onOpenChange: (open: boolean) => void;
+
+  /** Called with the import result on success. */
+  onImported?: (result: ImportResult) => void;
+
+  /**
+   * Override the file-content reader. Defaults to Tauri's
+   * `readTextFile`. Tests/stories inject a spy here so the flow can be
+   * exercised without hitting the Tauri filesystem plugin.
+   */
+  readFileContent?: (path: string) => Promise<string>;
+
+  /**
+   * Override the scan function. Defaults to {@link GedcomManager.scan}.
+   */
+  scan?: (content: string) => ScanResult;
+
+  /**
+   * Override the import function. Defaults to
+   * {@link GedcomManager.importFromContent}.
+   */
+  importTree?: (content: string, treeName: string) => Promise<ImportResult>;
+
+  /**
+   * Pre-populates the modal with a selected file. Stories use this to
+   * exercise the post-selection state without driving the Tauri file
+   * dialog. Production code does not pass this prop.
+   */
+  initialSelection?: SelectedFile;
+}
+
+const defaultReadFileContent = async (path: string): Promise<string> => {
+  const { readTextFile } = await import('@tauri-apps/plugin-fs');
+  return readTextFile(path);
+};
+
+const defaultScan = (content: string): ScanResult => GedcomManager.scan(content);
+
+const defaultImportTree = (content: string, treeName: string): Promise<ImportResult> =>
+  GedcomManager.importFromContent(content, treeName);
+
+/**
+ * Strip the extension and any leading directory off a filename to get
+ * a sensible default tree name. Mirrors what `importFromFile` does
+ * silently today.
+ */
+function deriveTreeName(filename: string): string {
+  const base = filename.split(/[/\\]/).pop() ?? filename;
+  return base.replace(/\.[^.]+$/, '');
+}
+
+/**
+ * Form host for importing a GEDCOM file into a new tree. Wraps the
+ * scan-preview-then-submit flow described in the home-page mockup.
+ *
+ * The modal owns its own error state — there is no inline error left
+ * on the home page after this lands.
+ */
+export function ImportGedcomModal({
+  open,
+  onOpenChange,
+  onImported,
+  readFileContent = defaultReadFileContent,
+  scan = defaultScan,
+  importTree = defaultImportTree,
+  initialSelection,
+}: ImportGedcomModalProps): JSX.Element {
+  const { t } = useTranslation('trees');
+  const queryClient = useQueryClient();
+  const formId = useId();
+  const nameId = useId();
+
+  const [selected, setSelected] = useState<SelectedFile | null>(initialSelection ?? null);
+  const [scanError, setScanError] = useState<string | null>(null);
+  const [name, setName] = useState(initialSelection ? deriveTreeName(initialSelection.name) : '');
+
+  const mutation = useMutation({
+    mutationFn: ({ content, treeName }: { content: string; treeName: string }) =>
+      importTree(content, treeName),
+    onSuccess: async (result) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.trees });
+      onImported?.(result);
+      onOpenChange(false);
+    },
+    onError: (err) => {
+      // Raw parser/Tauri errors are not translated — log them, surface a
+      // generic localized message in the UI instead.
+      console.error('Failed to import GEDCOM:', err);
+    },
+  });
+
+  useEffect(() => {
+    if (!open) {
+      setSelected(initialSelection ?? null);
+      setName(initialSelection ? deriveTreeName(initialSelection.name) : '');
+      setScanError(null);
+      mutation.reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const handleFileSelected = async (file: { path: string; name: string }): Promise<void> => {
+    setScanError(null);
+    try {
+      const content = await readFileContent(file.path);
+      const scanResult = scan(content);
+      setSelected({
+        path: file.path,
+        name: file.name,
+        content,
+        size: new Blob([content]).size,
+        scan: scanResult,
+      });
+      setName(deriveTreeName(file.name));
+    } catch (err) {
+      console.error('Failed to read or scan GEDCOM file:', err);
+      setScanError(err instanceof Error ? err.message : t('importGedcom.errorScan'));
+    }
+  };
+
+  const trimmedName = name.trim();
+  const hasFatalErrors = (selected?.scan.errors.length ?? 0) > 0;
+  const canSubmit =
+    selected !== null && trimmedName.length > 0 && !hasFatalErrors && !mutation.isPending;
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    if (!canSubmit || !selected) return;
+    mutation.mutate({ content: selected.content, treeName: trimmedName });
+  };
+
+  const closeModal = (): void => {
+    if (mutation.isPending) return;
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (next) {
+          onOpenChange(true);
+          return;
+        }
+        closeModal();
+      }}
+      size="lg"
+      title={<span className="font-serif italic">{t('importGedcom.title')}</span>}
+      description={t('importGedcom.subtitle')}
+      closeLabel={t('importGedcom.closeLabel')}
+      footerNote={<span className="font-mono">{t('importGedcom.footerNote')}</span>}
+      footer={
+        <>
+          <Button variant="ghost" onClick={closeModal} disabled={mutation.isPending}>
+            {t('importGedcom.cancel')}
+          </Button>
+          <Button type="submit" form={formId} disabled={!canSubmit}>
+            {t('importGedcom.submit')}
+          </Button>
+        </>
+      }
+    >
+      <form id={formId} onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {!selected && (
+          <Dropzone
+            state={scanError ? 'error' : 'idle'}
+            onFileSelected={handleFileSelected}
+            formatName={t('importGedcom.dropzoneFormatName')}
+            idleLabel={t('importGedcom.dropzoneLabel')}
+            hint={t('importGedcom.dropzoneHint')}
+            disabled={mutation.isPending}
+          />
+        )}
+
+        {scanError && !selected && (
+          <p role="alert" className="text-destructive text-sm">
+            {scanError}
+          </p>
+        )}
+
+        {selected && (
+          <>
+            <FileRow file={selected} onClear={() => setSelected(null)} />
+            <ScanGrid scan={selected.scan} />
+
+            {selected.scan.warnings.length > 0 && (
+              <WarningList
+                warnings={selected.scan.warnings}
+                label={t('importGedcom.warningsLabel', { count: selected.scan.warnings.length })}
+              />
+            )}
+
+            {selected.scan.errors.length > 0 && (
+              <ErrorList errors={selected.scan.errors} label={t('importGedcom.errorsLabel')} />
+            )}
+
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor={nameId} className="text-foreground text-sm font-medium">
+                {t('importGedcom.nameLabel')}
+              </label>
+              <Input
+                id={nameId}
+                required
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder={t('importGedcom.namePlaceholder')}
+                disabled={mutation.isPending}
+              />
+            </div>
+
+            <div className="border-border flex flex-col gap-1 rounded-lg border p-3">
+              <span className="text-foreground text-sm font-medium">
+                {t('importGedcom.optionsLabel')}
+              </span>
+              <SoonSwitch label={t('importGedcom.mergeDuplicatesLabel')} />
+              <SoonSwitch label={t('importGedcom.importMediaLabel')} />
+              <SoonSwitch label={t('importGedcom.hideLivingLabel')} />
+            </div>
+          </>
+        )}
+
+        {mutation.isError && (
+          <p role="alert" className="text-destructive text-sm">
+            {t('importGedcom.errorGeneric')}
+          </p>
+        )}
+      </form>
+    </Dialog>
+  );
+}
+
+interface FileRowProps {
+  file: SelectedFile;
+  onClear: () => void;
+}
+
+function FileRow({ file, onClear }: FileRowProps): JSX.Element {
+  const { t } = useTranslation('trees');
+  return (
+    <div className="border-border flex items-center gap-3 rounded-lg border p-3">
+      <Badge variant="primary" size="sm">
+        {t('importGedcom.fileBadge')}
+      </Badge>
+      <div className="flex flex-1 flex-col gap-0.5">
+        <span className="text-foreground text-sm font-medium">{file.name}</span>
+        <span className="text-muted-foreground font-mono text-xs">
+          {formatBytes(file.size)} · {t('importGedcom.fileEncoding')}
+        </span>
+      </div>
+      <Button variant="ghost" size="sm" leadingIcon="x" hideLabel onClick={onClear}>
+        {t('importGedcom.clearFileLabel')}
+      </Button>
+    </div>
+  );
+}
+
+interface ScanGridProps {
+  scan: ScanResult;
+}
+
+function ScanGrid({ scan }: ScanGridProps): JSX.Element {
+  const { t } = useTranslation('trees');
+  const items: StatGridItem[] = [
+    { value: scan.individuals, label: t('importGedcom.scanIndividuals') },
+    { value: scan.families, label: t('importGedcom.scanFamilies') },
+    {
+      value: scan.places,
+      label: (
+        <span className="inline-flex items-center gap-1.5">
+          {t('importGedcom.scanPlaces')}
+          <Badge variant="soon" size="sm">
+            {t('importGedcom.soonLabel')}
+          </Badge>
+        </span>
+      ),
+    },
+    { value: scan.sources, label: t('importGedcom.scanSources') },
+  ];
+  return <StatGrid items={items} />;
+}
+
+interface WarningListProps {
+  warnings: string[];
+  label: string;
+}
+
+function WarningList({ warnings, label }: WarningListProps): JSX.Element {
+  return (
+    <details className="border-warning/40 bg-warning/5 rounded-lg border p-3 text-sm">
+      <summary className="text-warning cursor-pointer font-medium">{label}</summary>
+      <ul className="text-muted-foreground mt-2 flex list-disc flex-col gap-1 pl-5">
+        {warnings.map((message, idx) => (
+          <li key={idx}>{message}</li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
+interface ErrorListProps {
+  errors: string[];
+  label: string;
+}
+
+function ErrorList({ errors, label }: ErrorListProps): JSX.Element {
+  return (
+    <div
+      role="alert"
+      className="border-destructive/40 bg-destructive/5 rounded-lg border p-3 text-sm"
+    >
+      <p className="text-destructive font-medium">{label}</p>
+      <ul className="text-muted-foreground mt-2 flex list-disc flex-col gap-1 pl-5">
+        {errors.map((message, idx) => (
+          <li key={idx}>{message}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface SoonSwitchProps {
+  label: string;
+}
+
+/**
+ * Disabled switch with a `Soon` badge — visually present in the
+ * options panel so the user sees future capability, but doesn't fool
+ * them into thinking it has any effect today.
+ */
+function SoonSwitch({ label }: SoonSwitchProps): JSX.Element {
+  const { t } = useTranslation('trees');
+  return (
+    <Switch
+      checked={false}
+      onCheckedChange={() => undefined}
+      disabled
+      label={
+        <span className="inline-flex items-center gap-2">
+          {label}
+          <Badge variant="soon" size="sm">
+            {t('importGedcom.soonLabel')}
+          </Badge>
+        </span>
+      }
+    />
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/components/trees/import-gedcom-modal.tsx
+++ b/src/components/trees/import-gedcom-modal.tsx
@@ -55,9 +55,15 @@ export interface ImportGedcomModalProps {
   initialSelection?: SelectedFile;
 }
 
+/** Default `importTree` implementation — wraps `GedcomManager.importFromContent`. */
 const defaultImportTree = (content: string, treeName: string): Promise<ImportResult> =>
   GedcomManager.importFromContent(content, treeName);
 
+/**
+ * Read a GEDCOM file's contents from disk via Tauri's filesystem
+ * plugin. The plugin import is lazy so non-Tauri test contexts can
+ * still load this module without resolving the native dependency.
+ */
 async function readGedcomFile(path: string): Promise<string> {
   const { readTextFile } = await import('@tauri-apps/plugin-fs');
   return readTextFile(path);
@@ -257,6 +263,11 @@ interface FileRowProps {
   onClear: () => void;
 }
 
+/**
+ * Compact row summarising the selected file (badge, filename, size,
+ * encoding) with a clear button that returns the modal to the
+ * pre-selection state so the user can pick a different file.
+ */
 function FileRow({ file, onClear }: FileRowProps): JSX.Element {
   const { t } = useTranslation('trees');
   return (
@@ -281,6 +292,11 @@ interface ScanGridProps {
   scan: ScanResult;
 }
 
+/**
+ * Four-cell stat grid summarising the GEDCOM scan: individuals,
+ * families, places (always 0 — see {@link ScanResult.places}), and
+ * sources. The Places cell renders a `Soon` badge to set expectations.
+ */
 function ScanGrid({ scan }: ScanGridProps): JSX.Element {
   const { t } = useTranslation('trees');
   const items: StatGridItem[] = [
@@ -307,6 +323,11 @@ interface WarningListProps {
   label: string;
 }
 
+/**
+ * Collapsible list of non-fatal scan warnings. Renders inside a
+ * `<details>` so the user can expand individual messages without the
+ * panel dominating the modal when there are many warnings.
+ */
 function WarningList({ warnings, label }: WarningListProps): JSX.Element {
   return (
     <details className="border-warning/40 bg-warning/5 rounded-lg border p-3 text-sm">
@@ -325,6 +346,11 @@ interface ErrorListProps {
   label: string;
 }
 
+/**
+ * Always-visible list of fatal scan errors. Rendered as `role="alert"`
+ * so assistive tech announces it; the modal's submit button stays
+ * disabled while there are entries here.
+ */
 function ErrorList({ errors, label }: ErrorListProps): JSX.Element {
   return (
     <div

--- a/src/components/trees/import-gedcom-modal.tsx
+++ b/src/components/trees/import-gedcom-modal.tsx
@@ -117,6 +117,10 @@ export function ImportGedcomModal({
     },
   });
 
+  // Reset form state every time the modal closes. `initialSelection`
+  // is intentionally omitted from the dep array — it's a story-only
+  // seam that never changes mid-session, and adding it would force a
+  // reset on every render.
   useEffect(() => {
     if (!open) {
       setSelected(initialSelection ?? null);

--- a/src/components/trees/import-gedcom-modal.tsx
+++ b/src/components/trees/import-gedcom-modal.tsx
@@ -134,8 +134,10 @@ export function ImportGedcomModal({
       });
       setName(deriveTreeName(file.name));
     } catch (err) {
+      // Raw parser/Tauri errors are not translated — log them, surface
+      // a generic localized message in the UI instead.
       console.error('Failed to read or scan GEDCOM file:', err);
-      setScanError(err instanceof Error ? err.message : t('importGedcom.errorScan'));
+      setScanError(t('importGedcom.errorScan'));
     }
   };
 

--- a/src/components/trees/import-gedcom-modal.tsx
+++ b/src/components/trees/import-gedcom-modal.tsx
@@ -10,23 +10,20 @@ import { Input } from '$components/ui/input';
 import { StatGrid, type StatGridItem } from '$components/ui/stat-grid';
 import { Switch } from '$components/ui/switch';
 import { GedcomManager, type ImportResult, type ScanResult } from '$/managers/GedcomManager';
+import { formatBytes } from '$lib/format';
 import { queryKeys } from '$lib/query-keys';
 
 /**
- * In-memory description of the user's GEDCOM selection. Lives only
- * inside the modal — the file path is captured for the Tauri-side
- * import flow but the file is never re-read.
+ * In-memory description of the user's GEDCOM selection. The full
+ * content is held in state because we already paid the read cost once
+ * to scan it; re-reading at submit would mean a second Tauri IPC
+ * round-trip for the same bytes.
  */
 interface SelectedFile {
-  /** Absolute path returned by Tauri's open dialog. */
   path: string;
-  /** Filename with extension (e.g. `tree.ged`). */
   name: string;
-  /** Full UTF-8 content read once at selection time. */
   content: string;
-  /** Byte length of the content in UTF-8. */
   size: number;
-  /** Result of `GedcomManager.scan(content)`. */
   scan: ScanResult;
 }
 
@@ -44,20 +41,9 @@ export interface ImportGedcomModalProps {
   onImported?: (result: ImportResult) => void;
 
   /**
-   * Override the file-content reader. Defaults to Tauri's
-   * `readTextFile`. Tests/stories inject a spy here so the flow can be
-   * exercised without hitting the Tauri filesystem plugin.
-   */
-  readFileContent?: (path: string) => Promise<string>;
-
-  /**
-   * Override the scan function. Defaults to {@link GedcomManager.scan}.
-   */
-  scan?: (content: string) => ScanResult;
-
-  /**
    * Override the import function. Defaults to
-   * {@link GedcomManager.importFromContent}.
+   * {@link GedcomManager.importFromContent}. Stories inject a spy here
+   * to assert what the submit handler passes downstream.
    */
   importTree?: (content: string, treeName: string) => Promise<ImportResult>;
 
@@ -69,15 +55,13 @@ export interface ImportGedcomModalProps {
   initialSelection?: SelectedFile;
 }
 
-const defaultReadFileContent = async (path: string): Promise<string> => {
-  const { readTextFile } = await import('@tauri-apps/plugin-fs');
-  return readTextFile(path);
-};
-
-const defaultScan = (content: string): ScanResult => GedcomManager.scan(content);
-
 const defaultImportTree = (content: string, treeName: string): Promise<ImportResult> =>
   GedcomManager.importFromContent(content, treeName);
+
+async function readGedcomFile(path: string): Promise<string> {
+  const { readTextFile } = await import('@tauri-apps/plugin-fs');
+  return readTextFile(path);
+}
 
 /**
  * Strip the extension and any leading directory off a filename to get
@@ -100,8 +84,6 @@ export function ImportGedcomModal({
   open,
   onOpenChange,
   onImported,
-  readFileContent = defaultReadFileContent,
-  scan = defaultScan,
   importTree = defaultImportTree,
   initialSelection,
 }: ImportGedcomModalProps): JSX.Element {
@@ -142,14 +124,13 @@ export function ImportGedcomModal({
   const handleFileSelected = async (file: { path: string; name: string }): Promise<void> => {
     setScanError(null);
     try {
-      const content = await readFileContent(file.path);
-      const scanResult = scan(content);
+      const content = await readGedcomFile(file.path);
       setSelected({
         path: file.path,
         name: file.name,
         content,
-        size: new Blob([content]).size,
-        scan: scanResult,
+        size: new TextEncoder().encode(content).length,
+        scan: GedcomManager.scan(content),
       });
       setName(deriveTreeName(file.name));
     } catch (err) {
@@ -384,10 +365,4 @@ function SoonSwitch({ label }: SoonSwitchProps): JSX.Element {
       }
     />
   );
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/src/i18n/locales/en/trees.json
+++ b/src/i18n/locales/en/trees.json
@@ -70,5 +70,35 @@
   },
   "actions": {
     "comingSoon": "Coming soon."
+  },
+  "importGedcom": {
+    "title": "Import GEDCOM",
+    "subtitle": "Drop a .ged file or click to select.",
+    "dropzoneLabel": "Drop a .ged file here, or click to browse",
+    "dropzoneHint": "Accepts .ged or .gedcom",
+    "dropzoneFormatName": "GEDCOM",
+    "fileBadge": "GED",
+    "fileEncoding": "UTF-8",
+    "clearFileLabel": "Choose a different file",
+    "scanIndividuals": "Individuals",
+    "scanFamilies": "Families",
+    "scanPlaces": "Places",
+    "scanSources": "Sources",
+    "warningsLabel_one": "{{count}} warning",
+    "warningsLabel_other": "{{count}} warnings",
+    "errorsLabel": "Errors",
+    "nameLabel": "Tree name",
+    "namePlaceholder": "e.g., Bourgoin family",
+    "optionsLabel": "Options",
+    "mergeDuplicatesLabel": "Merge duplicates",
+    "importMediaLabel": "Import linked media (OBJE)",
+    "hideLivingLabel": "Hide living people",
+    "footerNote": "Original file will not be modified.",
+    "cancel": "Cancel",
+    "submit": "Import tree",
+    "soonLabel": "Soon",
+    "closeLabel": "Close",
+    "errorScan": "Failed to read GEDCOM file.",
+    "errorGeneric": "Failed to import GEDCOM."
   }
 }

--- a/src/i18n/locales/fr/trees.json
+++ b/src/i18n/locales/fr/trees.json
@@ -70,5 +70,35 @@
   },
   "actions": {
     "comingSoon": "Bientôt."
+  },
+  "importGedcom": {
+    "title": "Importer GEDCOM",
+    "subtitle": "Déposez un fichier .ged ou cliquez pour le sélectionner.",
+    "dropzoneLabel": "Déposez un fichier .ged ici, ou cliquez pour parcourir",
+    "dropzoneHint": "Accepte .ged ou .gedcom",
+    "dropzoneFormatName": "GEDCOM",
+    "fileBadge": "GED",
+    "fileEncoding": "UTF-8",
+    "clearFileLabel": "Choisir un autre fichier",
+    "scanIndividuals": "Individus",
+    "scanFamilies": "Familles",
+    "scanPlaces": "Lieux",
+    "scanSources": "Sources",
+    "warningsLabel_one": "{{count}} avertissement",
+    "warningsLabel_other": "{{count}} avertissements",
+    "errorsLabel": "Erreurs",
+    "nameLabel": "Nom de l'arbre",
+    "namePlaceholder": "ex. Famille Bourgoin",
+    "optionsLabel": "Options",
+    "mergeDuplicatesLabel": "Fusionner les doublons",
+    "importMediaLabel": "Importer les médias liés (OBJE)",
+    "hideLivingLabel": "Masquer les personnes vivantes",
+    "footerNote": "Le fichier d'origine ne sera pas modifié.",
+    "cancel": "Annuler",
+    "submit": "Importer l'arbre",
+    "soonLabel": "Bientôt",
+    "closeLabel": "Fermer",
+    "errorScan": "Échec de la lecture du fichier GEDCOM.",
+    "errorGeneric": "Échec de l'importation GEDCOM."
   }
 }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -6,3 +6,16 @@ export function formatIsoDate(value: string | number | Date | null | undefined):
     return '—';
   }
 }
+
+const KB = 1024;
+const MB = 1024 * 1024;
+
+/**
+ * Format a byte count for human display (e.g., `12 B`, `1.4 KB`,
+ * `2.3 MB`). One decimal place above 1 KB.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < KB) return `${bytes} B`;
+  if (bytes < MB) return `${(bytes / KB).toFixed(1)} KB`;
+  return `${(bytes / MB).toFixed(1)} MB`;
+}

--- a/src/managers/GedcomManager.test.ts
+++ b/src/managers/GedcomManager.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+
+import { GedcomManager } from './GedcomManager';
+
+describe('GedcomManager.scan', () => {
+  it('counts top-level records and reports zero places', () => {
+    const content = [
+      '0 HEAD',
+      '1 SOUR Vata',
+      '0 @I1@ INDI',
+      '1 NAME John /Doe/',
+      '0 @I2@ INDI',
+      '1 NAME Jane /Doe/',
+      '0 @F1@ FAM',
+      '1 HUSB @I1@',
+      '1 WIFE @I2@',
+      '0 @S1@ SOUR',
+      '1 TITL A Source',
+      '0 @R1@ REPO',
+      '1 NAME An Archive',
+      '0 TRLR',
+    ].join('\n');
+
+    const result = GedcomManager.scan(content);
+
+    expect(result.individuals).toBe(2);
+    expect(result.families).toBe(1);
+    expect(result.sources).toBe(1);
+    expect(result.repositories).toBe(1);
+    expect(result.places).toBe(0);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('splits errors from warnings', () => {
+    const content = ['0 @I1@ INDI', '1 FAMS @MISSING@', '0 INDI', '0 TRLR'].join('\n');
+
+    const result = GedcomManager.scan(content);
+
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.errors.some((m) => m.toLowerCase().includes('missing xref'))).toBe(true);
+    expect(result.warnings.some((m) => m.toLowerCase().includes('undefined xref'))).toBe(true);
+  });
+
+  it('returns zero counts and a single error on empty content', () => {
+    const result = GedcomManager.scan('');
+
+    expect(result.individuals).toBe(0);
+    expect(result.families).toBe(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/managers/GedcomManager.ts
+++ b/src/managers/GedcomManager.ts
@@ -29,6 +29,23 @@ export interface ValidationResult {
 }
 
 /**
+ * Pre-import scan summary surfaced by the Import GEDCOM modal.
+ *
+ * `places` is exposed for the UI but always 0 today — the local parser
+ * counts top-level records (INDI, FAM, SOUR, REPO) and does not yet
+ * dedupe PLAC sub-tags inside events.
+ */
+export interface ScanResult {
+  individuals: number;
+  families: number;
+  places: number;
+  sources: number;
+  repositories: number;
+  errors: string[];
+  warnings: string[];
+}
+
+/**
  * Manages GEDCOM import/export operations.
  */
 export class GedcomManager {
@@ -178,6 +195,40 @@ export class GedcomManager {
         individuals: result.stats.individuals,
         families: result.stats.families,
       },
+    };
+  }
+
+  /**
+   * Scan GEDCOM content for the import preview.
+   *
+   * Counts top-level records and splits errors from warnings so the
+   * modal can render two distinct lists. `places` is always 0 — see
+   * {@link ScanResult.places}.
+   *
+   * @param content - GEDCOM text content
+   * @returns Scan result with counts and split error/warning lists
+   */
+  static scan(content: string): ScanResult {
+    const result = validate(content);
+
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    for (const err of result.errors) {
+      if (err.severity === 'warning') {
+        warnings.push(err.message);
+      } else {
+        errors.push(err.message);
+      }
+    }
+
+    return {
+      individuals: result.stats.individuals,
+      families: result.stats.families,
+      places: 0,
+      sources: result.stats.sources,
+      repositories: result.stats.repositories,
+      errors,
+      warnings,
     };
   }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -7,13 +7,13 @@ import packageJson from '../../package.json';
 import { AppStatusBar } from '$components/app-status-bar';
 import { PreferencesPopover } from '$components/preferences-popover';
 import { EditTreeModal } from '$components/trees/edit-tree-modal';
+import { ImportGedcomModal } from '$components/trees/import-gedcom-modal';
 import { NewTreeModal } from '$components/trees/new-tree-modal';
 import { TreeCard, type TreeCardLabels } from '$components/trees/tree-card';
 import { TreeCardCta } from '$components/trees/tree-card-cta';
 import { TreeSectionDivider } from '$components/trees/tree-section-divider';
 import { Button } from '$components/ui/button';
 import { getAllTrees } from '$db-system/trees';
-import { GedcomManager } from '$/managers/GedcomManager';
 import { TreeManager } from '$/managers/TreeManager';
 import { formatIsoDate } from '$lib/format';
 import { queryKeys } from '$lib/query-keys';
@@ -40,10 +40,9 @@ function sortTrees(trees: Tree[], key: SortKey): Tree[] {
 export function HomePage(): JSX.Element {
   const { t } = useTranslation(['common', 'trees']);
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const [sort, setSort] = useState<SortKey>('recent');
-  const [importError, setImportError] = useState<string | null>(null);
   const [newTreeOpen, setNewTreeOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
   const [editingTree, setEditingTree] = useState<Tree | null>(null);
 
   const {
@@ -53,18 +52,6 @@ export function HomePage(): JSX.Element {
   } = useQuery({
     queryKey: queryKeys.trees,
     queryFn: getAllTrees,
-  });
-
-  const importMutation = useMutation({
-    mutationFn: () => GedcomManager.importFromFile(),
-    onSuccess: () => {
-      setImportError(null);
-      void queryClient.invalidateQueries({ queryKey: queryKeys.trees });
-    },
-    onError: (err) => {
-      console.error('GEDCOM import failed:', err);
-      setImportError(err instanceof Error ? err.message : t('common:errors.importFailed'));
-    },
   });
 
   const sortedTrees = useMemo<Tree[]>(() => (trees ? sortTrees(trees, sort) : []), [trees, sort]);
@@ -164,20 +151,10 @@ export function HomePage(): JSX.Element {
               <Button leadingIcon="plus" onClick={() => setNewTreeOpen(true)}>
                 {t('trees:home.heroNew')}
               </Button>
-              <Button
-                variant="outline"
-                leadingIcon="download"
-                onClick={() => importMutation.mutate()}
-                disabled={importMutation.isPending}
-              >
+              <Button variant="outline" leadingIcon="download" onClick={() => setImportOpen(true)}>
                 {t('trees:home.heroImport')}
               </Button>
             </div>
-            {importError && (
-              <p role="alert" className="text-destructive mt-2 text-sm">
-                {importError}
-              </p>
-            )}
           </section>
 
           {treesContent}
@@ -202,6 +179,7 @@ export function HomePage(): JSX.Element {
       />
 
       <NewTreeModal open={newTreeOpen} onOpenChange={setNewTreeOpen} />
+      <ImportGedcomModal open={importOpen} onOpenChange={setImportOpen} />
       {editingTree && (
         <EditTreeModal
           tree={editingTree}


### PR DESCRIPTION
## Summary

Adds the **Import GEDCOM** modal triggered by the home-page hero button, replacing the current direct call to `GedcomManager.importFromFile()` plus the inline `role="alert"` error block on `Home.tsx`. The modal owns the full scan-preview-then-submit flow described in the mockup.

## What's in the box

- **`ImportGedcomModal`** (`src/components/trees/import-gedcom-modal.tsx`)
  - Pre-selection: `Dropzone` (click to browse via Tauri's file dialog).
  - Post-selection: file row, 4-cell scan grid (Indiv / Fam / Places / Sources), warnings + errors lists, name input pre-filled from the filename, options panel.
  - Cosmetic toggles render as disabled `Soon` switches — the import pipeline doesn't honor them yet, so we don't pretend to wire them.
- **`GedcomManager.scan(content)`** wraps the local parser's `validate()` and splits errors from warnings. `places` is always 0 today (the parser counts top-level records and doesn't dedupe `PLAC` sub-tags yet); the slot stays so the UI matches the mockup.
- 6 `play()` stories + 3 unit tests for `scan()`.
- Lifts `formatBytes` to `src/lib/format.ts` so the upcoming `DownloadTreeModal` can reuse it.

## Notes for reviewers

- `initialSelection` is a story-only test seam (documented in the prop's JSDoc) so post-selection states can be exercised without driving Tauri's file dialog.
- The `<details>` warning panel is collapsed by default; errors are always visible and block submit.
- French strings added to `src/i18n/locales/fr/trees.json`.

## Test plan

- [x] `pnpm tsc --noEmit` (no new errors; pre-existing popover errors unchanged on main)
- [x] `pnpm vitest run --project unit src/managers/GedcomManager.test.ts` — 3 passing
- [x] `pnpm vitest run --project storybook src/components/trees/import-gedcom-modal.stories.tsx` — 6 passing
- [x] `pnpm build` clean
- [ ] Manual: `pnpm tauri:dev` → Import GEDCOM → pick a real `.ged` → import succeeds and tree appears

Closes #93
