### PR TITLE
fix(agent): tell the prompt explicitly to commit before completing

### DIFF
--- a/.sandcastle/prompts/default.md
+++ b/.sandcastle/prompts/default.md
@@ -31,10 +31,18 @@ These are particular to this CI run and are **not** in `CLAUDE.md`:
 - The Tauri desktop app cannot be launched here (no display server). `pnpm tauri:dev` / `pnpm tauri:build` are unavailable. UI verification is performed manually by the maintainer after you finish.
 - Do not modify anything under `.sandcastle/` or `.github/workflows/agent-run.yml` unless the issue is explicitly about the agent workflow itself.
 
+# Commit before completing
+
+You **must commit your changes** with `git add` + `git commit` before signaling completion. Sandcastle collects commits from the branch — uncommitted edits are lost. Make one or more commits with conventional commit messages (`feat:`, `fix:`, `refactor:`, …) as described in `CLAUDE.md`. After committing, confirm `git status` shows a clean working tree.
+
 # When you're done
 
-When `pnpm verify` is green and the change matches the issue body:
+When all of these are true:
 
-Emit `<promise>COMPLETE</promise>` on its own line.
+1. `pnpm verify` is green on the final state of the branch
+2. The change matches the issue body
+3. `git status` shows no uncommitted changes (everything is committed)
+
+Then — and only then — emit `<promise>COMPLETE</promise>` on its own line.
 
 Do not emit this signal under any other condition.


### PR DESCRIPTION
## Summary

Third dry-run of the agent workflow (issue #97) was a partial success: the agent correctly read `CLAUDE.md`, applied the codemod, ran `pnpm verify` (green), and signaled `<promise>COMPLETE</promise>` — but **never committed**. Sandcastle reported `No commits to sync out` and the outcome computation correctly classified it as failed (0 commits = failed by design).

Root cause: although `CLAUDE.md` has a "Granular Commits" section, the agent didn't act on it reflexively, and the prompt's "When you're done" criteria didn't mention commits. The agent treated "done" as "verify green" and signaled completion with uncommitted edits in the worktree.

Fix: the prompt now has a dedicated "Commit before completing" section and the completion criteria explicitly include `git status` showing a clean tree.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, retry issue #97: remove `agent:failed`, add `agent:ready`. Confirm:
  - Agent commits its work
  - Workflow opens a PR (success path)
  - Issue gets `agent:success`