### PR TITLE
fix(agent): install Claude Code CLI in the agent workflow

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Configure git identity
         run: |
           git config user.name "vata-agent[bot]"


### PR DESCRIPTION
## Summary

Second dry-run of the agent workflow (issue #97) failed at **Run agent** with `sh: 1: claude: not found` (exit 127). Sandcastle's `claudeCode()` agent provider spawns the `claude` binary directly via subprocess — it doesn't ship the CLI itself.

Fix: add an `npm install -g @anthropic-ai/claude-code` step between **Install dependencies** and **Configure git identity**. Latest version each run (gets Anthropic's fixes automatically) rather than pinning.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, retry issue #97: remove `agent:failed`, re-add `agent:ready`. Confirm the agent gets past the spawn step.