### PR TITLE
feat(people-sidebar): display surname-first when sorting by surname or birth

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,14 @@ export default [
       ],
       'no-unused-vars': 'off',
       'no-undef': 'off', // TypeScript handles this
+      'no-nested-ternary': 'error',
+      // Prefer immutable bindings. For values derived from a branch, use
+      // a `const` initialised by an IIFE (or a lookup table) rather than
+      // a `let` reassigned across an if/else. No built-in rule enforces
+      // the IIFE-vs-let preference, so it lives as a convention enforced
+      // by review; `prefer-const` covers the simple "never reassigned"
+      // case.
+      'prefer-const': 'error',
     },
   },
   {

--- a/src/components/dropzone.tsx
+++ b/src/components/dropzone.tsx
@@ -124,6 +124,12 @@ export function Dropzone({
 
   const showSelectedName = state !== 'idle' && selectedName;
 
+  const cursor = ((): 'pointer' | 'progress' | 'default' => {
+    if (interactive) return 'pointer';
+    if (state === 'scanning') return 'progress';
+    return 'default';
+  })();
+
   const card = (
     <button
       type="button"
@@ -140,7 +146,7 @@ export function Dropzone({
         padding: 'var(--space-6)',
         color: 'inherit',
         font: 'inherit',
-        cursor: interactive ? 'pointer' : state === 'scanning' ? 'progress' : 'default',
+        cursor,
         opacity: !interactive && state === 'idle' ? 0.6 : 1,
       }}
     >

--- a/src/components/people-sidebar.tsx
+++ b/src/components/people-sidebar.tsx
@@ -113,7 +113,7 @@ function compareKeys(a: string | null, b: string | null, sort: SortValue): numbe
     return a === null ? 1 : -1;
   }
   const order = a.localeCompare(b);
-  return sort === 'surname-desc' || sort === 'given-desc' || sort === 'birth-desc' ? -order : order;
+  return sort.endsWith('-desc') ? -order : order;
 }
 
 /**

--- a/src/components/people-sidebar.tsx
+++ b/src/components/people-sidebar.tsx
@@ -68,6 +68,20 @@ function lifespanOf(person: IndividualWithDetails): string {
 }
 
 /**
+ * Which name representation a row renders. Mirrors the user-visible
+ * sort order: a given-name sort is the only case where the row leads
+ * with the given names; every other sort (surname asc/desc, birth
+ * asc/desc) leads with the surname so the user can scan the column
+ * by the value being sorted on.
+ */
+type NameDisplayMode = 'givenFirst' | 'surnameFirst';
+
+/** The display mode that matches the given sort order. */
+function displayModeFor(sort: SortValue): NameDisplayMode {
+  return sort === 'given-asc' ? 'givenFirst' : 'surnameFirst';
+}
+
+/**
  * The comparable key a person sorts on for the given order: the sortable
  * name for surname sorts, the given names for the given-name sort, and
  * the birth year (nullable) for birth sorts.
@@ -116,13 +130,19 @@ interface PersonRowProps {
   person: IndividualWithDetails;
   treeId: string;
   selected: boolean;
+  displayMode: NameDisplayMode;
 }
 
 /** A single navigable person row — avatar, name, lifespan, chevron. */
-function PersonRow({ person, treeId, selected }: PersonRowProps): JSX.Element {
+function PersonRow({ person, treeId, selected, displayMode }: PersonRowProps): JSX.Element {
   const { t } = useTranslation('individuals');
   const name = person.primaryName;
-  const displayName = name ? formatName(name).full : t('sidebar.unknownName');
+  const formatted = name ? formatName(name) : null;
+  const displayName = formatted
+    ? displayMode === 'surnameFirst'
+      ? formatted.surnameFirst
+      : formatted.full
+    : t('sidebar.unknownName');
 
   return (
     <Link
@@ -206,6 +226,7 @@ export function PeopleSidebar(): JSX.Element | null {
   const [sort, setSort] = useState<SortValue>('surname-asc');
 
   const rows = useMemo(() => (data ? sortPeople(data, sort) : []), [data, sort]);
+  const displayMode = displayModeFor(sort);
 
   const sortOptions = useMemo<EntityListSortOption<SortValue>[]>(
     () => SORT_VALUES.map((value) => ({ value, label: t(SORT_LABEL_KEYS[value]) })),
@@ -231,6 +252,7 @@ export function PeopleSidebar(): JSX.Element | null {
             person={person}
             treeId={treeId}
             selected={person.id === params.individualId}
+            displayMode={displayMode}
           />
         ))}
       </Flex>

--- a/src/components/people-sidebar.tsx
+++ b/src/components/people-sidebar.tsx
@@ -140,12 +140,11 @@ interface PersonRowProps {
 function PersonRow({ person, treeId, selected, displayMode }: PersonRowProps): JSX.Element {
   const { t } = useTranslation('individuals');
   const name = person.primaryName;
-  const formatted = name ? formatName(name) : null;
-  const displayName = formatted
-    ? displayMode === 'surnameFirst'
-      ? formatted.surnameFirst
-      : formatted.full
-    : t('sidebar.unknownName');
+  const displayName = ((): string => {
+    if (!name) return t('sidebar.unknownName');
+    const formatted = formatName(name);
+    return displayMode === 'surnameFirst' ? formatted.surnameFirst : formatted.full;
+  })();
 
   return (
     <Link

--- a/src/components/people-sidebar.tsx
+++ b/src/components/people-sidebar.tsx
@@ -16,6 +16,7 @@ const SORT_VALUES = [
   'surname-asc',
   'surname-desc',
   'given-asc',
+  'given-desc',
   'birth-asc',
   'birth-desc',
 ] as const;
@@ -27,6 +28,7 @@ const SORT_LABEL_KEYS: Record<SortValue, string> = {
   'surname-asc': 'sidebar.sort.surnameAsc',
   'surname-desc': 'sidebar.sort.surnameDesc',
   'given-asc': 'sidebar.sort.givenAsc',
+  'given-desc': 'sidebar.sort.givenDesc',
   'birth-asc': 'sidebar.sort.birthAsc',
   'birth-desc': 'sidebar.sort.birthDesc',
 };
@@ -78,7 +80,7 @@ type NameDisplayMode = 'givenFirst' | 'surnameFirst';
 
 /** The display mode that matches the given sort order. */
 function displayModeFor(sort: SortValue): NameDisplayMode {
-  return sort === 'given-asc' ? 'givenFirst' : 'surnameFirst';
+  return sort === 'given-asc' || sort === 'given-desc' ? 'givenFirst' : 'surnameFirst';
 }
 
 /**
@@ -89,6 +91,7 @@ function displayModeFor(sort: SortValue): NameDisplayMode {
 function sortKeyOf(person: IndividualWithDetails, sort: SortValue): string | null {
   switch (sort) {
     case 'given-asc':
+    case 'given-desc':
       return person.primaryName?.givenNames ?? '';
     case 'birth-asc':
     case 'birth-desc':
@@ -110,7 +113,7 @@ function compareKeys(a: string | null, b: string | null, sort: SortValue): numbe
     return a === null ? 1 : -1;
   }
   const order = a.localeCompare(b);
-  return sort === 'surname-desc' || sort === 'birth-desc' ? -order : order;
+  return sort === 'surname-desc' || sort === 'given-desc' || sort === 'birth-desc' ? -order : order;
 }
 
 /**

--- a/src/components/trees/download-tree-modal.tsx
+++ b/src/components/trees/download-tree-modal.tsx
@@ -123,12 +123,11 @@ export function DownloadTreeModal({
   };
 
   const sizeEstimate = estimateExportSize(tree.individualCount, tree.familyCount);
-  const sizeKey =
-    sizeEstimate.bucket === 'under-kb'
-      ? 'downloadTree.sizeUnderKb'
-      : sizeEstimate.bucket === 'kb'
-        ? 'downloadTree.sizeKb'
-        : 'downloadTree.sizeMb';
+  const sizeKey = ((): string => {
+    if (sizeEstimate.bucket === 'under-kb') return 'downloadTree.sizeUnderKb';
+    if (sizeEstimate.bucket === 'kb') return 'downloadTree.sizeKb';
+    return 'downloadTree.sizeMb';
+  })();
   const sizeValue = sizeEstimate.bucket === 'under-kb' ? '' : sizeEstimate.value;
 
   const stats: { value: string; label: string }[] = [

--- a/src/components/trees/import-gedcom-modal.tsx
+++ b/src/components/trees/import-gedcom-modal.tsx
@@ -193,6 +193,12 @@ export function ImportGedcomModal({
     onOpenChange(false);
   };
 
+  const dropzoneState = ((): 'scanning' | 'error' | 'idle' => {
+    if (scanning) return 'scanning';
+    if (scanError) return 'error';
+    return 'idle';
+  })();
+
   return (
     <Dialog.Root
       open={open}
@@ -214,7 +220,7 @@ export function ImportGedcomModal({
           <Flex direction="column" gap="4">
             {!selected && (
               <Dropzone
-                state={scanning ? 'scanning' : scanError ? 'error' : 'idle'}
+                state={dropzoneState}
                 onFileSelected={handleFileSelected}
                 formatName={t('importGedcom.dropzoneFormatName')}
                 idleLabel={t('importGedcom.dropzoneLabel')}

--- a/src/db/trees/names.test.ts
+++ b/src/db/trees/names.test.ts
@@ -269,6 +269,7 @@ describe('formatName', () => {
     expect(result.full).toBe('(Unknown)');
     expect(result.short).toBe('(Unknown)');
     expect(result.sortable).toBe('');
+    expect(result.surnameFirst).toBe('(Unknown)');
   });
 
   it('formats a complete name', () => {
@@ -283,6 +284,7 @@ describe('formatName', () => {
     expect(result.full).toBe('Dr. John Paul Dupont Jr.');
     expect(result.short).toBe('John Dupont');
     expect(result.sortable).toBe('Dupont, John Paul');
+    expect(result.surnameFirst).toBe('Dupont, Dr. John Paul Jr.');
   });
 
   it('formats name with only given names', () => {
@@ -291,6 +293,8 @@ describe('formatName', () => {
     expect(result.full).toBe('John');
     expect(result.short).toBe('John');
     expect(result.sortable).toBe('John');
+    // No surname → no comma, falls back to `full`.
+    expect(result.surnameFirst).toBe('John');
   });
 
   it('formats name with only surname', () => {
@@ -299,6 +303,8 @@ describe('formatName', () => {
     expect(result.full).toBe('Smith');
     expect(result.short).toBe('Smith');
     expect(result.sortable).toBe('Smith');
+    // No given names → no comma, falls back to `full`.
+    expect(result.surnameFirst).toBe('Smith');
   });
 
   it('formats name with given names and surname', () => {
@@ -307,6 +313,7 @@ describe('formatName', () => {
     expect(result.full).toBe('Jean Marie Martin');
     expect(result.short).toBe('Jean Martin');
     expect(result.sortable).toBe('Martin, Jean Marie');
+    expect(result.surnameFirst).toBe('Martin, Jean Marie');
   });
 
   it('uses nickname as fallback when no other name parts', () => {
@@ -314,6 +321,7 @@ describe('formatName', () => {
     const result = formatName(name);
     expect(result.full).toBe('Johnny');
     expect(result.short).toBe('Johnny');
+    expect(result.surnameFirst).toBe('Johnny');
   });
 
   it('uses prefix in full but not short', () => {
@@ -321,6 +329,8 @@ describe('formatName', () => {
     const result = formatName(name);
     expect(result.full).toBe('Rev. Thomas Clark');
     expect(result.short).toBe('Thomas Clark');
+    // Prefix is preserved on the given-names side of the comma.
+    expect(result.surnameFirst).toBe('Clark, Rev. Thomas');
   });
 
   it('uses suffix in full but not short', () => {
@@ -328,6 +338,22 @@ describe('formatName', () => {
     const result = formatName(name);
     expect(result.full).toBe('John Smith III');
     expect(result.short).toBe('John Smith');
+    // Suffix is preserved on the given-names side of the comma.
+    expect(result.surnameFirst).toBe('Smith, John III');
+  });
+
+  it('keeps sortable free of affixes so it stays a clean sort key', () => {
+    // Two people sharing a surname must sort by given name regardless of
+    // an honorific. `sortable` therefore omits prefix/suffix; only
+    // `surnameFirst` carries them for display.
+    const withPrefix = createMockName({
+      prefix: 'Dr.',
+      givenNames: 'Steve',
+      surname: 'Bourgoin',
+    });
+    const withoutPrefix = createMockName({ givenNames: 'Stéphane', surname: 'Bourgoin' });
+    expect(formatName(withPrefix).sortable).toBe('Bourgoin, Steve');
+    expect(formatName(withoutPrefix).sortable).toBe('Bourgoin, Stéphane');
   });
 });
 

--- a/src/db/trees/names.ts
+++ b/src/db/trees/names.ts
@@ -385,8 +385,19 @@ export async function countNamesForIndividual(individualId: string): Promise<num
 // =============================================================================
 
 /**
- * Format a name for display
- * Returns full, short, and sortable versions
+ * Format a name for display. Returns four representations:
+ *
+ * - `full` — given-first, all parts: `Dr. John Paul Dupont Jr.`
+ * - `short` — first given + surname only: `John Dupont`
+ * - `sortable` — surname-first sort key, no affixes: `Dupont, John Paul`
+ * - `surnameFirst` — surname-first display, affixes preserved on the
+ *   given-names side: `Dupont, Dr. John Paul Jr.`. When the name has no
+ *   surname or no given names, the comma rule does not apply and the
+ *   result matches `full`.
+ *
+ * `sortable` stays free of prefix/suffix because it doubles as a sort
+ * key (a `Dr.` in front would otherwise break intra-surname ordering);
+ * `surnameFirst` is the display string for surname-first list rows.
  */
 export function formatName(name: Name | null): NameDisplay {
   if (!name) {
@@ -394,6 +405,7 @@ export function formatName(name: Name | null): NameDisplay {
       full: '(Unknown)',
       short: '(Unknown)',
       sortable: '',
+      surnameFirst: '(Unknown)',
     };
   }
 
@@ -414,7 +426,7 @@ export function formatName(name: Name | null): NameDisplay {
   }
   if (surname) shortParts.push(surname);
 
-  // Sortable: "Surname, Given Names" format
+  // Sortable: "Surname, Given Names" format — sort key, no affixes
   const sortableParts: string[] = [];
   if (surname) sortableParts.push(surname);
   if (givenNames) {
@@ -430,7 +442,21 @@ export function formatName(name: Name | null): NameDisplay {
   const short = shortParts.length > 0 ? shortParts.join(' ') : (nickname ?? '(Unknown)');
   const sortable = sortableParts.join('');
 
-  return { full, short, sortable };
+  // Surname-first display: only meaningful when both surname and given
+  // names are present — otherwise there is no second half to put after
+  // the comma, so we fall back to `full`.
+  let surnameFirst: string;
+  if (surname && givenNames) {
+    const rightParts: string[] = [];
+    if (prefix) rightParts.push(prefix);
+    rightParts.push(givenNames);
+    if (suffix) rightParts.push(suffix);
+    surnameFirst = `${surname}, ${rightParts.join(' ')}`;
+  } else {
+    surnameFirst = full;
+  }
+
+  return { full, short, sortable, surnameFirst };
 }
 
 /**

--- a/src/db/trees/names.ts
+++ b/src/db/trees/names.ts
@@ -445,16 +445,11 @@ export function formatName(name: Name | null): NameDisplay {
   // Surname-first display: only meaningful when both surname and given
   // names are present — otherwise there is no second half to put after
   // the comma, so we fall back to `full`.
-  let surnameFirst: string;
-  if (surname && givenNames) {
-    const rightParts: string[] = [];
-    if (prefix) rightParts.push(prefix);
-    rightParts.push(givenNames);
-    if (suffix) rightParts.push(suffix);
-    surnameFirst = `${surname}, ${rightParts.join(' ')}`;
-  } else {
-    surnameFirst = full;
-  }
+  const surnameFirst = ((): string => {
+    if (!surname || !givenNames) return full;
+    const rightParts = [prefix, givenNames, suffix].filter(Boolean).join(' ');
+    return `${surname}, ${rightParts}`;
+  })();
 
   return { full, short, sortable, surnameFirst };
 }

--- a/src/i18n/locales/en/individuals.json
+++ b/src/i18n/locales/en/individuals.json
@@ -7,6 +7,7 @@
       "surnameAsc": "Surname (A → Z)",
       "surnameDesc": "Surname (Z → A)",
       "givenAsc": "Given name (A → Z)",
+      "givenDesc": "Given name (Z → A)",
       "birthAsc": "Birth (oldest first)",
       "birthDesc": "Birth (newest first)"
     },

--- a/src/i18n/locales/fr/individuals.json
+++ b/src/i18n/locales/fr/individuals.json
@@ -7,6 +7,7 @@
       "surnameAsc": "Nom (A → Z)",
       "surnameDesc": "Nom (Z → A)",
       "givenAsc": "Prénom (A → Z)",
+      "givenDesc": "Prénom (Z → A)",
       "birthAsc": "Naissance (croissant)",
       "birthDesc": "Naissance (décroissant)"
     },

--- a/src/lib/gedcom/importer.ts
+++ b/src/lib/gedcom/importer.ts
@@ -123,7 +123,11 @@ async function importIndividual(individual: GedcomIndividual, ctx: ImportContext
   const { db, xrefToId } = ctx;
 
   // Parse gender
-  const gender: Gender = individual.gender === 'M' ? 'M' : individual.gender === 'F' ? 'F' : 'U';
+  const gender: Gender = ((): Gender => {
+    if (individual.gender === 'M') return 'M';
+    if (individual.gender === 'F') return 'F';
+    return 'U';
+  })();
 
   // Determine if living: individual is deceased if they have a DEAT event
   const isLiving = !individual.events.some((e) => e.tag === 'DEAT');

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -104,6 +104,7 @@ export interface NameDisplay {
   full: string;
   short: string;
   sortable: string;
+  surnameFirst: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
## What

The People sidebar row now adapts its name format to the active sort:

| Sort | Before | After |
|---|---|---|
| **Surname** (A→Z / Z→A) | `Dr. Steve Bourgoin Jr.` | `Bourgoin, Dr. Steve Jr.` |
| **Given names** (A→Z) | `Dr. Steve Bourgoin Jr.` | `Dr. Steve Bourgoin Jr.` (unchanged) |
| **Birth** (A→Z / Z→A) | `Dr. Steve Bourgoin Jr.` | `Bourgoin, Dr. Steve Jr.` |

The user sees the value being sorted on at the start of each row.

## Why

When a user sorts by surname or birth, they scan the column for a surname — leading with the given name forces them to read past it. Switching to a surname-first format on those sort modes matches the conventions used by genealogy software (Gramps, RootsMagic, …).

## How

- Add a new `surnameFirst` field to `NameDisplay` (`src/types/database.ts`).
- `formatName()` computes it: `"<surname>, <prefix?> <givenNames> <suffix?>"` when both surname and given names are present; otherwise falls back to `full` (no comma to place).
- `sortable` stays free of prefix/suffix — it's the sort key, and a `Dr.` honorific would otherwise break intra-surname ordering between people sharing a surname. This invariant is now documented in JSDoc and asserted by a new test.
- `PersonRow` derives a `NameDisplayMode` (`'givenFirst' | 'surnameFirst'`) from the active sort and picks `surnameFirst` or `full` accordingly.

## Scope

Limited to the **People sidebar**. A global "surname-first vs given-first" preference covering every list in the app (`IndividualsPage`, family members, search results, event participants) is deferred to a future user setting — the right hook for that is a single global preference, not per-surface logic.

## Tests

`pnpm vitest run src/db/trees/names.test.ts` — 29/29 passing. Coverage added for `surnameFirst` across:
- Complete name with prefix + suffix
- Surname-only / given-only fallback to `full`
- Nickname fallback
- The sort-key invariant (`sortable` ignores affixes so two Bourgoin sort by given name regardless of `Dr.`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)