### PR TITLE
refactor: prefer const+IIFE over let across the codebase

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,12 +33,15 @@ export default [
       'no-unused-vars': 'off',
       'no-undef': 'off', // TypeScript handles this
       'no-nested-ternary': 'error',
-      // Prefer immutable bindings. For values derived from a branch, use
-      // a `const` initialised by an IIFE (or a lookup table) rather than
-      // a `let` reassigned across an if/else. No built-in rule enforces
-      // the IIFE-vs-let preference, so it lives as a convention enforced
-      // by review; `prefer-const` covers the simple "never reassigned"
-      // case.
+      // Prefer immutable bindings. For values derived from a branch,
+      // use a `const` initialised by an IIFE (or a lookup table, or a
+      // small named helper) rather than a `let` reassigned across an
+      // if/else. `prefer-const` covers the never-reassigned case;
+      // beyond that, the IIFE-vs-let preference is enforced by review
+      // — `init-declarations` was tried and reverted because it
+      // forced cosmetic `= undefined` initialisers on genuine
+      // loop-accumulator `let`s and pushed branch-derived values into
+      // sub-optimal async IIFEs.
       'prefer-const': 'error',
     },
   },

--- a/src/components/people-sidebar.tsx
+++ b/src/components/people-sidebar.tsx
@@ -238,15 +238,11 @@ export function PeopleSidebar(): JSX.Element | null {
   const treeId = params.treeId;
   if (treeId === undefined) return null;
 
-  let body: ReactNode;
-  if (isLoading) {
-    body = <PeopleListSkeleton />;
-  } else if (isError) {
-    body = <PeopleListMessage>{tCommon('errors.loadFailed')}</PeopleListMessage>;
-  } else if (rows.length === 0) {
-    body = <PeopleListMessage icon>{t('sidebar.empty')}</PeopleListMessage>;
-  } else {
-    body = (
+  const body: ReactNode = ((): ReactNode => {
+    if (isLoading) return <PeopleListSkeleton />;
+    if (isError) return <PeopleListMessage>{tCommon('errors.loadFailed')}</PeopleListMessage>;
+    if (rows.length === 0) return <PeopleListMessage icon>{t('sidebar.empty')}</PeopleListMessage>;
+    return (
       <Flex direction="column" gap="1" p="2">
         {rows.map((person) => (
           <PersonRow
@@ -259,7 +255,7 @@ export function PeopleSidebar(): JSX.Element | null {
         ))}
       </Flex>
     );
-  }
+  })();
 
   return (
     <EntityListPanel

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -380,15 +380,12 @@ async function migrateSystemDbFilenameToPath(db: Database): Promise<void> {
     if (tree.path.startsWith(treesDir + '/')) continue;
 
     try {
-      // Determine the slug from the old value
-      let slug: string;
-      if (tree.path.endsWith('.db')) {
-        // Bare filename: "harry-potter-demo.db" → "harry-potter-demo"
-        slug = tree.path.replace(/\.db$/, '');
-      } else {
-        // Bad path from previous migration: extract last segment
-        slug = tree.path.split('/').pop() ?? tree.path;
-      }
+      // Determine the slug from the old value: bare filename strips the
+      // `.db` suffix; a bad path from a previous migration keeps only
+      // its last segment.
+      const slug = tree.path.endsWith('.db')
+        ? tree.path.replace(/\.db$/, '')
+        : (tree.path.split('/').pop() ?? tree.path);
 
       const newPath = await getTreePathForSlug(slug);
       const oldFilename = `${slug}.db`;

--- a/src/db/trees/citations-with-details.ts
+++ b/src/db/trees/citations-with-details.ts
@@ -95,48 +95,7 @@ export async function getCitationDetailsForSource(sourceId: string): Promise<Cit
   // (b) Individuals linked via the event (event_participants)
   // Only for citations that have an event link
   const eventLinkedCitations = citationRows.filter((r) => r.event_id !== null);
-  let participantRows: RawIndividualRow[] = [];
-
-  if (eventLinkedCitations.length > 0) {
-    // Build a mapping: event_id → citation_id (we know there is at most one
-    // event per citation from the query above)
-    const eventIds = eventLinkedCitations.map((r) => r.event_id as number);
-    const eventIdToCitationId = new Map<number, number>(
-      eventLinkedCitations.map((r) => [r.event_id as number, r.citation_id])
-    );
-
-    const rawParticipants = await db.select<
-      {
-        event_id: number;
-        individual_id: number;
-        given_names: string | null;
-        surname: string | null;
-      }[]
-    >(
-      `SELECT
-         ep.event_id                            AS event_id,
-         i.id                                   AS individual_id,
-         n.given_names                          AS given_names,
-         n.surname                              AS surname
-       FROM event_participants ep
-       JOIN individuals i
-         ON i.id = ep.individual_id
-       LEFT JOIN names n
-         ON n.individual_id = i.id
-         AND n.is_primary = 1
-       WHERE ep.event_id IN (${eventIds.map((_, idx) => `$${idx + 1}`).join(', ')})
-         AND ep.individual_id IS NOT NULL
-       ORDER BY ep.event_id, i.id`,
-      eventIds
-    );
-
-    participantRows = rawParticipants.map((r) => ({
-      citation_id: eventIdToCitationId.get(r.event_id)!,
-      individual_id: r.individual_id,
-      given_names: r.given_names,
-      surname: r.surname,
-    }));
-  }
+  const participantRows = await loadEventParticipantRows(eventLinkedCitations);
 
   // Step 3: merge and deduplicate individuals per citation
   const individualsByCitation = new Map<number, Map<number, { id: string; name: string }>>();
@@ -170,4 +129,56 @@ export async function getCitationDetailsForSource(sourceId: string): Promise<Cit
       linkedIndividuals,
     };
   });
+}
+
+/**
+ * Fetch the individuals linked to a set of event-bearing citations via
+ * `event_participants`. Returns an empty array when no citation has an
+ * event link; each result row carries the citation id so callers can
+ * merge with directly-linked individuals.
+ */
+async function loadEventParticipantRows(
+  eventLinkedCitations: RawCitationRow[]
+): Promise<RawIndividualRow[]> {
+  if (eventLinkedCitations.length === 0) return [];
+  const db = await getTreeDb();
+
+  // Build a mapping: event_id → citation_id (we know there is at most one
+  // event per citation from the parent query)
+  const eventIds = eventLinkedCitations.map((r) => r.event_id as number);
+  const eventIdToCitationId = new Map<number, number>(
+    eventLinkedCitations.map((r) => [r.event_id as number, r.citation_id])
+  );
+
+  const rawParticipants = await db.select<
+    {
+      event_id: number;
+      individual_id: number;
+      given_names: string | null;
+      surname: string | null;
+    }[]
+  >(
+    `SELECT
+       ep.event_id                            AS event_id,
+       i.id                                   AS individual_id,
+       n.given_names                          AS given_names,
+       n.surname                              AS surname
+     FROM event_participants ep
+     JOIN individuals i
+       ON i.id = ep.individual_id
+     LEFT JOIN names n
+       ON n.individual_id = i.id
+       AND n.is_primary = 1
+     WHERE ep.event_id IN (${eventIds.map((_, idx) => `$${idx + 1}`).join(', ')})
+       AND ep.individual_id IS NOT NULL
+     ORDER BY ep.event_id, i.id`,
+    eventIds
+  );
+
+  return rawParticipants.map((r) => ({
+    citation_id: eventIdToCitationId.get(r.event_id)!,
+    individual_id: r.individual_id,
+    given_names: r.given_names,
+    surname: r.surname,
+  }));
 }

--- a/src/db/trees/events.ts
+++ b/src/db/trees/events.ts
@@ -92,6 +92,22 @@ function mapToEventParticipant(raw: RawEventParticipant): EventParticipant {
   };
 }
 
+/**
+ * Look up the Place row referenced by an event. Returns `null` when
+ * the place no longer exists (orphaned foreign key — the schema does
+ * not enforce ON DELETE behaviour here).
+ */
+async function loadPlaceForEvent(placeId: string): Promise<Place | null> {
+  const db = await getTreeDb();
+  const placeRows = await db.select<RawPlace[]>(
+    `SELECT id, name, full_name, place_type_id, parent_id, latitude, longitude, notes, created_at, updated_at
+     FROM places
+     WHERE id = $1`,
+    [parseEntityId(placeId)]
+  );
+  return placeRows[0] ? mapToPlace(placeRows[0]) : null;
+}
+
 // =============================================================================
 // EventType Operations
 // =============================================================================
@@ -244,19 +260,7 @@ export async function getEventWithDetails(id: string): Promise<EventWithDetails 
   }
 
   // Get place if exists
-  let place: Place | null = null;
-  if (event.placeId) {
-    const db = await getTreeDb();
-    const placeRows = await db.select<RawPlace[]>(
-      `SELECT id, name, full_name, place_type_id, parent_id, latitude, longitude, notes, created_at, updated_at
-       FROM places
-       WHERE id = $1`,
-      [parseEntityId(event.placeId)]
-    );
-    if (placeRows[0]) {
-      place = mapToPlace(placeRows[0]);
-    }
-  }
+  const place = event.placeId ? await loadPlaceForEvent(event.placeId) : null;
 
   // Get participants
   const participants = await getEventParticipants(id);

--- a/src/db/trees/places.ts
+++ b/src/db/trees/places.ts
@@ -381,16 +381,10 @@ export async function getPlaceWithHierarchy(id: string): Promise<PlaceWithHierar
   if (!place) return null;
 
   // Get place type
-  let placeType: PlaceType | null = null;
-  if (place.placeTypeId) {
-    placeType = await getPlaceTypeById(place.placeTypeId);
-  }
+  const placeType = place.placeTypeId ? await getPlaceTypeById(place.placeTypeId) : null;
 
   // Get parent place
-  let parent: Place | null = null;
-  if (place.parentId) {
-    parent = await getPlaceById(place.parentId);
-  }
+  const parent = place.parentId ? await getPlaceById(place.parentId) : null;
 
   // Get children
   const children = await getChildPlaces(id);

--- a/src/gedcom-date/parse.ts
+++ b/src/gedcom-date/parse.ts
@@ -63,18 +63,11 @@ export function parse(input: string): ParseResult {
  * Parse a simple date with optional modifier.
  */
 function parseSimple(input: string, original: string): ParseResult {
-  let remaining = input;
-  let modifier: DateModifier | undefined;
-
-  // Check for modifier prefix
+  // Check for modifier prefix — pick the first matching one (none of
+  // ABT/CAL/EST/BEF/AFT is a prefix of another, so order is irrelevant).
   const modifiers: DateModifier[] = ['ABT', 'CAL', 'EST', 'BEF', 'AFT'];
-  for (const mod of modifiers) {
-    if (remaining.startsWith(mod + ' ')) {
-      modifier = mod;
-      remaining = remaining.slice(mod.length + 1).trim();
-      break;
-    }
-  }
+  const modifier = modifiers.find((mod) => input.startsWith(mod + ' '));
+  const remaining = modifier ? input.slice(modifier.length + 1).trim() : input;
 
   const datePoint = parseDatePoint(remaining);
   if (!datePoint) {
@@ -150,10 +143,9 @@ function parseRange(input: string, original: string): ParseResult {
  * Parse a date period (FROM ... TO ...).
  */
 function parsePeriod(input: string, original: string): ParseResult {
-  let from: DatePoint | undefined;
-  let to: DatePoint | undefined;
-
-  // Check for FROM ... TO ... pattern
+  // Each branch (FROM ... TO, FROM only, TO only, neither) is self-
+  // contained and returns its full ParseResult, so `from` / `to` can
+  // stay as branch-local `const`s instead of outer `let`s.
   if (input.startsWith('FROM ')) {
     const content = input.slice(5).trim();
     const toIndex = content.indexOf(' TO ');
@@ -163,60 +155,39 @@ function parsePeriod(input: string, original: string): ParseResult {
       const fromStr = content.slice(0, toIndex).trim();
       const toStr = content.slice(toIndex + 4).trim();
 
-      const fromParsed = parseDatePoint(fromStr);
-      if (!fromParsed) {
-        return {
-          success: false,
-          error: `Invalid period start date: ${fromStr}`,
-          original,
-        };
+      const from = parseDatePoint(fromStr);
+      if (!from) {
+        return { success: false, error: `Invalid period start date: ${fromStr}`, original };
       }
-      from = fromParsed;
 
-      const toParsed = parseDatePoint(toStr);
-      if (!toParsed) {
-        return {
-          success: false,
-          error: `Invalid period end date: ${toStr}`,
-          original,
-        };
+      const to = parseDatePoint(toStr);
+      if (!to) {
+        return { success: false, error: `Invalid period end date: ${toStr}`, original };
       }
-      to = toParsed;
-    } else {
-      // FROM ... only
-      const fromParsed = parseDatePoint(content);
-      if (!fromParsed) {
-        return {
-          success: false,
-          error: `Invalid period start date: ${content}`,
-          original,
-        };
-      }
-      from = fromParsed;
+
+      return { success: true, date: { type: 'period', from, to }, original };
     }
-  } else if (input.startsWith('TO ')) {
-    // TO ... only
-    const content = input.slice(3).trim();
-    const toParsed = parseDatePoint(content);
-    if (!toParsed) {
-      return {
-        success: false,
-        error: `Invalid period end date: ${content}`,
-        original,
-      };
+
+    // FROM ... only
+    const from = parseDatePoint(content);
+    if (!from) {
+      return { success: false, error: `Invalid period start date: ${content}`, original };
     }
-    to = toParsed;
+    return { success: true, date: { type: 'period', from, to: undefined }, original };
   }
 
-  return {
-    success: true,
-    date: {
-      type: 'period',
-      from,
-      to,
-    },
-    original,
-  };
+  if (input.startsWith('TO ')) {
+    // TO ... only
+    const content = input.slice(3).trim();
+    const to = parseDatePoint(content);
+    if (!to) {
+      return { success: false, error: `Invalid period end date: ${content}`, original };
+    }
+    return { success: true, date: { type: 'period', from: undefined, to }, original };
+  }
+
+  // Neither FROM nor TO prefix — empty period.
+  return { success: true, date: { type: 'period', from: undefined, to: undefined }, original };
 }
 
 /**

--- a/src/gedcom-parser/parse.ts
+++ b/src/gedcom-parser/parse.ts
@@ -213,15 +213,17 @@ function parseIndividual(lines: GedcomLine[], startIndex: number, xref: string):
 function parseName(lines: GedcomLine[], startIndex: number, value?: string): GedcomName {
   const name: GedcomName = {};
 
-  // Parse name value (e.g., "Jean /DUPONT/ Jr.")
-  let parsedSuffix: string | undefined;
-  if (value) {
+  // Parse name value (e.g., "Jean /DUPONT/ Jr.") — populates `name`
+  // with whatever we can derive from the inline value, and surfaces
+  // the parsed suffix separately so we can fall back to it later if
+  // no NSFX sub-tag is seen.
+  const parsed = value ? parseNameValue(value) : null;
+  if (value && parsed) {
     name.value = value;
-    const parsed = parseNameValue(value);
     if (parsed.givenNames) name.givenNames = parsed.givenNames;
     if (parsed.surname) name.surname = parsed.surname;
-    parsedSuffix = parsed.suffix;
   }
+  const parsedSuffix = parsed?.suffix;
 
   // Parse sub-tags
   const children = getChildLines(lines, startIndex);

--- a/src/lib/gedcom/importer.ts
+++ b/src/lib/gedcom/importer.ts
@@ -104,6 +104,19 @@ export async function importGedcom(content: string): Promise<ImportStats> {
 /**
  * Load event types into cache for fast lookup.
  */
+/**
+ * Try to derive a `date_sort` value from a raw GEDCOM date string.
+ * Returns `null` when the date is absent, unparseable, or has no
+ * usable point — callers always store the original string in
+ * `date_original` regardless.
+ */
+function tryParseSortDate(date: string | undefined): string | null {
+  if (!date) return null;
+  const parsed = parse(date);
+  if (parsed.success && parsed.date) return toSortDate(parsed.date);
+  return null;
+}
+
 async function loadEventTypeCache(ctx: ImportContext): Promise<void> {
   const { db, eventTypeCache } = ctx;
 
@@ -197,29 +210,19 @@ async function importIndividualEvent(
 ): Promise<boolean> {
   const { db, eventTypeCache } = ctx;
 
-  // Get event type ID
-  let eventTypeId: number | undefined;
-
-  if (event.tag === 'EVEN' && event.type) {
-    // Custom event - create or get custom event type
-    eventTypeId = await getOrCreateCustomEventType(event.type, 'individual', ctx);
-  } else {
-    eventTypeId = eventTypeCache.get(event.tag);
-  }
+  // Get event type ID — either a custom one we materialise on the fly,
+  // or one pulled from the cache for a standard tag.
+  const eventTypeId =
+    event.tag === 'EVEN' && event.type
+      ? await getOrCreateCustomEventType(event.type, 'individual', ctx)
+      : eventTypeCache.get(event.tag);
 
   if (eventTypeId === undefined) {
     // Unknown event type - skip silently
     return false;
   }
 
-  // Parse date
-  let dateSort: string | null = null;
-  if (event.date) {
-    const parsed = parse(event.date);
-    if (parsed.success && parsed.date) {
-      dateSort = toSortDate(parsed.date);
-    }
-  }
+  const dateSort = tryParseSortDate(event.date);
 
   // Get or create place
   const placeId = event.place ? await getOrCreatePlace(event.place, ctx) : null;
@@ -315,28 +318,18 @@ async function importFamilyEvent(
 ): Promise<boolean> {
   const { db, eventTypeCache } = ctx;
 
-  // Get event type ID
-  let eventTypeId: number | undefined;
-
-  if (event.tag === 'EVEN' && event.type) {
-    // Custom event
-    eventTypeId = await getOrCreateCustomEventType(event.type, 'family', ctx);
-  } else {
-    eventTypeId = eventTypeCache.get(event.tag);
-  }
+  // Get event type ID — either a custom one we materialise on the fly,
+  // or one pulled from the cache for a standard tag.
+  const eventTypeId =
+    event.tag === 'EVEN' && event.type
+      ? await getOrCreateCustomEventType(event.type, 'family', ctx)
+      : eventTypeCache.get(event.tag);
 
   if (eventTypeId === undefined) {
     return false;
   }
 
-  // Parse date
-  let dateSort: string | null = null;
-  if (event.date) {
-    const parsed = parse(event.date);
-    if (parsed.success && parsed.date) {
-      dateSort = toSortDate(parsed.date);
-    }
-  }
+  const dateSort = tryParseSortDate(event.date);
 
   // Get or create place
   const placeId = event.place ? await getOrCreatePlace(event.place, ctx) : null;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -93,13 +93,10 @@ export function HomePage(): JSX.Element {
     }
   };
 
-  let treesContent: JSX.Element;
-  if (error) {
-    treesContent = <Text color="gray">{t('common:errors.loadFailed')}</Text>;
-  } else if (isLoading) {
-    treesContent = <Text color="gray">{t('trees:loading')}</Text>;
-  } else {
-    treesContent = (
+  const treesContent = ((): JSX.Element => {
+    if (error) return <Text color="gray">{t('common:errors.loadFailed')}</Text>;
+    if (isLoading) return <Text color="gray">{t('trees:loading')}</Text>;
+    return (
       <>
         <Box style={{ marginTop: 'clamp(48px, 7vw, 76px)', marginBottom: 22 }}>
           <TreeSectionDivider
@@ -141,7 +138,7 @@ export function HomePage(): JSX.Element {
         </Grid>
       </>
     );
-  }
+  })();
 
   return (
     <Flex direction="column" height="100vh">


### PR DESCRIPTION
## What

Follow-up to PR #135 which established `no-nested-ternary` and the "prefer immutable bindings" convention. This PR applies the convention to the rest of the codebase: every `let foo;` / `let foo = null;` followed by branched assignment is now a `const` — built via an IIFE, a ternary, `.find`, or a small named helper, whichever fits best.

## Why

PR #135 wired up the rule but only fixed the files it touched. This PR is the codebase-wide sweep.

## How

Per-file:

| File | Before | After |
|---|---|---|
| `db/connection.ts` | `let slug` + if/else | ternary |
| `db/trees/places.ts` | `let placeType`/`parent = null` + if | ternaries against existing helpers |
| `db/trees/events.ts` | `let place = null` + multi-statement if | extracted `loadPlaceForEvent` helper |
| `db/trees/citations-with-details.ts` | `let participantRows = []` + big if | extracted `loadEventParticipantRows` helper |
| `lib/gedcom/importer.ts` | duplicated `let eventTypeId` / `let dateSort` (×2) | ternaries + new `tryParseSortDate` helper |
| `gedcom-date/parse.ts` `parseSimple` | `let modifier` + for/break loop | `.find` + derived `remaining` |
| `gedcom-date/parse.ts` `parsePeriod` | `let from`/`to` + sequential validation | each branch returns its own complete `ParseResult` |
| `gedcom-parser/parse.ts` `parsedSuffix` | `let parsedSuffix` (was an IIFE in an earlier draft of this branch but it hid side effects on `name`) | explicit if-block for mutations, `const parsedSuffix = parsed?.suffix` separately |
| `pages/Home.tsx` `treesContent` | `let` + if/else if/else | IIFE over the three render branches |
| `components/people-sidebar.tsx` `body` | `let` + if/else if/else | IIFE |

Legitimate `let`s left alone (with a rationale per site, see the commit message):
- Module-level connection cache (`db/connection.ts`)
- Loop accumulators (`FamilyManager`, `families.ts`, `lib/gedcom/exporter.ts`)
- Loop traversal variable (`places.getPlaceHierarchy.currentId`)
- Async listener handle (`routes/tree/$treeId.tsx.unlisten`)

## On `init-declarations: 'always'`

I tried `init-declarations: ['error', 'always']` in this branch to make the convention lintable. The `/simplify` review pushed back convincingly:

- It forced cosmetic `= undefined` on legitimate `let`s (loop accumulators, listener handles) — pure noise
- It pushed branch-derived async values into sub-optimal **async IIFEs** when a small named helper was clearly cleaner

I reverted it. `prefer-const` enforces the lintable part; the IIFE-vs-let preference is now a documented review convention in `eslint.config.js`.

## Tests

`pnpm vitest run` — 556/556 passing. Pure refactor, no functional change. Lint, TypeScript, build all green.

## Net

10 files changed, **-32 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)