### PR TITLE
feat: polish home page hover states and chrome

### DIFF
--- a/src/components/app-status-bar.tsx
+++ b/src/components/app-status-bar.tsx
@@ -62,7 +62,7 @@ export interface AppStatusBarProps {
  *   } : undefined}
  *   preferencesTrigger={
  *     <PreferencesPopover>
- *       <Button variant="outline" size="1">
+ *       <Button variant="soft" size="2">
  *         {t('common:statusBar.preferences')}
  *       </Button>
  *     </PreferencesPopover>
@@ -91,16 +91,11 @@ export function AppStatusBar({
         </Text>
         <Box flexGrow="1" aria-hidden />
         {debug && (
-          <>
-            <Button size="1" variant="outline" color="gray" onClick={debug.onClick}>
-              <Icon name="bug" size={13} />
-              {debug.label}
-              {debug.shortcut && <Kbd size="1">{debug.shortcut}</Kbd>}
-            </Button>
-            <Text size="1" color="gray" aria-hidden>
-              ·
-            </Text>
-          </>
+          <Button size="2" variant="soft" color="gray" onClick={debug.onClick}>
+            <Icon name="bug" size={16} />
+            {debug.label}
+            {debug.shortcut && <Kbd size="1">{debug.shortcut}</Kbd>}
+          </Button>
         )}
         {preferencesTrigger}
       </footer>

--- a/src/components/trees/tree-card-cta.tsx
+++ b/src/components/trees/tree-card-cta.tsx
@@ -30,20 +30,15 @@ export interface TreeCardCtaProps {
 export function TreeCardCta({ title, subtitle, onClick }: TreeCardCtaProps): JSX.Element {
   return (
     <Card asChild variant="surface" size="3" style={{ minHeight: 240, width: '100%' }}>
-      <button type="button" onClick={onClick}>
+      <button type="button" className="tree-card-cta" onClick={onClick}>
         <Flex direction="column" align="center" justify="center" gap="3" height="100%">
           <Flex
             align="center"
             justify="center"
-            style={{
-              width: 56,
-              height: 56,
-              borderRadius: '50%',
-              border: '1px dashed var(--accent-a7)',
-              color: 'var(--accent-11)',
-            }}
+            style={{ position: 'relative', width: 56, height: 56, color: 'var(--accent-11)' }}
           >
-            <Icon name="plus" size={24} />
+            <span className="cta-ring" aria-hidden />
+            <Icon name="plus" size={24} className="cta-plus" />
           </Flex>
           <Flex direction="column" align="center" gap="1">
             <Text size="2" weight="medium">

--- a/src/components/trees/tree-card.tsx
+++ b/src/components/trees/tree-card.tsx
@@ -150,7 +150,7 @@ export function TreeCard({
   onDelete,
 }: TreeCardProps): JSX.Element {
   return (
-    <Card asChild variant="surface" size="3" style={{ minHeight: 240 }}>
+    <Card asChild variant="surface" size="3" className="tree-card" style={{ minHeight: 240 }}>
       <article>
         <Flex direction="column" gap="4" height="100%">
           <Box>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -145,7 +145,15 @@ export function HomePage(): JSX.Element {
 
   return (
     <Flex direction="column" height="100vh">
-      <Box flexGrow="1" overflow="auto">
+      <Box
+        flexGrow="1"
+        overflow="auto"
+        style={{
+          backgroundImage:
+            'radial-gradient(800px 500px at 8% 0%, var(--accent-a2), transparent 70%), ' +
+            'radial-gradient(600px 400px at 100% 100%, var(--accent-a1), transparent 70%)',
+        }}
+      >
         <Box
           style={{
             maxWidth: 1480,
@@ -153,9 +161,6 @@ export function HomePage(): JSX.Element {
             paddingInline: 'clamp(28px, 6vw, 88px)',
             paddingTop: 'clamp(48px, 8vw, 96px)',
             paddingBottom: 56,
-            backgroundImage:
-              'radial-gradient(800px 500px at 8% 0%, var(--accent-a2), transparent 70%), ' +
-              'radial-gradient(600px 400px at 100% 100%, var(--accent-a1), transparent 70%)',
           }}
         >
           <Box style={{ marginBottom: 'clamp(32px, 5vw, 56px)' }}>
@@ -198,8 +203,8 @@ export function HomePage(): JSX.Element {
         }
         preferencesTrigger={
           <PreferencesPopover>
-            <Button variant="outline" size="1" color="gray">
-              <Icon name="settings" size={13} />
+            <Button variant="soft" size="2" color="gray">
+              <Icon name="settings" size={16} />
               {t('common:statusBar.preferences')}
             </Button>
           </PreferencesPopover>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -139,6 +139,12 @@
   --heading-font-family: 'Fraunces', ui-serif, Georgia, 'Times New Roman', serif;
   --code-font-family: 'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
 
+  /* Buttons get the pointer cursor — Radix Themes ships `default`. */
+  --cursor-button: pointer;
+
+  /* Shared decelerating ease for hover micro-interactions (easeOutQuint). */
+  --ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);
+
   /* Accent — clay / terracotta — light */
   --accent-1: oklch(0.992 0.005 38);
   --accent-2: oklch(0.98 0.012 38);
@@ -296,6 +302,117 @@
 @media (min-width: 1440px) {
   .trees-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/* ============================================================
+   Tree cards — a light hover cue: the card lifts a few pixels
+   and its border warms to the accent, so the card under the
+   pointer reads as active. Kept subtle: the card is not itself
+   a click target (the actions inside it are).
+   ============================================================ */
+
+.tree-card {
+  transition:
+    transform 240ms var(--ease-out-quint),
+    box-shadow 240ms ease;
+}
+
+.tree-card::after {
+  transition: box-shadow 240ms ease;
+}
+
+.tree-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 26px -18px rgba(0, 0, 0, 0.6);
+}
+
+.tree-card:hover::after {
+  box-shadow: 0 0 0 1px var(--accent-a7);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* The transform/box-shadow transitions stay declared but inert —
+     with `transform` unchanged on hover there is nothing to animate. */
+  .tree-card:hover {
+    transform: none;
+  }
+}
+
+/* ============================================================
+   "Start a new tree" CTA tile.
+
+   The card wears a dashed border — echoing the dashed ring
+   inside — so it reads as an empty "new tree" slot rather than
+   a data card. Radix draws the card border as a box-shadow on
+   ::after; swap it for a real border so it can actually dash.
+   (Keyboard focus is a separate `outline`, so this is safe.)
+
+   On hover (and keyboard focus) the whole tile swells slightly
+   and its border brightens — a card-level cue distinct from the
+   data cards' lift — while the ring at the centre brightens,
+   blooms a warm halo, scales up, and the plus lifts toward it.
+   ============================================================ */
+
+.tree-card-cta {
+  transition: scale 260ms var(--ease-out-quint);
+}
+
+.tree-card-cta::after {
+  box-shadow: none;
+  border: 1px dashed var(--accent-a7);
+  transition: border-color 220ms ease;
+}
+
+.cta-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 1px dashed var(--accent-a7);
+  scale: 1;
+  transition:
+    border-color 220ms ease,
+    box-shadow 260ms ease,
+    scale 340ms var(--ease-out-quint);
+}
+
+.cta-plus {
+  transition: scale 340ms var(--ease-out-quint);
+}
+
+.tree-card-cta:hover .cta-ring,
+.tree-card-cta:focus-visible .cta-ring {
+  border-color: var(--accent-9);
+  scale: 1.07;
+  box-shadow: 0 0 26px -4px var(--accent-a6);
+}
+
+.tree-card-cta:hover .cta-plus,
+.tree-card-cta:focus-visible .cta-plus {
+  scale: 1.14;
+}
+
+.tree-card-cta:hover,
+.tree-card-cta:focus-visible {
+  scale: 1.015;
+}
+
+.tree-card-cta:hover::after,
+.tree-card-cta:focus-visible::after {
+  border-color: var(--accent-9);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Neutralise only the scale; border-color and box-shadow keep
+     transitioning (a fade is not motion). The scale transitions stay
+     declared but inert once `scale` is unchanged on hover. */
+  .tree-card-cta:hover,
+  .tree-card-cta:focus-visible,
+  .tree-card-cta:hover .cta-ring,
+  .tree-card-cta:focus-visible .cta-ring,
+  .tree-card-cta:hover .cta-plus,
+  .tree-card-cta:focus-visible .cta-plus {
+    scale: 1;
   }
 }
 


### PR DESCRIPTION
## Summary

Home page UI polish.

- **Gradient** — the radial-gradient background moves onto the scroll container, so it spans the full window width instead of stopping at the 1480px content column.
- **Tree card hover** — cards lift 2px and their border warms to the accent.
- **"New tree" CTA** — wears a dashed border echoing the dashed ring inside; on hover the ring brightens, blooms a warm halo and scales, and the whole tile swells slightly.
- **Status bar** — Debug and Preferences buttons switch to the soft variant at size 2; the dot separator between them is dropped.
- **Cursor** — sets --cursor-button to pointer so all buttons show the hand cursor.

All hover motion is gated behind prefers-reduced-motion.

## Test plan

- [ ] Hover tree cards — subtle lift + border warm
- [ ] Hover / focus the New tree CTA — ring + border react
- [ ] Status bar buttons render at the new size with the keycap
- [ ] Verify in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)