### PR TITLE
feat(tree): add People section sidebar to the in-tree shell

### DIFF
--- a/docs/ui/layouts.md
+++ b/docs/ui/layouts.md
@@ -8,19 +8,19 @@ The two layouts are the visual expression of the **two app contexts** (outside p
 
 ## Two Layout Modes
 
-| Layout mode   | When used                                     | Key characteristic                                                       |
-| ------------- | --------------------------------------------- | ------------------------------------------------------------------------ |
-| Picker layout | Before opening a tree (tree selection screen) | Full-width content, no header, no side panels                            |
-| In-tree shell | Every page inside an open tree                | Navigation header + fixed three-column layout (left / body / right)      |
+| Layout mode   | When used                                     | Key characteristic                                                  |
+| ------------- | --------------------------------------------- | ------------------------------------------------------------------- |
+| Picker layout | Before opening a tree (tree selection screen) | Full-width content, no header, no side panels                       |
+| In-tree shell | Every page inside an open tree                | Navigation header + fixed three-column layout (left / body / right) |
 
 ## The In-Tree Shell
 
 `TreeShell` (`src/components/tree-shell.tsx`) frames every route under `/tree/$treeId/...`:
 
 - A persistent **header** carrying `TreeNav` — the navigation bar for the tree's sections (Home, People, Families, Events, Places). Each section is an icon-and-label button; the section in view is highlighted, and Events and Places render disabled until their routes exist. A Settings button on the right opens the preferences popover. The header does not remount as the user moves between sections.
-- A fixed **three-column** body: a 264px left panel, the routed page, and a 320px right panel. Column widths are fixed; each column scrolls independently.
+- A fixed **three-column** body: a 332px left panel, the routed page, and a 320px right panel. Column widths are fixed; each column scrolls independently.
 
-The two side panels are reserved structural space — they hold contextual content (entity lists, contextual detail panels) added in later work. The shell applies to **all** in-tree routes, the tree overview included — there is no full-width exception.
+The **left panel** holds the active section's entity list — for the People section, the list of people (`PeopleSidebar`); the shell picks it from the active navigation section, so it persists (and keeps the open entity highlighted) as the user moves between a section's list and detail routes. The **right panel** is reserved structural space for contextual detail, added in later work. The shell applies to **all** in-tree routes, the tree overview included — there is no full-width exception.
 
 ## Forms Open in Separate Windows
 

--- a/src/components/entity-list-panel.tsx
+++ b/src/components/entity-list-panel.tsx
@@ -68,6 +68,13 @@ export function EntityListPanel<T extends string = string>({
   sort,
   children,
 }: EntityListPanelProps<T>): JSX.Element {
+  // Radix Select hands back a plain string; resolve it against the typed
+  // options instead of asserting, so an unknown value is a no-op.
+  const handleSortChange = (value: string): void => {
+    const option = sort.options.find((candidate) => candidate.value === value);
+    if (option) sort.onChange(option.value);
+  };
+
   return (
     <Flex asChild direction="column" height="100%" overflow="hidden">
       <aside aria-label={title}>
@@ -104,11 +111,7 @@ export function EntityListPanel<T extends string = string>({
           >
             {sort.label}
           </Text>
-          <Select.Root
-            value={sort.value}
-            onValueChange={(value) => sort.onChange(value as T)}
-            disabled={sort.disabled}
-          >
+          <Select.Root value={sort.value} onValueChange={handleSortChange} disabled={sort.disabled}>
             <Select.Trigger aria-label={sort.label} style={{ flex: 1 }} />
             <Select.Content>
               {sort.options.map((option) => (

--- a/src/components/entity-list-panel.tsx
+++ b/src/components/entity-list-panel.tsx
@@ -2,29 +2,29 @@ import { type ReactNode } from 'react';
 import { Badge, Box, Flex, Select, Text } from '@radix-ui/themes';
 
 /** A single option offered by the {@link EntityListPanel} sort control. */
-export interface EntityListSortOption {
+export interface EntityListSortOption<T extends string = string> {
   /** Stable value persisted as the active sort. */
-  value: string;
+  value: T;
   /** Translated, user-facing label. */
   label: string;
 }
 
 /** Configuration for the {@link EntityListPanel} sort footer. */
-export interface EntityListSort {
+export interface EntityListSort<T extends string = string> {
   /** Translated label shown before the select (e.g. "Sort by"). */
   label: string;
   /** Available sort options, in display order. */
-  options: EntityListSortOption[];
+  options: EntityListSortOption<T>[];
   /** Currently selected option value. */
-  value: string;
+  value: T;
   /** Called with the new value when the user picks an option. */
-  onChange: (value: string) => void;
+  onChange: (value: T) => void;
   /** Disables the select — e.g. while the list has no rows to sort. */
   disabled?: boolean;
 }
 
 /** Props accepted by {@link EntityListPanel}. */
-export interface EntityListPanelProps {
+export interface EntityListPanelProps<T extends string = string> {
   /** Panel title — the entity name in plural (e.g. "People"). */
   title: string;
   /**
@@ -35,7 +35,7 @@ export interface EntityListPanelProps {
   /** Primary action control, rendered top-right (e.g. a "New" button). */
   action?: ReactNode;
   /** Sort footer configuration. */
-  sort: EntityListSort;
+  sort: EntityListSort<T>;
   /** The list body — entity rows, or a loading / empty / error state. */
   children: ReactNode;
 }
@@ -48,25 +48,26 @@ export interface EntityListPanelProps {
  * It is entity-agnostic by composition — the body is supplied as
  * `children` and the panel never inspects row shape, so People,
  * Families, Places and Events can each render their own row markup
- * through the same frame.
+ * through the same frame. The sort-value type `T` flows through, so each
+ * consumer keeps its own typed union of sort options.
  *
  * @example
  * <EntityListPanel
  *   title={t('nav.individuals')}
  *   count={people.length}
- *   action={<Button size="1" disabled>{t('sidebar.newButton')}</Button>}
+ *   action={<Button size="2" disabled>{t('sidebar.newButton')}</Button>}
  *   sort={{ label, options, value, onChange }}
  * >
  *   {people.map((person) => <PersonRow key={person.id} ... />)}
  * </EntityListPanel>
  */
-export function EntityListPanel({
+export function EntityListPanel<T extends string = string>({
   title,
   count,
   action,
   sort,
   children,
-}: EntityListPanelProps): JSX.Element {
+}: EntityListPanelProps<T>): JSX.Element {
   return (
     <Flex asChild direction="column" height="100%" overflow="hidden">
       <aside aria-label={title}>
@@ -103,7 +104,11 @@ export function EntityListPanel({
           >
             {sort.label}
           </Text>
-          <Select.Root value={sort.value} onValueChange={sort.onChange} disabled={sort.disabled}>
+          <Select.Root
+            value={sort.value}
+            onValueChange={(value) => sort.onChange(value as T)}
+            disabled={sort.disabled}
+          >
             <Select.Trigger aria-label={sort.label} style={{ flex: 1 }} />
             <Select.Content>
               {sort.options.map((option) => (

--- a/src/components/entity-list-panel.tsx
+++ b/src/components/entity-list-panel.tsx
@@ -1,0 +1,120 @@
+import { type ReactNode } from 'react';
+import { Badge, Box, Flex, Select, Text } from '@radix-ui/themes';
+
+/** A single option offered by the {@link EntityListPanel} sort control. */
+export interface EntityListSortOption {
+  /** Stable value persisted as the active sort. */
+  value: string;
+  /** Translated, user-facing label. */
+  label: string;
+}
+
+/** Configuration for the {@link EntityListPanel} sort footer. */
+export interface EntityListSort {
+  /** Translated label shown before the select (e.g. "Sort by"). */
+  label: string;
+  /** Available sort options, in display order. */
+  options: EntityListSortOption[];
+  /** Currently selected option value. */
+  value: string;
+  /** Called with the new value when the user picks an option. */
+  onChange: (value: string) => void;
+  /** Disables the select — e.g. while the list has no rows to sort. */
+  disabled?: boolean;
+}
+
+/** Props accepted by {@link EntityListPanel}. */
+export interface EntityListPanelProps {
+  /** Panel title — the entity name in plural (e.g. "People"). */
+  title: string;
+  /**
+   * Total number of entities, shown as a badge next to the title.
+   * `undefined` renders a placeholder dash (e.g. while loading).
+   */
+  count?: number;
+  /** Primary action control, rendered top-right (e.g. a "New" button). */
+  action?: ReactNode;
+  /** Sort footer configuration. */
+  sort: EntityListSort;
+  /** The list body — entity rows, or a loading / empty / error state. */
+  children: ReactNode;
+}
+
+/**
+ * The reusable shell for an entity list in the in-tree shell's left
+ * column: a fixed header (title, count badge, primary action), a
+ * scrollable body, and a fixed sort footer.
+ *
+ * It is entity-agnostic by composition — the body is supplied as
+ * `children` and the panel never inspects row shape, so People,
+ * Families, Places and Events can each render their own row markup
+ * through the same frame.
+ *
+ * @example
+ * <EntityListPanel
+ *   title={t('nav.individuals')}
+ *   count={people.length}
+ *   action={<Button size="1" disabled>{t('sidebar.newButton')}</Button>}
+ *   sort={{ label, options, value, onChange }}
+ * >
+ *   {people.map((person) => <PersonRow key={person.id} ... />)}
+ * </EntityListPanel>
+ */
+export function EntityListPanel({
+  title,
+  count,
+  action,
+  sort,
+  children,
+}: EntityListPanelProps): JSX.Element {
+  return (
+    <Flex asChild direction="column" height="100%" overflow="hidden">
+      <aside aria-label={title}>
+        <Flex
+          align="center"
+          gap="2"
+          flexShrink="0"
+          style={{ padding: '14px 14px 12px', borderBottom: '1px solid var(--gray-a4)' }}
+        >
+          <Text asChild size="5" weight="bold" trim="both">
+            <h2 style={{ margin: 0 }}>{title}</h2>
+          </Text>
+          <Badge variant="outline" color="gray" radius="full">
+            {count ?? '–'}
+          </Badge>
+          <Box flexGrow="1" />
+          {action}
+        </Flex>
+
+        <Box flexGrow="1" minHeight="0" overflow="auto">
+          {children}
+        </Box>
+
+        <Flex
+          align="center"
+          gap="3"
+          flexShrink="0"
+          style={{ padding: '10px 14px', borderTop: '1px solid var(--gray-a4)' }}
+        >
+          <Text
+            size="1"
+            color="gray"
+            style={{ fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase' }}
+          >
+            {sort.label}
+          </Text>
+          <Select.Root value={sort.value} onValueChange={sort.onChange} disabled={sort.disabled}>
+            <Select.Trigger aria-label={sort.label} style={{ flex: 1 }} />
+            <Select.Content>
+              {sort.options.map((option) => (
+                <Select.Item key={option.value} value={option.value}>
+                  {option.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+      </aside>
+    </Flex>
+  );
+}

--- a/src/components/people-sidebar.css
+++ b/src/components/people-sidebar.css
@@ -1,3 +1,10 @@
+/**
+ * Scoped styles for the PeopleSidebar person rows. Radix Themes covers the
+ * panel structure, but the row link's interaction and selection states
+ * (hover, focus, aria-current) plus the dashed-circle initials avatar and
+ * compact two-line typography are a bespoke surface with no Radix primitive
+ * — hence local CSS.
+ */
 .person-row {
   display: flex;
   align-items: center;

--- a/src/components/people-sidebar.css
+++ b/src/components/people-sidebar.css
@@ -1,0 +1,95 @@
+.person-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px 6px 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-3);
+  color: var(--gray-12);
+  text-decoration: none;
+  cursor: var(--cursor-link);
+  transition:
+    background-color 120ms,
+    border-color 120ms;
+}
+
+.person-row:hover {
+  background-color: var(--gray-a2);
+  border-color: var(--gray-a4);
+}
+
+.person-row:focus-visible {
+  outline: 2px solid var(--focus-a8);
+  outline-offset: -1px;
+}
+
+.person-row[aria-current='page'] {
+  background-color: var(--accent-a3);
+  border-color: var(--accent-a7);
+}
+
+.person-row__avatar {
+  flex: 0 0 30px;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border: 1.25px dashed var(--gray-a7);
+  border-radius: 9999px;
+  color: var(--gray-11);
+  font-family: var(--code-font-family);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.person-row[aria-current='page'] .person-row__avatar {
+  border-color: var(--accent-a8);
+  color: var(--accent-11);
+}
+
+.person-row__text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  line-height: 1.2;
+}
+
+.person-row__name {
+  overflow: hidden;
+  color: var(--gray-12);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.person-row[aria-current='page'] .person-row__name {
+  color: var(--accent-12);
+}
+
+.person-row__meta {
+  overflow: hidden;
+  color: var(--gray-10);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.person-row[aria-current='page'] .person-row__meta {
+  color: var(--accent-a11);
+}
+
+.person-row__chev {
+  flex: 0 0 14px;
+  color: var(--gray-9);
+}
+
+.person-row[aria-current='page'] .person-row__chev {
+  color: var(--accent-11);
+}

--- a/src/components/people-sidebar.tsx
+++ b/src/components/people-sidebar.tsx
@@ -33,12 +33,20 @@ const SORT_LABEL_KEYS: Record<SortValue, string> = {
 
 const SKELETON_ROW_COUNT = 7;
 
-/** Year of an event, read from its normalized `YYYY-MM-DD` sort date. */
+/**
+ * Year of an event, read from the first four characters of its
+ * normalized `YYYY-MM-DD` sort date. Null when the event or its sort
+ * date is missing.
+ */
 function eventYear(event: { dateSort: string | null } | null): string | null {
   return event?.dateSort ? event.dateSort.slice(0, 4) : null;
 }
 
-/** Avatar initials — first given-name letter + first surname letter. */
+/**
+ * Avatar initials for a name — the first given-name letter and the first
+ * surname letter, uppercased. Falls back to the nickname's first letter,
+ * then to `?` when the name carries no usable text.
+ */
 function initialsOf(name: Name | null): string {
   if (!name) return '?';
   const given = name.givenNames?.trim().split(/\s+/)[0]?.charAt(0) ?? '';
@@ -49,14 +57,21 @@ function initialsOf(name: Name | null): string {
   return nickname ? nickname.toUpperCase() : '?';
 }
 
-/** Lifespan string — `1854 — 1921`, `1854 —` when living, `?` per unknown year. */
+/**
+ * The lifespan line for a person — `1854 — 1921`, or `1854 —` when the
+ * person is living. An unknown birth or death year shows as `?`.
+ */
 function lifespanOf(person: IndividualWithDetails): string {
   const birth = eventYear(person.birthEvent) ?? '?';
   if (person.isLiving) return `${birth} —`;
   return `${birth} — ${eventYear(person.deathEvent) ?? '?'}`;
 }
 
-/** The comparable key a person sorts on, for the given order. */
+/**
+ * The comparable key a person sorts on for the given order: the sortable
+ * name for surname sorts, the given names for the given-name sort, and
+ * the birth year (nullable) for birth sorts.
+ */
 function sortKeyOf(person: IndividualWithDetails, sort: SortValue): string | null {
   switch (sort) {
     case 'given-asc':

--- a/src/components/people-sidebar.tsx
+++ b/src/components/people-sidebar.tsx
@@ -67,8 +67,11 @@ function sortKeyOf(person: IndividualWithDetails, sort: SortValue): string | nul
   }
 }
 
+/**
+ * Compare two sort keys for the given order. A null key — an unknown
+ * birth year — always sorts last, whichever direction is active.
+ */
 function compareKeys(a: string | null, b: string | null, sort: SortValue): number {
-  // A null key (an unknown birth year) sorts last regardless of direction.
   if (a === null || b === null) {
     if (a === b) return 0;
     return a === null ? 1 : -1;
@@ -89,6 +92,7 @@ function sortPeople(people: IndividualWithDetails[], sort: SortValue): Individua
     .map((decorated) => decorated.person);
 }
 
+/** Props accepted by {@link PersonRow}. */
 interface PersonRowProps {
   person: IndividualWithDetails;
   treeId: string;

--- a/src/components/people-sidebar.tsx
+++ b/src/components/people-sidebar.tsx
@@ -11,14 +11,18 @@ import { useIndividuals } from '$hooks/useIndividuals';
 import { formatName } from '$db-tree/names';
 import type { IndividualWithDetails, Name } from '$/types/database';
 
-/** The sort orders offered by the People sidebar. */
-type SortValue = 'surname-asc' | 'surname-desc' | 'given-asc' | 'birth-asc' | 'birth-desc';
+/** The sort orders offered by the People sidebar, in display order. */
+const SORT_VALUES = [
+  'surname-asc',
+  'surname-desc',
+  'given-asc',
+  'birth-asc',
+  'birth-desc',
+] as const;
 
-/**
- * i18n label key per sort order — the single source the option list is
- * derived from, so the `SortValue` union and the rendered options cannot
- * drift apart.
- */
+type SortValue = (typeof SORT_VALUES)[number];
+
+/** i18n label key per sort order — one entry is required for every SortValue. */
 const SORT_LABEL_KEYS: Record<SortValue, string> = {
   'surname-asc': 'sidebar.sort.surnameAsc',
   'surname-desc': 'sidebar.sort.surnameDesc',
@@ -189,11 +193,7 @@ export function PeopleSidebar(): JSX.Element | null {
   const rows = useMemo(() => (data ? sortPeople(data, sort) : []), [data, sort]);
 
   const sortOptions = useMemo<EntityListSortOption<SortValue>[]>(
-    () =>
-      (Object.keys(SORT_LABEL_KEYS) as SortValue[]).map((value) => ({
-        value,
-        label: t(SORT_LABEL_KEYS[value]),
-      })),
+    () => SORT_VALUES.map((value) => ({ value, label: t(SORT_LABEL_KEYS[value]) })),
     [t]
   );
 

--- a/src/components/people-sidebar.tsx
+++ b/src/components/people-sidebar.tsx
@@ -1,0 +1,220 @@
+import './people-sidebar.css';
+
+import { type ReactNode, useMemo, useState } from 'react';
+import { Link, useParams } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { Button, Flex, Skeleton, Text } from '@radix-ui/themes';
+
+import { EntityListPanel, type EntityListSortOption } from './entity-list-panel';
+import { Icon } from '$components/icon';
+import { useIndividuals } from '$hooks/useIndividuals';
+import { formatName } from '$db-tree/names';
+import type { IndividualWithDetails, Name } from '$/types/database';
+
+/** The sort orders offered by the People sidebar. */
+type SortValue = 'surname-asc' | 'surname-desc' | 'given-asc' | 'birth-asc' | 'birth-desc';
+
+const SKELETON_ROW_COUNT = 7;
+
+/** Year of an event, read from its normalized `YYYY-MM-DD` sort date. */
+function eventYear(event: { dateSort: string | null } | null): string | null {
+  return event?.dateSort ? event.dateSort.slice(0, 4) : null;
+}
+
+/** Avatar initials — first given-name letter + first surname letter. */
+function initialsOf(name: Name | null): string {
+  if (!name) return '?';
+  const given = name.givenNames?.trim().split(/\s+/)[0]?.charAt(0) ?? '';
+  const surname = name.surname?.trim().charAt(0) ?? '';
+  const initials = (given + surname).toUpperCase();
+  if (initials) return initials;
+  const nickname = name.nickname?.trim().charAt(0);
+  return nickname ? nickname.toUpperCase() : '?';
+}
+
+/** Lifespan string — `1854 — 1921`, `1854 —` when living, `?` per unknown year. */
+function lifespanOf(person: IndividualWithDetails): string {
+  const birth = eventYear(person.birthEvent) ?? '?';
+  if (person.isLiving) return `${birth} —`;
+  return `${birth} — ${eventYear(person.deathEvent) ?? '?'}`;
+}
+
+function comparePeople(
+  a: IndividualWithDetails,
+  b: IndividualWithDetails,
+  sort: SortValue
+): number {
+  switch (sort) {
+    case 'surname-desc':
+      return formatName(b.primaryName).sortable.localeCompare(formatName(a.primaryName).sortable);
+    case 'given-asc':
+      return (a.primaryName?.givenNames ?? '').localeCompare(b.primaryName?.givenNames ?? '');
+    case 'birth-asc':
+    case 'birth-desc': {
+      const ay = eventYear(a.birthEvent);
+      const by = eventYear(b.birthEvent);
+      // Individuals with no known birth year sort last in both directions.
+      if (ay === by) return 0;
+      if (ay === null) return 1;
+      if (by === null) return -1;
+      return sort === 'birth-asc' ? ay.localeCompare(by) : by.localeCompare(ay);
+    }
+    case 'surname-asc':
+    default:
+      return formatName(a.primaryName).sortable.localeCompare(formatName(b.primaryName).sortable);
+  }
+}
+
+interface PersonRowProps {
+  person: IndividualWithDetails;
+  treeId: string;
+  selected: boolean;
+}
+
+/** A single navigable person row — avatar, name, lifespan, chevron. */
+function PersonRow({ person, treeId, selected }: PersonRowProps): JSX.Element {
+  const { t } = useTranslation('individuals');
+  const name = person.primaryName;
+  const displayName = name ? formatName(name).full : t('sidebar.unknownName');
+
+  return (
+    <Link
+      to="/tree/$treeId/individual/$individualId"
+      params={{ treeId, individualId: person.id }}
+      className="person-row"
+      aria-current={selected ? 'page' : undefined}
+    >
+      <span className="person-row__avatar" aria-hidden="true">
+        {initialsOf(name)}
+      </span>
+      <span className="person-row__text">
+        <span className="person-row__name">{displayName}</span>
+        <span className="person-row__meta">{lifespanOf(person)}</span>
+      </span>
+      <Icon name="chevron-right" size={14} className="person-row__chev" />
+    </Link>
+  );
+}
+
+/** Placeholder rows shown while the people query is loading. */
+function PeopleListSkeleton(): JSX.Element {
+  return (
+    <Flex direction="column" gap="1" p="2" aria-hidden="true">
+      {Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
+        <Flex key={index} align="center" gap="3" px="2" py="2">
+          <Skeleton width="30px" height="30px" style={{ borderRadius: '9999px' }} />
+          <Flex direction="column" gap="1" flexGrow="1">
+            <Skeleton width="60%" height="12px" />
+            <Skeleton width="35%" height="10px" />
+          </Flex>
+        </Flex>
+      ))}
+    </Flex>
+  );
+}
+
+/** Centered message for the empty and error states. */
+function PeopleListMessage({
+  children,
+  icon,
+}: {
+  children: ReactNode;
+  icon?: boolean;
+}): JSX.Element {
+  return (
+    <Flex
+      direction="column"
+      align="center"
+      justify="center"
+      gap="2"
+      px="5"
+      py="8"
+      style={{ textAlign: 'center' }}
+    >
+      {icon && <Icon name="user" size={24} style={{ color: 'var(--gray-8)' }} />}
+      <Text size="2" color="gray">
+        {children}
+      </Text>
+    </Flex>
+  );
+}
+
+/**
+ * The People section sidebar — the list of every person in the open tree,
+ * rendered in the in-tree shell's left column. Header (title, count, a
+ * disabled "New" button), the scrollable person list, and a sort footer.
+ *
+ * Search and filtering are deliberately out of scope for this iteration.
+ * Clicking a row opens that individual's detail route; the row matching
+ * the open `$individualId` is highlighted.
+ *
+ * Composed on top of {@link EntityListPanel}, the entity-agnostic shell
+ * shared by every section list.
+ */
+export function PeopleSidebar(): JSX.Element | null {
+  const { t } = useTranslation('individuals');
+  const { t: tCommon } = useTranslation('common');
+  const params = useParams({ strict: false });
+  const { data, isLoading, isError } = useIndividuals();
+  const [sort, setSort] = useState<SortValue>('surname-asc');
+
+  const rows = useMemo(
+    () => (data ? [...data].sort((a, b) => comparePeople(a, b, sort)) : []),
+    [data, sort]
+  );
+
+  const sortOptions: EntityListSortOption[] = [
+    { value: 'surname-asc', label: t('sidebar.sort.surnameAsc') },
+    { value: 'surname-desc', label: t('sidebar.sort.surnameDesc') },
+    { value: 'given-asc', label: t('sidebar.sort.givenAsc') },
+    { value: 'birth-asc', label: t('sidebar.sort.birthAsc') },
+    { value: 'birth-desc', label: t('sidebar.sort.birthDesc') },
+  ];
+
+  const treeId = params.treeId;
+  if (treeId === undefined) return null;
+
+  let body: ReactNode;
+  if (isLoading) {
+    body = <PeopleListSkeleton />;
+  } else if (isError) {
+    body = <PeopleListMessage>{tCommon('errors.loadFailed')}</PeopleListMessage>;
+  } else if (rows.length === 0) {
+    body = <PeopleListMessage icon>{t('sidebar.empty')}</PeopleListMessage>;
+  } else {
+    body = (
+      <Flex direction="column" gap="1" p="2">
+        {rows.map((person) => (
+          <PersonRow
+            key={person.id}
+            person={person}
+            treeId={treeId}
+            selected={person.id === params.individualId}
+          />
+        ))}
+      </Flex>
+    );
+  }
+
+  return (
+    <EntityListPanel
+      title={tCommon('nav.individuals')}
+      count={data?.length}
+      action={
+        <Button size="2" disabled>
+          <Icon name="plus" size={16} />
+          {t('sidebar.newButton')}
+        </Button>
+      }
+      sort={{
+        label: t('sidebar.sortLabel'),
+        options: sortOptions,
+        value: sort,
+        onChange: (value) => setSort(value as SortValue),
+        disabled: rows.length === 0,
+      }}
+    >
+      {body}
+    </EntityListPanel>
+  );
+}

--- a/src/components/people-sidebar.tsx
+++ b/src/components/people-sidebar.tsx
@@ -14,6 +14,19 @@ import type { IndividualWithDetails, Name } from '$/types/database';
 /** The sort orders offered by the People sidebar. */
 type SortValue = 'surname-asc' | 'surname-desc' | 'given-asc' | 'birth-asc' | 'birth-desc';
 
+/**
+ * i18n label key per sort order — the single source the option list is
+ * derived from, so the `SortValue` union and the rendered options cannot
+ * drift apart.
+ */
+const SORT_LABEL_KEYS: Record<SortValue, string> = {
+  'surname-asc': 'sidebar.sort.surnameAsc',
+  'surname-desc': 'sidebar.sort.surnameDesc',
+  'given-asc': 'sidebar.sort.givenAsc',
+  'birth-asc': 'sidebar.sort.birthAsc',
+  'birth-desc': 'sidebar.sort.birthDesc',
+};
+
 const SKELETON_ROW_COUNT = 7;
 
 /** Year of an event, read from its normalized `YYYY-MM-DD` sort date. */
@@ -39,30 +52,41 @@ function lifespanOf(person: IndividualWithDetails): string {
   return `${birth} — ${eventYear(person.deathEvent) ?? '?'}`;
 }
 
-function comparePeople(
-  a: IndividualWithDetails,
-  b: IndividualWithDetails,
-  sort: SortValue
-): number {
+/** The comparable key a person sorts on, for the given order. */
+function sortKeyOf(person: IndividualWithDetails, sort: SortValue): string | null {
   switch (sort) {
-    case 'surname-desc':
-      return formatName(b.primaryName).sortable.localeCompare(formatName(a.primaryName).sortable);
     case 'given-asc':
-      return (a.primaryName?.givenNames ?? '').localeCompare(b.primaryName?.givenNames ?? '');
+      return person.primaryName?.givenNames ?? '';
     case 'birth-asc':
-    case 'birth-desc': {
-      const ay = eventYear(a.birthEvent);
-      const by = eventYear(b.birthEvent);
-      // Individuals with no known birth year sort last in both directions.
-      if (ay === by) return 0;
-      if (ay === null) return 1;
-      if (by === null) return -1;
-      return sort === 'birth-asc' ? ay.localeCompare(by) : by.localeCompare(ay);
-    }
+    case 'birth-desc':
+      return eventYear(person.birthEvent);
     case 'surname-asc':
+    case 'surname-desc':
     default:
-      return formatName(a.primaryName).sortable.localeCompare(formatName(b.primaryName).sortable);
+      return formatName(person.primaryName).sortable;
   }
+}
+
+function compareKeys(a: string | null, b: string | null, sort: SortValue): number {
+  // A null key (an unknown birth year) sorts last regardless of direction.
+  if (a === null || b === null) {
+    if (a === b) return 0;
+    return a === null ? 1 : -1;
+  }
+  const order = a.localeCompare(b);
+  return sort === 'surname-desc' || sort === 'birth-desc' ? -order : order;
+}
+
+/**
+ * Sort people by the given order. Decorate-sort-undecorate: each person's
+ * key is computed once up front, so `formatName` runs O(n) times rather
+ * than O(n log n) inside the comparator.
+ */
+function sortPeople(people: IndividualWithDetails[], sort: SortValue): IndividualWithDetails[] {
+  return people
+    .map((person) => ({ person, key: sortKeyOf(person, sort) }))
+    .sort((a, b) => compareKeys(a.key, b.key, sort))
+    .map((decorated) => decorated.person);
 }
 
 interface PersonRowProps {
@@ -158,18 +182,16 @@ export function PeopleSidebar(): JSX.Element | null {
   const { data, isLoading, isError } = useIndividuals();
   const [sort, setSort] = useState<SortValue>('surname-asc');
 
-  const rows = useMemo(
-    () => (data ? [...data].sort((a, b) => comparePeople(a, b, sort)) : []),
-    [data, sort]
-  );
+  const rows = useMemo(() => (data ? sortPeople(data, sort) : []), [data, sort]);
 
-  const sortOptions: EntityListSortOption[] = [
-    { value: 'surname-asc', label: t('sidebar.sort.surnameAsc') },
-    { value: 'surname-desc', label: t('sidebar.sort.surnameDesc') },
-    { value: 'given-asc', label: t('sidebar.sort.givenAsc') },
-    { value: 'birth-asc', label: t('sidebar.sort.birthAsc') },
-    { value: 'birth-desc', label: t('sidebar.sort.birthDesc') },
-  ];
+  const sortOptions = useMemo<EntityListSortOption<SortValue>[]>(
+    () =>
+      (Object.keys(SORT_LABEL_KEYS) as SortValue[]).map((value) => ({
+        value,
+        label: t(SORT_LABEL_KEYS[value]),
+      })),
+    [t]
+  );
 
   const treeId = params.treeId;
   if (treeId === undefined) return null;
@@ -210,7 +232,7 @@ export function PeopleSidebar(): JSX.Element | null {
         label: t('sidebar.sortLabel'),
         options: sortOptions,
         value: sort,
-        onChange: (value) => setSort(value as SortValue),
+        onChange: setSort,
         disabled: rows.length === 0,
       }}
     >

--- a/src/components/tree-shell.tsx
+++ b/src/components/tree-shell.tsx
@@ -1,9 +1,12 @@
 import { type ReactNode } from 'react';
 import { Box, Flex, Grid, IconButton } from '@radix-ui/themes';
+import { useRouterState } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
 import { Icon } from '$components/icon';
 import { PreferencesPopover } from '$components/preferences-popover';
+import { resolveNavSection } from '$lib/nav-sections';
+import { PeopleSidebar } from './people-sidebar';
 import { TreeNav } from './tree-nav';
 
 /**
@@ -20,13 +23,14 @@ export interface TreeShellProps {
  *
  * A persistent 56px header carries the {@link TreeNav} navigation bar on
  * the left and a Settings button (opening the {@link PreferencesPopover})
- * on the right, above a fixed three-column layout: a 264px left panel,
+ * on the right, above a fixed three-column layout: a 332px left panel,
  * the page body, and a 320px right panel.
  *
- * The two side panels are intentionally empty in this iteration. They are
- * the reserved structural home for contextual content (entity lists,
- * contextual detail panels) added in later work. Column widths are fixed —
- * no resizing, collapsing, or responsive behaviour. Each column scrolls
+ * The left panel renders the active section's entity list, selected from
+ * the active navigation section — for the People section, the
+ * {@link PeopleSidebar}. The right panel is reserved structural space for
+ * contextual detail, added in later work. Column widths are fixed — no
+ * resizing, collapsing, or responsive behaviour. Each column scrolls
  * independently, so long content in one never moves the others.
  *
  * Rendered once by the in-tree layout route, wrapping the routed `Outlet`.
@@ -38,6 +42,8 @@ export interface TreeShellProps {
  */
 export function TreeShell({ children }: TreeShellProps): JSX.Element {
   const { t } = useTranslation('common');
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const activeSection = resolveNavSection(pathname);
   return (
     <Flex direction="column" height="100vh" overflow="hidden">
       <Flex
@@ -61,14 +67,16 @@ export function TreeShell({ children }: TreeShellProps): JSX.Element {
           </PreferencesPopover>
         </header>
       </Flex>
-      <Grid columns="264px minmax(0, 1fr) 320px" flexGrow="1" minHeight="0">
+      <Grid columns="332px minmax(0, 1fr) 320px" flexGrow="1" minHeight="0">
         <Box
-          overflow="auto"
+          overflow="hidden"
           style={{
             background: 'var(--color-panel-solid)',
             borderRight: '1px solid var(--gray-a4)',
           }}
-        />
+        >
+          {activeSection === 'people' && <PeopleSidebar />}
+        </Box>
         <Box asChild overflow="auto">
           <main style={{ background: 'var(--color-background)' }}>{children}</main>
         </Box>

--- a/src/i18n/locales/en/individuals.json
+++ b/src/i18n/locales/en/individuals.json
@@ -1,3 +1,16 @@
 {
-  "heading": "Individual {{individualId}}"
+  "heading": "Individual {{individualId}}",
+  "sidebar": {
+    "newButton": "New",
+    "sortLabel": "Sort by",
+    "sort": {
+      "surnameAsc": "Surname (A → Z)",
+      "surnameDesc": "Surname (Z → A)",
+      "givenAsc": "Given name (A → Z)",
+      "birthAsc": "Birth (oldest first)",
+      "birthDesc": "Birth (newest first)"
+    },
+    "empty": "No people yet",
+    "unknownName": "Unknown"
+  }
 }

--- a/src/i18n/locales/fr/individuals.json
+++ b/src/i18n/locales/fr/individuals.json
@@ -1,3 +1,16 @@
 {
-  "heading": "Individu {{individualId}}"
+  "heading": "Individu {{individualId}}",
+  "sidebar": {
+    "newButton": "Nouveau",
+    "sortLabel": "Trier par",
+    "sort": {
+      "surnameAsc": "Nom (A → Z)",
+      "surnameDesc": "Nom (Z → A)",
+      "givenAsc": "Prénom (A → Z)",
+      "birthAsc": "Naissance (croissant)",
+      "birthDesc": "Naissance (décroissant)"
+    },
+    "empty": "Aucune personne",
+    "unknownName": "Sans nom"
+  }
 }


### PR DESCRIPTION
## Summary

Implements the People section sidebar — the entity list in the in-tree shell's left panel — from the Claude Design handoff.

- **`EntityListPanel`** — entity-agnostic shell (header, scrollable body, sort footer), generic over its sort-value type. Reusable by future section lists (Families, Places, Events).
- **`PeopleSidebar`** — the People consumer: person rows (initials avatar, full name, lifespan), client-side sort, loading / empty / error states.
- **`TreeShell`** renders the sidebar from the active nav section, so it persists across the People list and individual-detail routes with the open individual highlighted.
- Left panel widened to 332px to match the design.

## Scope

Search and filtering (the design's search input + filter popover) are intentionally **out of scope** for this iteration. The "New" button is rendered disabled — there is no individual-creation flow yet.

## Notes

- The list is not virtualized; for very large trees this is a known follow-up.
- No component tests — the repo has no `.test.tsx` precedent; establishing component-test infrastructure is deferred to its own task.

## Verification

- `tsc --noEmit` — passes
- ESLint (changed files) — clean
- `vitest run` — 555/555 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)