### PR TITLE
docs(skills): three adjustments from 2-week capture-idea / link-task review

### DIFF
--- a/.claude/skills/capture-idea/SKILL.md
+++ b/.claude/skills/capture-idea/SKILL.md
@@ -18,6 +18,12 @@ Activate as soon as the user expresses one of these intents in either French or 
 
 If the user is asking for the work to be done **now**, this skill does not apply — proceed with the task instead.
 
+## Batch captures
+
+When a planning or design session produces multiple icebox items at once, **invoke this skill once per item** — N items means N separate capture-idea invocations. Do not create a batch of issues via a direct `gh issue create` loop: that path bypasses steps 6 and 7 (Issue Type + Icebox status mutations), leaving items untyped and likely at Status=Todo in the project (the auto-add default) rather than Icebox.
+
+If the user says "file all of these as icebox items", work through the list sequentially, running each item through the full capture flow before moving to the next.
+
 ## Capture flow
 
 Follow these steps in order. Do **not** ask the user for confirmation before creating — the trigger phrase is itself the explicit signal.

--- a/.claude/skills/link-task/SKILL.md
+++ b/.claude/skills/link-task/SKILL.md
@@ -90,6 +90,12 @@ git config branch."$(git branch --show-current)".ghIssue 2>/dev/null
 
 If the value is empty, no link exists for this branch. **Do not search GitHub at PR time** — Phase A is the only entry point for that. Just create the PR without a magic word.
 
+Exception: if the branch name begins with `feat/` or `fix/` and no link is stored, emit a soft one-line warning before proceeding:
+
+> ⚠ No issue linked for this `feat/` branch — if it closes a backlog item, run Phase A first. Continuing without `Closes #N`.
+
+This does not block PR creation — it surfaces the gap so the user can decide to run Phase A retroactively.
+
 ### 2. Inject the magic word
 
 If the value is `<N>`, ensure the PR description body ends with a footer line:

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -148,6 +148,8 @@ Activates on phrases like:
 
 The agent composes a concise English title (and optional body), reads the repo's existing labels, picks 0–2 that match, creates the issue with `gh issue create`, then via GraphQL sets the org-level Issue Type (Feature by default; Bug or Task if context suggests) and pins the Project Status to **Icebox**. Replies with the issue number, type, labels, "Icebox", and URL.
 
+**Batch captures**: when a session produces multiple ideas at once, invoke the skill once per item — never batch via a direct `gh issue create` loop, which bypasses the type and Icebox mutations.
+
 ### `link-task`
 
 Activates at the **start** of a dev task, on phrases like:
@@ -156,11 +158,13 @@ Activates at the **start** of a dev task, on phrases like:
 - "add a feature for Z" / "fix bug W"
 - "commençons sur X" / "on s'attaque à X"
 
+**Habit rule**: for every `feat/` or `fix/` branch, run `link-task` explicitly before writing any code — don't rely on trigger phrases alone. If no matching open issue exists, run `capture-idea` first to file one, then `link-task` to bind it to the branch.
+
 Phase A: searches the repo's open issues via the GraphQL `search` API (returns `issueType` alongside title and state — `gh issue list --json` doesn't expose the type field), lists up to 5 candidates as `#<number> · <type> · <state> · <title>`, lets the user pick from existing open issues. Stores the choice in `git config branch.<branch>.ghIssue`.
 
 **Note**: `link-task` does NOT create new issues — it only links to existing ones. If no matching issue exists, run `capture-idea` to create one first, then run `link-task` to link it.
 
-Phase B: at PR creation, reads that git config and appends `Closes #N` to the description. GitHub auto-closes the linked issue on merge, and the Project's auto-status workflow moves it to **Done**.
+Phase B: at PR creation, reads that git config and appends `Closes #N` to the description. GitHub auto-closes the linked issue on merge, and the Project's auto-status workflow moves it to **Done**. If the branch is `feat/` or `fix/` and no link is stored, Phase B emits a soft warning before proceeding.
 
 ## Manual setup checklist
 
@@ -210,5 +214,5 @@ The bootstrap script prints these manual steps after running.
 - **Auto-add isn't picking up new issues**: the workflow on the Project must be enabled (UI step 4 above).
 - **Forgot to link at task start**: trigger `link-task` mid-task — _"link this task to a GitHub issue"_ — Phase A runs again and overwrites `git config`.
 - **Wrong issue linked**: re-run Phase A; `git config` overwrites cleanly.
-- **PR already opened without `Closes #N`**: edit the PR description manually or via `gh pr edit --body "..."`.
+- **PR already opened without `Closes #N`**: edit the PR description manually or via `gh pr edit --body "..."` .
 - **Issue lacks a Type after capture**: the GraphQL step failed silently. Set the type from the GitHub UI (issue header → "Type" dropdown).


### PR DESCRIPTION
Companion to the adoption review in #123.

Three targeted fixes surfaced by auditing 38 issues and 19 PRs created in the 2 weeks since the skills shipped (PR #66, 2026-05-01).

## Summary

- **link-task `SKILL.md`** — Phase B now emits a soft ⚠ warning when a `feat/` or `fix/` branch has no stored `ghIssue`. Previously silently skipped, leaving issues open indefinitely after merge.
- **capture-idea `SKILL.md`** — New "Batch captures" section. 25 issues were created in one batch via a direct `gh issue create` loop, bypassing the Issue Type + Icebox status mutations. The skill now explicitly documents that batch sessions must invoke it once per item.
- **`docs/dev-tools/issue-tracking.md`** — Added a "Habit rule" to the `link-task` description converting it from phrase-triggered to branch-prefix-proactive: _"for every `feat/` or `fix/` branch, run link-task before any code changes."_ Also added the batch-capture note to the `capture-idea` summary block, and documented Phase B's new warning in the `link-task` summary.

## Test plan

- [ ] Open a `feat/` branch without running Phase A, then trigger `/commit-push-pr` — verify the warning appears before PR creation
- [ ] Trigger `capture-idea` twice in one session for two separate ideas — verify each goes through the full 8-step flow individually
- [ ] Check the three updated files render correctly on GitHub (table alignment, code blocks)

Closes #123

---
_Generated by [Claude Code](https://claude.ai/code/session_01YY21xVraYLAeG8hC4pzCmT)_