### PR TITLE
Add $managers/* and $types/* to path aliases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,11 +110,11 @@ Each file in `src/db/trees/` and `src/db/system/` follows this structure:
 | `$lib/*`        | `src/lib/*`        |
 | `$components/*` | `src/components/*` |
 | `$hooks/*`      | `src/hooks/*`      |
-| `$managers`     | `src/managers`     |
+| `$managers/*`   | `src/managers/*`   |
 | `$db`           | `src/db`           |
 | `$db-system/*`  | `src/db/system/*`  |
 | `$db-tree/*`    | `src/db/trees/*`   |
-| `$types`        | `src/types`        |
+| `$types/*`      | `src/types/*`      |
 
 ## Routing
 

--- a/src/components/people-sidebar.tsx
+++ b/src/components/people-sidebar.tsx
@@ -9,7 +9,7 @@ import { EntityListPanel, type EntityListSortOption } from './entity-list-panel'
 import { Icon } from '$components/icon';
 import { useIndividuals } from '$hooks/useIndividuals';
 import { formatName } from '$db-tree/names';
-import type { IndividualWithDetails, Name } from '$/types/database';
+import type { IndividualWithDetails, Name } from '$types/database';
 
 /** The sort orders offered by the People sidebar, in display order. */
 const SORT_VALUES = [

--- a/src/components/trees/delete-tree-modal.tsx
+++ b/src/components/trees/delete-tree-modal.tsx
@@ -14,7 +14,7 @@ import {
 } from '@radix-ui/themes';
 
 import { deleteTree as defaultDeleteTree } from '$db-system/trees';
-import { GedcomManager } from '$/managers/GedcomManager';
+import { GedcomManager } from '$managers/GedcomManager';
 import { queryKeys } from '$lib/query-keys';
 
 /**

--- a/src/components/trees/download-tree-modal.tsx
+++ b/src/components/trees/download-tree-modal.tsx
@@ -15,7 +15,7 @@ import {
 } from '@radix-ui/themes';
 
 import { Icon } from '$components/icon';
-import { GedcomManager } from '$/managers/GedcomManager';
+import { GedcomManager } from '$managers/GedcomManager';
 
 /**
  * Lightweight projection of {@link Tree} carrying just what the modal

--- a/src/components/trees/edit-tree-modal.tsx
+++ b/src/components/trees/edit-tree-modal.tsx
@@ -16,7 +16,7 @@ import {
 import { updateTree as defaultUpdateTree } from '$db-system/trees';
 import { formatIsoDate } from '$lib/format';
 import { queryKeys } from '$lib/query-keys';
-import type { Tree } from '$/types/database';
+import type { Tree } from '$types/database';
 
 interface UpdateTreeInput {
   name: string;

--- a/src/components/trees/import-gedcom-modal.tsx
+++ b/src/components/trees/import-gedcom-modal.tsx
@@ -18,7 +18,7 @@ import {
 
 import { Dropzone } from '$components/dropzone';
 import { Icon } from '$components/icon';
-import { GedcomManager, type ImportResult, type ScanResult } from '$/managers/GedcomManager';
+import { GedcomManager, type ImportResult, type ScanResult } from '$managers/GedcomManager';
 import { formatBytes } from '$lib/format';
 import { queryKeys } from '$lib/query-keys';
 

--- a/src/components/trees/new-tree-modal.tsx
+++ b/src/components/trees/new-tree-modal.tsx
@@ -13,7 +13,7 @@ import {
   TextField,
 } from '@radix-ui/themes';
 
-import { TreeManager } from '$/managers/TreeManager';
+import { TreeManager } from '$managers/TreeManager';
 import { queryKeys } from '$lib/query-keys';
 
 interface CreateTreeInput {

--- a/src/db/system/trees.ts
+++ b/src/db/system/trees.ts
@@ -1,6 +1,6 @@
 import type Database from '@tauri-apps/plugin-sql';
 import { getSystemDb } from '../connection';
-import type { Tree } from '$/types/database';
+import type { Tree } from '$types/database';
 
 interface RawTree {
   id: number;

--- a/src/db/trees/citations-with-details.test.ts
+++ b/src/db/trees/citations-with-details.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTreeInMemoryDb } from '$/test/sqlite-memory';
 import { getCitationDetailsForSource } from './citations-with-details';
 import { createSource } from './sources';
-import { SourceWorkspaceManager } from '$/managers/SourceWorkspaceManager';
+import { SourceWorkspaceManager } from '$managers/SourceWorkspaceManager';
 
 // A single in-memory DB shared across all tests in this file.
 const db = createTreeInMemoryDb();

--- a/src/db/trees/citations-with-details.ts
+++ b/src/db/trees/citations-with-details.ts
@@ -1,6 +1,6 @@
 import { getTreeDb } from '../connection';
 import { formatEntityId, parseEntityId } from '$/lib/entityId';
-import type { CitationDetail } from '$/types/database';
+import type { CitationDetail } from '$types/database';
 
 // =============================================================================
 // Raw database row types (snake_case as in SQLite)

--- a/src/db/trees/citations.ts
+++ b/src/db/trees/citations.ts
@@ -10,7 +10,7 @@ import type {
   UpdateCitationInput,
   CitationLink,
   CreateCitationLinkInput,
-} from '$/types/database';
+} from '$types/database';
 
 // =============================================================================
 // Raw database row types (snake_case as in SQLite)

--- a/src/db/trees/event-timeline.ts
+++ b/src/db/trees/event-timeline.ts
@@ -1,7 +1,7 @@
 import { getTreeDb } from '../connection';
 import { parseEntityId, formatEntityId } from '$/lib/entityId';
 import { getEventsByIndividualIdWithDetails } from './events';
-import type { EventTimelineEntry, EventTimelineThumbnail } from '$/types/database';
+import type { EventTimelineEntry, EventTimelineThumbnail } from '$types/database';
 
 interface RawCitationSource {
   event_id: number;

--- a/src/db/trees/events.ts
+++ b/src/db/trees/events.ts
@@ -14,7 +14,7 @@ import type {
   CreateEventTypeInput,
   Place,
   ParticipantRole,
-} from '$/types/database';
+} from '$types/database';
 
 // =============================================================================
 // Raw database row types (snake_case as in SQLite)

--- a/src/db/trees/families.ts
+++ b/src/db/trees/families.ts
@@ -10,7 +10,7 @@ import type {
   Pedigree,
   FamilyWithMembers,
   IndividualWithDetails,
-} from '$/types/database';
+} from '$types/database';
 import { getIndividualById } from './individuals';
 import { getPrimaryName, getNamesByIndividualId } from './names';
 

--- a/src/db/trees/files.ts
+++ b/src/db/trees/files.ts
@@ -5,7 +5,7 @@ import type {
   CreateFileInput,
   UpdateFileInput,
   CreateSourceFileInput,
-} from '$/types/database';
+} from '$types/database';
 
 // =============================================================================
 // Raw database row types (snake_case as in SQLite)

--- a/src/db/trees/individuals.ts
+++ b/src/db/trees/individuals.ts
@@ -6,7 +6,7 @@ import type {
   Gender,
   CreateIndividualInput,
   UpdateIndividualInput,
-} from '$/types/database';
+} from '$types/database';
 
 // =============================================================================
 // Raw database row type (snake_case as in SQLite)

--- a/src/db/trees/names.test.ts
+++ b/src/db/trees/names.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTreeInMemoryDb } from '$/test/sqlite-memory';
 import { createIndividual } from './individuals';
-import type { Name } from '$/types/database';
+import type { Name } from '$types/database';
 import {
   getNamesByIndividualId,
   getPrimaryName,

--- a/src/db/trees/names.ts
+++ b/src/db/trees/names.ts
@@ -7,7 +7,7 @@ import type {
   CreateNameInput,
   UpdateNameInput,
   NameDisplay,
-} from '$/types/database';
+} from '$types/database';
 
 // =============================================================================
 // Raw database row type (snake_case as in SQLite)

--- a/src/db/trees/places.ts
+++ b/src/db/trees/places.ts
@@ -7,7 +7,7 @@ import type {
   UpdatePlaceInput,
   CreatePlaceTypeInput,
   PlaceWithHierarchy,
-} from '$/types/database';
+} from '$types/database';
 
 // =============================================================================
 // Raw database row types (snake_case as in SQLite)

--- a/src/db/trees/repositories.ts
+++ b/src/db/trees/repositories.ts
@@ -1,6 +1,6 @@
 import { getTreeDb } from '../connection';
 import { formatEntityId, parseEntityId } from '$/lib/entityId';
-import type { Repository, CreateRepositoryInput, UpdateRepositoryInput } from '$/types/database';
+import type { Repository, CreateRepositoryInput, UpdateRepositoryInput } from '$types/database';
 
 // =============================================================================
 // Raw database row type (snake_case as in SQLite)

--- a/src/db/trees/sources.ts
+++ b/src/db/trees/sources.ts
@@ -1,6 +1,6 @@
 import { getTreeDb } from '../connection';
 import { formatEntityId, parseEntityId } from '$/lib/entityId';
-import type { Source, CreateSourceInput, UpdateSourceInput } from '$/types/database';
+import type { Source, CreateSourceInput, UpdateSourceInput } from '$types/database';
 
 // =============================================================================
 // Raw database row type (snake_case as in SQLite)

--- a/src/hooks/useFamilies.ts
+++ b/src/hooks/useFamilies.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '$/lib/query-keys';
-import { FamilyManager } from '$/managers/FamilyManager';
+import { FamilyManager } from '$managers/FamilyManager';
 
 export function useFamilies() {
   return useQuery({

--- a/src/hooks/useIndividuals.ts
+++ b/src/hooks/useIndividuals.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '$/lib/query-keys';
-import { IndividualManager } from '$/managers/IndividualManager';
+import { IndividualManager } from '$managers/IndividualManager';
 
 export function useIndividuals() {
   return useQuery({

--- a/src/lib/event-type-labels.test.ts
+++ b/src/lib/event-type-labels.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { EventType } from '$/types/database';
+import type { EventType } from '$types/database';
 
 import { getEventTypeLabel } from './event-type-labels';
 

--- a/src/lib/event-type-labels.ts
+++ b/src/lib/event-type-labels.ts
@@ -1,4 +1,4 @@
-import type { EventType } from '$/types/database';
+import type { EventType } from '$types/database';
 
 const GEDCOM_EVENT_TYPE_LABELS: Record<string, string> = {
   // Individual events

--- a/src/lib/gedcom/importer.ts
+++ b/src/lib/gedcom/importer.ts
@@ -16,7 +16,7 @@ import {
 } from '@vata-apps/gedcom-parser';
 import { parse, toSortDate } from '@vata-apps/gedcom-date';
 import { getTreeDb } from '$/db/connection';
-import type { Gender } from '$/types/database';
+import type { Gender } from '$types/database';
 import { formatEntityId, parseEntityId } from '$/lib/entityId';
 import type Database from '@tauri-apps/plugin-sql';
 

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,4 +1,4 @@
-import type { ParticipantRole } from '$/types/database';
+import type { ParticipantRole } from '$types/database';
 
 export interface TemplateSlot {
   key: string;

--- a/src/managers/FamilyManager.ts
+++ b/src/managers/FamilyManager.ts
@@ -19,7 +19,7 @@ import type {
   FamilyWithMembers,
   IndividualWithDetails,
   Pedigree,
-} from '$/types/database';
+} from '$types/database';
 
 export class FamilyManager {
   /**

--- a/src/managers/IndividualManager.ts
+++ b/src/managers/IndividualManager.ts
@@ -28,7 +28,7 @@ import type {
   IndividualWithDetails,
   Name,
   UpdateIndividualInput,
-} from '$/types/database';
+} from '$types/database';
 
 export interface CreateIndividualWithNameInput extends CreateIndividualInput {
   name?: {

--- a/src/managers/SourceWorkspaceManager.ts
+++ b/src/managers/SourceWorkspaceManager.ts
@@ -5,7 +5,7 @@ import { createFamily, addFamilyMember } from '$db-tree/families';
 import { createCitation, createCitationLink } from '$db-tree/citations';
 import { createPlace } from '$db-tree/places';
 import { getTemplateById, type TemplateDefinition } from '$lib/templates';
-import type { Gender } from '$/types/database';
+import type { Gender } from '$types/database';
 
 // =============================================================================
 // Types

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -17,10 +17,10 @@ import { TreeCard, type TreeCardLabels } from '$components/trees/tree-card';
 import { TreeCardCta } from '$components/trees/tree-card-cta';
 import { TreeSectionDivider } from '$components/trees/tree-section-divider';
 import { getAllTrees } from '$db-system/trees';
-import { TreeManager } from '$/managers/TreeManager';
+import { TreeManager } from '$managers/TreeManager';
 import { formatIsoDate } from '$lib/format';
 import { queryKeys } from '$lib/query-keys';
-import type { Tree } from '$/types/database';
+import type { Tree } from '$types/database';
 
 type SortKey = 'recent' | 'name' | 'size';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,10 +22,12 @@
       "$components/*": ["src/components/*"],
       "$hooks/*": ["src/hooks/*"],
       "$managers": ["src/managers"],
+      "$managers/*": ["src/managers/*"],
       "$db": ["src/db"],
       "$db-system/*": ["src/db/system/*"],
       "$db-tree/*": ["src/db/trees/*"],
       "$types": ["src/types"],
+      "$types/*": ["src/types/*"],
       "@vata-apps/gedcom-parser": ["src/gedcom-parser"],
       "@vata-apps/gedcom-date": ["src/gedcom-date"]
     }


### PR DESCRIPTION
Closes #97

## Summary

- Added `$managers/*` → `src/managers/*` and `$types/*` → `src/types/*` path aliases to `tsconfig.json`, alongside the existing bare `$managers` and `$types` entries
- Codemoded all 30 affected source files: `$/managers/X` imports become `$managers/X`, `$/types/X` imports become `$types/X`
- Updated the Path Aliases table in `CLAUDE.md` to show the new `/*` forms as the canonical aliases

## Notes for the reviewer

Vite and Vitest configs were not changed — their plain-string prefix aliases (`$managers`, `$types`) already resolve sub-paths correctly via Vite's prefix-replacement mechanism, matching the same pattern used by `$lib`, `$components`, and `$hooks`. The bare `$managers` and `$types` entries are retained in `tsconfig.json` to preserve backward compatibility with any bare imports (e.g. `import ... from '$managers'`), though no such imports exist in the codebase today.

---
🤖 Agent workflow · 1 iteration(s) · claude-sonnet-4-6