### PR TITLE
chore(skills): add shepherd-pr skill + draft-by-default PR override

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,0 +1,23 @@
+---
+allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
+description: Commit, push, and open a PR (draft by default for this repo)
+---
+
+## Context
+
+- Current git status: !`git status`
+- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+
+## Your task
+
+Based on the above changes:
+
+1. Create a new branch if on main
+2. Create a single commit with an appropriate message
+3. Push the branch to origin
+4. Create a pull request using `gh pr create --draft`. **The `--draft` flag is required.**
+
+   This repo opens every PR as draft so CodeRabbit's automatic review fires only after the local `/review` gate has run. The `shepherd-pr` skill takes it from here — it executes `/review`, addresses real findings, marks the PR ready (`gh pr ready <N>`), then watches CI and CodeRabbit until approval.
+
+5. You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.

--- a/.claude/skills/shepherd-pr/SKILL.md
+++ b/.claude/skills/shepherd-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Drive a freshly opened PR through the local `/review` gate, the rea
 
 # Shepherd PR
 
-Takes a freshly opened PR from "just pushed" to "CodeRabbit-approved" without manual polling. Backed by `gh` + GraphQL — no MCP, no API key.
+Takes a freshly opened PR from "just pushed" to "CodeRabbit-approved" without manual polling. Backed by `gh` CLI + GraphQL — no MCP, no API key.
 
 The skill runs **after** PR creation. Pre-PR cleanup belongs to `/simplify`.
 

--- a/.claude/skills/shepherd-pr/SKILL.md
+++ b/.claude/skills/shepherd-pr/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: shepherd-pr
+description: Drive a freshly opened PR through the local `/review` gate, the ready-flip, CI, and CodeRabbit until the bot posts an APPROVED review with all non-Chromatic checks green. Use immediately after `gh pr create` (or `/commit-push-pr`) returns, or when the user says things like "watch the PR", "wait for CodeRabbit", "make sure CI passes", "shepherd PR #N". Polls check status, parses CodeRabbit's rate-limit messages, retriggers stalled reviews, triages inline threads (fix-and-push vs reply-and-resolve), and stops when approval arrives or a real blocker needs the user.
+---
+
+# Shepherd PR
+
+Takes a freshly opened PR from "just pushed" to "CodeRabbit-approved" without manual polling. Backed by `gh` + GraphQL — no MCP, no API key.
+
+The skill runs **after** PR creation. Pre-PR cleanup belongs to `/simplify`.
+
+---
+
+## When to invoke
+
+- Right after `gh pr create --draft` (or `/commit-push-pr`) returns a PR URL.
+- When the user says "watch PR #N", "wait for CodeRabbit", "shepherd this", "make sure CI passes".
+
+Do **not** invoke before a PR exists. Do not invoke for `/simplify` (that's the pre-PR cleanup, separate skill).
+
+---
+
+## The loop at a glance
+
+```
+draft PR
+  → Phase 0: /review locally → fixes → gh pr ready
+  → Phase 1: wait CI (ignore Chromatic)
+  → Phase 2: read CodeRabbit verdict
+       ├─ APPROVED       → done
+       ├─ CHANGES_REQ.   → Phase 3 (triage)
+       └─ rate-limited   → wait + retrigger, loop
+  → Phase 3: triage threads (fix-and-push OR reply-and-resolve)
+  → Phase 4: retrigger CodeRabbit, loop back to Phase 1
+```
+
+---
+
+## Phase 0 — Draft + local `/review` gate
+
+Runs immediately after the PR is created, **before any polling and before CodeRabbit is allowed to fire**. The whole point is to land at a clean state before flipping the PR to ready.
+
+### 1. Confirm draft state
+
+```bash
+gh pr view <N> --repo vata-apps/vata-app --json isDraft
+```
+
+If `isDraft` is `false`, mark it back to draft:
+
+```bash
+gh pr ready <N> --repo vata-apps/vata-app --undo
+```
+
+The draft state holds CodeRabbit off — its workflow skips drafts, so we don't burn the hourly per-developer rate-limit budget on a review we're about to invalidate.
+
+### 2. Run `/review`
+
+Invoke the `/review` slash command. It performs a local AI review of the branch diff, distinct from CodeRabbit's later automatic pass.
+
+### 3. Apply real findings only
+
+Same triage table as Phase 3 below — fix-and-push for genuine bugs, ignore for nits / false positives / suggestions that contradict project rules. Bundle fixes into one or two follow-up commits.
+
+### 4. Flip to ready
+
+Once `/review` is clean:
+
+```bash
+gh pr ready <N> --repo vata-apps/vata-app
+```
+
+This is the explicit handoff to CodeRabbit. From here CI also begins to matter — proceed to Phase 1.
+
+---
+
+## Phase 1 — Wait for CI checks to settle
+
+Use the `Monitor` tool with the canonical poll:
+
+```bash
+gh pr checks <N> --repo vata-apps/vata-app --json name,bucket
+```
+
+**Treat `UI Review` and `UI Tests` (Chromatic) as expected-pending and ignore them.** `.github/workflows/chromatic.yml` deliberately runs with `exitZeroOnChanges: true`; the user approves Chromatic baselines manually on a separate cadence.
+
+Required-green checks (must reach `pass` before declaring success): `Lint, Format, Build & Test`, `Visual review`, `CodeRabbit`, `Storybook Publish`.
+
+If `Lint, Format, Build & Test` fails, fix the failure (lint, types, broken test), push, and re-enter Phase 1. Do not move on while it's red.
+
+---
+
+## Phase 2 — Read CodeRabbit's verdict
+
+```bash
+gh pr view <N> --repo vata-apps/vata-app --json reviews \
+  | jq '[.reviews[] | select(.author.login=="coderabbitai")] | last | {state, at: .submittedAt}'
+```
+
+Three mutually exclusive states:
+
+### Approved
+
+`state == APPROVED`. All non-Chromatic checks green. **Done — exit and hand back to the user.**
+
+### Changes requested
+
+`state == CHANGES_REQUESTED`. Go to Phase 3.
+
+### No review yet despite `CodeRabbit: pass` check
+
+The check status reflects the bot's workflow finishing, not a posted review. Scan issue-level comments for the literal string `Rate limit exceeded`:
+
+```bash
+gh api repos/vata-apps/vata-app/issues/<N>/comments \
+  | jq '.[] | select(.body | contains("Rate limit exceeded")) | .body' \
+  | head -c 500
+```
+
+The bot tells you exactly how long to wait — `Please wait X minutes and Y seconds`. Schedule a wakeup ~2 minutes past that, then post:
+
+```bash
+gh pr comment <N> --repo vata-apps/vata-app --body "@coderabbitai full review"
+```
+
+Re-enter Phase 1. If after one full retrigger CodeRabbit still hasn't posted a review, push a one-line nudge commit (e.g., a clarifying inline comment in the diff). The push triggers a fresh review path that the comment-only retrigger sometimes misses.
+
+---
+
+## Phase 3 — Triage inline threads
+
+List inline review comments:
+
+```bash
+gh api repos/vata-apps/vata-app/pulls/<N>/comments \
+  | jq '.[] | {id, path, line, body: .body[0:300]}'
+```
+
+For each comment, decide:
+
+| Finding type                                                  | Action                                                                                                                                            |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Real bug or genuine quality fix                               | Apply in code, run `pnpm lint && pnpm tsc --noEmit`, push commit. CodeRabbit auto-resolves the thread on next review.                             |
+| False positive / nit / suggestion contradicting project rules | Reply with reasoning via `gh api repos/.../pulls/<N>/comments/<id>/replies`, then resolve via GraphQL `resolveReviewThread`. **Don't push code.** |
+
+### Canonical contradiction (memorise)
+
+CodeRabbit periodically suggests surfacing `err.message` directly to end users. The project's `# English Only` / i18n rule (CLAUDE.md) forbids hardcoded English in client-facing strings — raw Tauri/parser/DB errors are not localized. **Resolution:** reply with a one-sentence pointer to the i18n rule (and to the precedent on PR #118), resolve the thread, leave the localized `errorGeneric` in place. Do not change code.
+
+### Resolving a thread
+
+Find the unresolved thread IDs:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "vata-apps", name: "vata-app") {
+    pullRequest(number: <N>) {
+      reviewThreads(first: 20) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) { nodes { databaseId path line } }
+        }
+      }
+    }
+  }
+}'
+```
+
+Reply on the inline comment:
+
+```bash
+gh api repos/vata-apps/vata-app/pulls/<N>/comments/<comment_id>/replies \
+  -X POST -f body="<reasoning>"
+```
+
+Then resolve:
+
+```bash
+gh api graphql -f query='mutation{resolveReviewThread(input:{threadId:"<thread_id>"}){thread{id isResolved}}}'
+```
+
+---
+
+## Phase 4 — Retrigger and re-poll
+
+After pushing a fix or resolving threads-only, post:
+
+```bash
+gh pr comment <N> --repo vata-apps/vata-app --body "@coderabbitai full review"
+```
+
+A push alone also retriggers, but the explicit comment is more reliable when the only change was thread resolution.
+
+If rate-limited again, loop back to the wait-then-retrigger logic from Phase 2.
+
+---
+
+## Pre-merge checks (CodeRabbit's top-level review)
+
+CodeRabbit's review body lists named pre-merge checks. Most pass automatically when the PR follows the standard template (Title, Description, Linked Issues, Out-of-Scope). The one that bites in this repo:
+
+- **Docstring Coverage ≥ 80 %**. Below threshold renders as a warning (`⚠️`), but a warning is enough to block approval. **Mitigation:** when shipping a multi-component file, proactively docstring every new helper / sub-component / non-trivial function. PR #118 hit this and needed a follow-up commit; PR #120 cleared it on the first pass after this rule was internalised.
+
+---
+
+## Stop conditions
+
+1. CodeRabbit's latest review is `APPROVED` AND all non-Chromatic checks are `pass`. → success, hand back to the user.
+2. Two consecutive rate-limit retriggers fail to produce a new review. → escalate with a one-line summary.
+3. A finding requires user judgment (e.g., an architectural disagreement, a backwards-compat call, or a security-sensitive trade-off). → escalate with a one-paragraph summary.
+
+The user merges. This skill never runs `gh pr merge`.
+
+---
+
+## What this skill must not do
+
+- Auto-merge the PR. Chromatic baselines may still be pending; the user owns merge.
+- Override the `Closes #N` footer from `link-task` Phase B.
+- Apply CodeRabbit suggestions blindly — every thread goes through the triage table.
+- Push to `main` or any branch other than the PR's own.
+- Skip `pnpm lint && pnpm tsc --noEmit` after applying a CR fix before pushing.
+- Flip the PR to ready before Phase 0 (`/review`) is clean — premature `gh pr ready` wakes CodeRabbit on a state we're still cleaning up and burns rate-limit budget.
+
+---
+
+## Useful commands (cheat sheet)
+
+```bash
+# Confirm draft state (Phase 0 entry)
+gh pr view <N> --repo vata-apps/vata-app --json isDraft
+
+# Flip to ready once /review is clean (Phase 0 exit)
+gh pr ready <N> --repo vata-apps/vata-app
+
+# Settled-state CI check (excluding Chromatic)
+gh pr checks <N> --repo vata-apps/vata-app --json name,bucket \
+  | jq '[.[] | select(.name|test("UI Review|UI Tests")|not)]'
+
+# Latest CodeRabbit review state
+gh pr view <N> --repo vata-apps/vata-app --json reviews \
+  | jq '[.reviews[] | select(.author.login=="coderabbitai")] | last | {state, at: .submittedAt}'
+
+# Inline review comments
+gh api repos/vata-apps/vata-app/pulls/<N>/comments
+
+# Reply on an inline thread
+gh api repos/vata-apps/vata-app/pulls/<N>/comments/<comment_id>/replies \
+  -X POST -f body="<reasoning>"
+
+# Resolve an inline thread
+gh api graphql -f query='mutation{resolveReviewThread(input:{threadId:"<id>"}){thread{id isResolved}}}'
+
+# Find unresolved thread IDs + their first comment
+gh api graphql -f query='{repository(owner:"vata-apps",name:"vata-app"){pullRequest(number:<N>){reviewThreads(first:20){nodes{id isResolved comments(first:1){nodes{databaseId path line}}}}}}}'
+
+# Retrigger CR after rate-limit
+gh pr comment <N> --repo vata-apps/vata-app --body "@coderabbitai full review"
+```
+
+---
+
+## Edge cases
+
+- **PR opened against a non-`main` base.** Same skill applies; `gh pr` operations don't care about the base branch.
+- **CI failure not in the named-green list.** If a workflow not in the required list fails (e.g., a one-off `Codecov` job), report the failure to the user and pause — don't silently skip it.
+- **Repo (`vata-apps/vata-app`) is hardcoded.** Same convention as `link-task`. This skill lives in the Vata repo; cross-repo use needs a different skill.
+- **Forked PR / contributor without write access.** This skill runs as the PR author. If CodeRabbit insists on changes the agent cannot make (e.g., labels, milestones), escalate.
+- **CodeRabbit posts a `COMMENTED` review after `APPROVED`.** Don't panic — `COMMENTED` is informational and does not dismiss `APPROVED`. Treat the latest non-`COMMENTED` CodeRabbit review as the verdict.

--- a/.claude/skills/shepherd-pr/SKILL.md
+++ b/.claude/skills/shepherd-pr/SKILL.md
@@ -22,10 +22,10 @@ Do **not** invoke before a PR exists. Do not invoke for `/simplify` (that's the 
 
 ## The loop at a glance
 
-```
+```text
 draft PR
   → Phase 0: /review locally → fixes → gh pr ready
-  → Phase 1: wait CI (ignore Chromatic)
+  → Phase 1: wait CI (ignore Chromatic baseline gates)
   → Phase 2: read CodeRabbit verdict
        ├─ APPROVED       → done
        ├─ CHANGES_REQ.   → Phase 3 (triage)
@@ -239,7 +239,9 @@ gh pr view <N> --repo vata-apps/vata-app --json isDraft
 # Flip to ready once /review is clean (Phase 0 exit)
 gh pr ready <N> --repo vata-apps/vata-app
 
-# Settled-state CI check (excluding Chromatic)
+# Settled-state CI check (excluding the expected-pending Chromatic
+# baseline gates `UI Review` and `UI Tests` — the build/deploy
+# Chromatic jobs `Visual review` and `Storybook Publish` stay in)
 gh pr checks <N> --repo vata-apps/vata-app --json name,bucket \
   | jq '[.[] | select(.name|test("UI Review|UI Tests")|not)]'
 

--- a/.claude/skills/shepherd-pr/SKILL.md
+++ b/.claude/skills/shepherd-pr/SKILL.md
@@ -82,7 +82,11 @@ Use the `Monitor` tool with the canonical poll:
 gh pr checks <N> --repo vata-apps/vata-app --json name,bucket
 ```
 
-**Treat `UI Review` and `UI Tests` (Chromatic) as expected-pending and ignore them.** `.github/workflows/chromatic.yml` deliberately runs with `exitZeroOnChanges: true`; the user approves Chromatic baselines manually on a separate cadence.
+Three of the checks come from Chromatic, and they're **not** all the same thing — don't conflate them:
+
+- `Visual review` is the Chromatic build job. It runs `exitZeroOnChanges: true`, so it almost always reaches `pass`. **Required green.**
+- `Storybook Publish` is the static deploy of the Storybook bundle. **Required green.**
+- `UI Review` and `UI Tests` are Chromatic's baseline-approval gates. They stay `pending` until the user approves baselines manually in the Chromatic dashboard, on a separate cadence. **Expected-pending — ignore.**
 
 Required-green checks (must reach `pass` before declaring success): `Lint, Format, Build & Test`, `Visual review`, `CodeRabbit`, `Storybook Publish`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,9 +282,11 @@ chore: upgrade drizzle-orm to 0.30.0
 Before creating a pull request (via `gh pr create`, any slash command that opens a PR, or any other means), the agent MUST:
 
 1. Run `/simplify` to launch the three-agent reuse / quality / efficiency review on the branch diff. Apply the fixes that are real issues; skip false positives and stylistic nits.
-2. Then create the PR.
+2. Then create the PR. **Always open it as draft** (`gh pr create --draft`, or via `/commit-push-pr` which sets the flag automatically). The draft state holds CodeRabbit off until the local `/review` gate has run, so we don't burn the hourly rate-limit budget on a state we're about to clean up.
 
-CodeRabbit reviews the PR automatically once it is opened — that is the canonical CodeRabbit pass. A local CodeRabbit run is **optional** and can be triggered on demand with `pnpm review` (uncommitted changes) or `pnpm review:all` (full branch diff); it is no longer a required pre-PR step.
+After the PR is opened, invoke the `shepherd-pr` skill. It runs `/review` locally, applies the real findings, flips the PR to ready (`gh pr ready <N>` — that's the explicit handoff to CodeRabbit), then drives CI + CodeRabbit to approval without manual polling.
+
+CodeRabbit reviews the PR automatically once it is marked ready — that is the canonical CodeRabbit pass. A local CodeRabbit run is **optional** and can be triggered on demand with `pnpm review` (uncommitted changes) or `pnpm review:all` (full branch diff); it is no longer a required pre-PR step.
 
 ---
 
@@ -319,6 +321,7 @@ The following specialized skills are loaded automatically when relevant, or on d
 | `new-route`               | When adding a new page or entity view under `/tree/$treeId/`                                                                                                                     |
 | `storybook-stories`       | When touching anything under `src/components/ui/` (wrappers + their `*.stories.tsx`) or any `*.stories.tsx` elsewhere                                                            |
 | `design-system-standards` | When designing or reviewing UI under `src/components/ui/`, `src/components/**`, or `src/pages/**` — decision tree for reuse / extend / create-new, token rules, audit heuristics |
+| `shepherd-pr`             | After `gh pr create` returns — drives the PR through `/review`, the ready-flip, CI, and CodeRabbit until it's approved or surfaces a real blocker                                |
 
 The UI layer is built on Tailwind v4 (CSS-first via `@theme` in `src/styles/app.css`) + Radix primitives + `tailwind-variants`. Wrappers live under `src/components/ui/` with colocated tests and Storybook stories. See `docs/ui/design-system.md` and `docs/ui/storybook.md`.
 


### PR DESCRIPTION
## Summary

Encodes the post-PR loop we ran manually for PRs #118 / #119 / #120 (Import / Download / Delete tree modals) so the next dev task — and CodeRabbit itself, since `.coderabbit.yaml` ingests `.claude/skills/**/SKILL.md` as `code_guidelines` — has a single source of truth.

## What's in the box

- **`.claude/skills/shepherd-pr/SKILL.md`** — drives a PR from "just pushed" to "CodeRabbit-approved":
  - **Phase 0**: confirms draft state, runs the local `/review` slash command, applies real findings, flips the PR to ready (`gh pr ready`). The point is to land at a clean state before CodeRabbit fires its hourly-rate-limited review.
  - **Phase 1**: polls CI via `Monitor`, treats Chromatic (`UI Review`, `UI Tests`) as expected-pending, requires the rest to be green.
  - **Phase 2**: reads CodeRabbit's verdict — APPROVED / CHANGES_REQUESTED / rate-limited (parses the bot's own "wait X minutes" message).
  - **Phase 3**: triages each inline thread — fix-and-push for real bugs; reply + resolve via GraphQL `resolveReviewThread` for false positives. Includes the canonical contradiction (CodeRabbit asking for raw `err.message` violates the project's i18n rule) and the resolution.
  - **Phase 4**: retriggers via `@coderabbitai full review` (or a one-line nudge commit when the comment-trigger stalls), loops.
- **`.claude/commands/commit-push-pr.md`** — project-level override of the `commit-commands:commit-push-pr` plugin. Same behavior, with `gh pr create --draft` baked in. Versioned with the repo, survives plugin updates.
- **`CLAUDE.md`** — Pre-PR Review section now mandates draft-by-default and points at `shepherd-pr`; Available Skills table gains a row.

## Why this matters

When we shipped #118/#119/#120 last night, CodeRabbit's hourly per-developer rate limit forced ~50 min waits on every retrigger, and one of its findings (surface raw `err.message` to users) directly contradicted the project's i18n rule and what CodeRabbit itself had endorsed on PR1. Both classes of friction are now encoded:

- **Draft-by-default** keeps CodeRabbit asleep until `/review` has had its pass — no more burning rate-limit budget on a state we're about to clean up.
- **Triage table** names the canonical contradiction so future-me doesn't relitigate it.
- **`.coderabbit.yaml`** already globs `.claude/skills/**/SKILL.md`, so the bot picks up these guardrails automatically once this PR merges.

## Test plan

- [x] `pnpm format:check` clean.
- [x] `pnpm exec eslint src/` clean (no source touched).
- [ ] **Self-test on this PR**: this PR was opened as draft via `gh pr create --draft`. The `shepherd-pr` skill itself will run `/review`, apply any real findings, then flip to ready. If the loop completes without manual intervention, the skill works.