### PR TITLE
feat(agent): authenticate via GitHub App instead of a PAT

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -20,16 +20,23 @@ jobs:
     timeout-minutes: 45
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number }}
-      # PAT (not GITHUB_TOKEN) so the agent's PR triggers ci.yml — GitHub
-      # suppresses downstream workflows for GITHUB_TOKEN-authored events.
-      GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
       PR_BODY_PATH: /tmp/agent-pr-body.md
 
     steps:
+      # Mint a token from the vata-agent GitHub App — used instead of
+      # GITHUB_TOKEN (whose PRs do not trigger ci.yml) and instead of a PAT
+      # (whose actions are attributed to a person, not the bot).
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+
       - name: Checkout main
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          token: ${{ secrets.AGENT_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -50,11 +57,17 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code
 
       - name: Configure git identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
-          git config user.name "vata-agent[bot]"
-          git config user.email "vata-agent@users.noreply.github.com"
+          BOT_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email "${BOT_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
       - name: Fetch issue data
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh issue view "$ISSUE_NUMBER" --json title,body,url,labels > /tmp/issue.json
 
       - name: Detect Opus opt-in
@@ -67,6 +80,8 @@ jobs:
           fi
 
       - name: Reset agent labels to running
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh issue edit "$ISSUE_NUMBER" \
             --remove-label "agent:ready" \
@@ -112,6 +127,7 @@ jobs:
         id: deliver
         if: steps.outcome.outputs.outcome == 'success' || steps.outcome.outputs.outcome == 'partial'
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           OUTCOME: ${{ steps.outcome.outputs.outcome }}
           BRANCH: ${{ steps.agent.outputs.branch }}
           ITERATIONS: ${{ steps.agent.outputs.iterations }}
@@ -151,6 +167,7 @@ jobs:
       - name: Comment on failure
         if: steps.outcome.outputs.outcome == 'failed' || steps.deliver.outcome == 'failure'
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DELIVER: ${{ steps.deliver.outcome }}
           BRANCH: ${{ steps.agent.outputs.branch }}
           ITERATIONS: ${{ steps.agent.outputs.iterations }}
@@ -178,6 +195,7 @@ jobs:
       - name: Apply final label
         if: always()
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           OUTCOME: ${{ steps.outcome.outputs.outcome }}
           DELIVER: ${{ steps.deliver.outcome }}
         run: |

--- a/docs/adr/0008-autonomous-agent-execution.md
+++ b/docs/adr/0008-autonomous-agent-execution.md
@@ -38,7 +38,7 @@ Adopt **`@ai-hero/sandcastle`** as the execution engine, **invoked exclusively f
 - **Branch**: sandcastle creates a worktree on `agent/issue-N` with `branchStrategy: { type: "branch" }`.
 - **Quality gate**: between iterations, the agent runs the `pnpm verify` suite (lint + format check + build + vitest) so it sees its own failures and self-corrects. The same suite is re-run by `main.ts` in the worktree after sandcastle finishes, as an independent verification.
 - **PR creation**: opened by the workflow (not by the agent) once the run completes successfully, with `Closes #N` in the body for auto-close at merge. The PR body itself is written by the agent (a `<pr-description>` block extracted from its output); the workflow only frames it with the `Closes` line and a metadata footer.
-- **Token**: the workflow authenticates with a fine-grained PAT (`AGENT_GH_TOKEN`), not the default `GITHUB_TOKEN`. GitHub suppresses downstream workflow triggers for `GITHUB_TOKEN`-authored events, so a PAT is required for the agent's PR to run `ci.yml`.
+- **Token**: the workflow authenticates with a token minted from a dedicated GitHub App (`vata-agent`), not the default `GITHUB_TOKEN` and not a PAT. GitHub suppresses downstream workflow triggers for `GITHUB_TOKEN`-authored events (so `ci.yml` would not run on the agent's PR); a PAT would fix that but attributes every commit, PR, and comment to a person. The App gives both: `ci.yml` runs, and all activity is attributed to `vata-agent[bot]`.
 
 ### Label-based outcome tracking
 
@@ -87,7 +87,7 @@ Project Status (Icebox / Todo / In Progress / Done) is **not piloted by the work
 
 Label cleanup before each run is performed inline in `agent-run.yml` via a batched `gh issue edit --remove-label … --remove-label …` call — no separate script.
 
-In CI, `ANTHROPIC_API_KEY` and `AGENT_GH_TOKEN` are supplied from repo secrets — no `.env` file is created. `.sandcastle/.env` and `.sandcastle/logs/` are gitignored for any future local-debug use.
+In CI, `ANTHROPIC_API_KEY`, `AGENT_APP_ID`, and `AGENT_APP_PRIVATE_KEY` are supplied from repo secrets — no `.env` file is created. `.sandcastle/.env` and `.sandcastle/logs/` are gitignored for any future local-debug use.
 
 ## Why
 

--- a/docs/dev-tools/agent-workflow.md
+++ b/docs/dev-tools/agent-workflow.md
@@ -79,11 +79,12 @@ The workflow's job is the boring middle: read, execute, check, package as a PR. 
    ```
 
 2. Create a dedicated Anthropic API key (`vata-sandcastle-prod`) with a $100/month spend limit in the Anthropic Console. Store as repo secret `ANTHROPIC_API_KEY`.
-3. Create a fine-grained PAT scoped to this repo with **Contents: Read and write**, **Pull requests: Read and write**, **Issues: Read and write**. Store as repo secret `AGENT_GH_TOKEN`. The workflow uses it instead of `GITHUB_TOKEN` so the agent's PR triggers `ci.yml`.
-4. Enable **Allow GitHub Actions to create and approve pull requests** at the org level (`github.com/organizations/vata-apps/settings/actions`) — a repo-level toggle cannot override an org that disallows it.
-5. Confirm `.sandcastle/main.ts` and `.sandcastle/prompts/default.md` are present (scaffolded during installation).
-6. Confirm `.github/workflows/agent-run.yml` is present (added during configuration).
-7. Dry-test on a small `Task`-type issue (rename, doc fix) before pointing it at anything substantive.
+3. Create a GitHub App (`vata-agent`) on the org with **Contents: Read and write**, **Pull requests: Read and write**, **Issues: Read and write** (webhook disabled). Install it on this repo. The workflow mints a token from it instead of `GITHUB_TOKEN` so the agent's PR triggers `ci.yml`, and instead of a PAT so all activity is attributed to `vata-agent[bot]` rather than a person. Store as repo secrets:
+   - `AGENT_APP_ID` — the App ID
+   - `AGENT_APP_PRIVATE_KEY` — the full contents of the App's generated `.pem` private key
+4. Confirm `.sandcastle/main.ts` and `.sandcastle/prompts/default.md` are present (scaffolded during installation).
+5. Confirm `.github/workflows/agent-run.yml` is present (added during configuration).
+6. Dry-test on a small `Task`-type issue (rename, doc fix) before pointing it at anything substantive.
 
 ## Limits and known issues
 


### PR DESCRIPTION
## Summary

The PAT (#146) made the agent's PR and `gh` actions show up under a personal account. Switching to a dedicated GitHub App (`vata-agent`) fixes attribution without losing the CI trigger:

- The agent's PR **still triggers `ci.yml`** — GitHub Apps are exempt from the `GITHUB_TOKEN` anti-loop rule
- Every commit, PR, label, and comment is attributed to **`vata-agent[bot]`**, not a person

## Changes

- New `Generate app token` step mints a token via `actions/create-github-app-token` from `AGENT_APP_ID` + `AGENT_APP_PRIVATE_KEY`
- `actions/checkout` and all six `gh`-using steps now use the minted token
- `Configure git identity` resolves the bot's user id so commits link to the bot account (canonical `<id>+vata-agent[bot]@users.noreply.github.com` email)
- ADR-008 + setup checklist updated; the `AGENT_GH_TOKEN` PAT is retired

## After merge

- `AGENT_GH_TOKEN` secret can be deleted and the PAT revoked
- Retry an issue: confirm the PR is opened by `vata-agent[bot]` and `ci.yml` runs on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)