### PR TITLE
docs(skills): apply 3 adoption-review adjustments from #123

### DIFF
--- a/.claude/skills/capture-idea/SKILL.md
+++ b/.claude/skills/capture-idea/SKILL.md
@@ -18,6 +18,12 @@ Activate as soon as the user expresses one of these intents in either French or 
 
 If the user is asking for the work to be done **now**, this skill does not apply — proceed with the task instead.
 
+## Batch captures
+
+When a planning or design session produces multiple icebox items at once, **invoke this skill once per item** — N items means N separate capture-idea invocations. Do not create a batch of issues via a direct `gh issue create` loop: that path bypasses steps 6 and 7 (Issue Type + Icebox status mutations), leaving items untyped and likely at Status=Todo in the project (the auto-add default) rather than Icebox.
+
+If the user says "file all of these as icebox items", work through the list sequentially, running each item through the full capture flow before moving to the next.
+
 ## Capture flow
 
 Follow these steps in order. Do **not** ask the user for confirmation before creating — the trigger phrase is itself the explicit signal.

--- a/.claude/skills/link-task/SKILL.md
+++ b/.claude/skills/link-task/SKILL.md
@@ -90,6 +90,12 @@ git config branch."$(git branch --show-current)".ghIssue 2>/dev/null
 
 If the value is empty, no link exists for this branch. **Do not search GitHub at PR time** — Phase A is the only entry point for that. Just create the PR without a magic word.
 
+Exception: if the branch name begins with `feat/` or `fix/` and no link is stored, emit a soft one-line warning before proceeding:
+
+> ⚠ No issue linked for this `feat/` branch — if it closes a backlog item, run Phase A first. Continuing without `Closes #N`.
+
+This does not block PR creation — it surfaces the gap so the user can decide to run Phase A retroactively.
+
 ### 2. Inject the magic word
 
 If the value is `<N>`, ensure the PR description body ends with a footer line:

--- a/docs/dev-tools/issue-tracking.md
+++ b/docs/dev-tools/issue-tracking.md
@@ -51,5 +51,5 @@ The transition from `Icebox` → `Todo` is the explicit promotion moment ("yes, 
 
 Two Claude Code skills automate the workflow — see their skill files for trigger phrases and behavior:
 
-- **`capture-idea`** — files an idea as an issue, picks 0–2 labels, sets the type, and pins Status to **Icebox**.
-- **`link-task`** — at the start of a dev task, binds the branch to an existing open issue so the PR auto-closes it on merge. It does not create issues; use `capture-idea` first if none exists.
+- **`capture-idea`** — files an idea as an issue, picks 0–2 labels, sets the type, and pins Status to **Icebox**. **Batch captures**: when a session produces multiple ideas at once, invoke the skill once per item — never batch via a direct `gh issue create` loop, which bypasses the type and Icebox mutations.
+- **`link-task`** — at the start of a dev task, binds the branch to an existing open issue so the PR auto-closes it on merge. It does not create issues; use `capture-idea` first if none exists. **Habit rule**: for every `feat/` or `fix/` branch, run `link-task` explicitly before writing any code — don't rely on trigger phrases alone. If Phase B detects a `feat/`/`fix/` branch with no stored link, it emits a soft warning before proceeding.


### PR DESCRIPTION
## Summary

Applies the three adjustments proposed in the adoption review (#123) of the `capture-idea` and `link-task` skills 2 weeks after they shipped.

- **`capture-idea` SKILL** — new **Batch captures** section: batch sessions must invoke the skill once per item, never via a direct `gh issue create` loop (which bypasses the Issue Type + Icebox status mutations).
- **`link-task` SKILL** — Phase B now emits a soft one-line warning when a `feat/` or `fix/` branch has no stored `ghIssue` link, instead of silently skipping.
- **`docs/dev-tools/issue-tracking.md`** — surfaces both rules in the skill summaries (habit rule + batch-capture note).

Companion to the original (closed-without-merge) PR #124.

Closes #123

## Test plan

- [ ] Open a `feat/` branch without running Phase A, then trigger `/commit-push-pr` — verify the warning appears before PR creation.
- [ ] Trigger `capture-idea` twice in one session for two separate ideas — verify each goes through the full 8-step flow individually.
- [ ] Check the three updated files render correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)