### PR TITLE
feat(agent): add the review-feedback workflow (ADR-009)

### DIFF
--- a/.github/workflows/agent-address-review.yml
+++ b/.github/workflows/agent-address-review.yml
@@ -1,0 +1,238 @@
+name: Agent Address Review
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: agent-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  # Lightweight gate: only proceed for changes-requested reviews on open
+  # agent PRs that actually carry feedback. Keeps an empty "Request changes"
+  # misclick from spending a paid agent run.
+  triage:
+    if: >-
+      github.event.review.state == 'changes_requested' &&
+      github.event.pull_request.state == 'open' &&
+      github.event.pull_request.user.login == 'vata-agent[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+
+      - name: Check for actionable feedback
+        id: check
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_ID: ${{ github.event.review.id }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+        run: |
+          COMMENT_COUNT=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate \
+            --jq "[.[] | select(.pull_request_review_id == $REVIEW_ID)] | length")
+          if [ -n "$REVIEW_BODY" ] || [ "${COMMENT_COUNT:-0}" -gt 0 ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR_NUMBER" --body "🤖 This \"Request changes\" review has no summary and no line comments — nothing to address. Add comments and re-submit the review to dispatch the agent."
+          fi
+
+  address:
+    needs: triage
+    if: needs.triage.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BRANCH: ${{ github.event.pull_request.head.ref }}
+      REVIEW_ID: ${{ github.event.review.id }}
+      REVIEW_DATA_PATH: /tmp/review-context.json
+      REVIEW_REPLIES_PATH: /tmp/review-replies.json
+      REVIEW_SUMMARY_PATH: /tmp/review-summary.md
+
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure git identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          BOT_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email "${BOT_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+      - name: Resolve issue number
+        id: issue
+        run: |
+          case "$BRANCH" in
+            agent/issue-*)
+              echo "number=${BRANCH#agent/issue-}" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::PR branch '$BRANCH' is not an agent/issue-* branch"
+              exit 1 ;;
+          esac
+
+      - name: Detect Opus opt-in
+        id: model
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          if gh issue view "$ISSUE_NUMBER" --json labels --jq '.labels[].name' | grep -qx 'agent:use-opus'; then
+            echo "use_opus=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "use_opus=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare PR branch
+        run: |
+          git fetch origin "$BRANCH" main
+          git checkout -B main origin/main
+          git branch -f "$BRANCH" "origin/$BRANCH"
+
+      - name: Gather review context
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+        run: |
+          gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate \
+            --jq "[.[] | select(.pull_request_review_id == $REVIEW_ID) | {id, path, line, body, diffHunk: .diff_hunk}]" \
+            > /tmp/line-comments.json
+          gh issue view "$ISSUE_NUMBER" --json number,title,body > /tmp/issue.json
+          jq -n \
+            --argjson prNumber "$PR_NUMBER" \
+            --arg reviewBody "$REVIEW_BODY" \
+            --slurpfile lineComments /tmp/line-comments.json \
+            --slurpfile issue /tmp/issue.json \
+            '{prNumber: $prNumber, reviewBody: $reviewBody, lineComments: $lineComments[0], issue: $issue[0]}' \
+            > "$REVIEW_DATA_PATH"
+
+      - name: Run agent
+        id: agent
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          USE_OPUS: ${{ steps.model.outputs.use_opus }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+        run: pnpm exec tsx .sandcastle/address-review.ts
+
+      - name: Compute outcome
+        id: outcome
+        if: always()
+        env:
+          AGENT_STEP: ${{ steps.agent.outcome }}
+          COMMITS: ${{ steps.agent.outputs.commits }}
+          COMPLETED: ${{ steps.agent.outputs.completed }}
+          VERIFY_PASSED: ${{ steps.agent.outputs.verify_passed }}
+          HAS_REPLIES: ${{ steps.agent.outputs.has_replies }}
+        run: |
+          if [ "$AGENT_STEP" != "success" ]; then
+            echo "outcome=failed" >> "$GITHUB_OUTPUT"
+          elif [ "${COMMITS:-0}" = "0" ] && [ "$HAS_REPLIES" != "true" ]; then
+            echo "outcome=failed" >> "$GITHUB_OUTPUT"
+          elif [ "$VERIFY_PASSED" != "true" ]; then
+            echo "outcome=failed" >> "$GITHUB_OUTPUT"
+          elif [ "$COMPLETED" = "true" ]; then
+            echo "outcome=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "outcome=partial" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push branch
+        if: >-
+          (steps.outcome.outputs.outcome == 'success' || steps.outcome.outputs.outcome == 'partial')
+          && steps.agent.outputs.commits != '0'
+        run: git push origin "$BRANCH"
+
+      - name: Post per-thread replies
+        if: steps.outcome.outputs.outcome == 'success' || steps.outcome.outputs.outcome == 'partial'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          [ -f "$REVIEW_REPLIES_PATH" ] || exit 0
+          jq -c '.[]' "$REVIEW_REPLIES_PATH" | while read -r entry; do
+            id=$(echo "$entry" | jq -r '.id')
+            sha=$(echo "$entry" | jq -r '.sha // empty')
+            note=$(echo "$entry" | jq -r '.note')
+            if [ -n "$sha" ]; then
+              body="🤖 Addressed in \`$sha\` — $note"
+            else
+              body="🤖 Not addressed — $note"
+            fi
+            gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$id/replies" -f body="$body" || true
+          done
+
+      - name: Post summary comment
+        if: always() && steps.outcome.outputs.outcome != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OUTCOME: ${{ steps.outcome.outputs.outcome }}
+          COMMITS: ${{ steps.agent.outputs.commits }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          case "$OUTCOME" in
+            success)
+              if [ "${COMMITS:-0}" = "0" ]; then
+                HEADER="ℹ️ Reviewed your feedback — no code changes. See the per-comment replies for why."
+              else
+                HEADER="✅ Addressed your review in ${COMMITS} commit(s). Re-review when ready."
+              fi ;;
+            partial)
+              HEADER="⚠️ Ran out of iterations — partially addressed (${COMMITS} commit(s)). Re-review." ;;
+            *)
+              HEADER="❌ Couldn't address the review. Logs: ${RUN_URL}" ;;
+          esac
+          {
+            echo "$HEADER"
+            if [ -f "$REVIEW_SUMMARY_PATH" ]; then
+              echo
+              cat "$REVIEW_SUMMARY_PATH"
+            fi
+          } > /tmp/summary-comment.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/summary-comment.md

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -102,7 +102,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           USE_OPUS: ${{ steps.model.outputs.use_opus }}
           ISSUE_DATA_PATH: /tmp/issue.json
-        run: pnpm exec tsx .sandcastle/main.ts
+        run: pnpm exec tsx .sandcastle/run.ts
 
       - name: Compute outcome
         id: outcome

--- a/.sandcastle/.gitignore
+++ b/.sandcastle/.gitignore
@@ -1,2 +1,3 @@
 .env
 logs/
+worktrees/

--- a/.sandcastle/address-review.ts
+++ b/.sandcastle/address-review.ts
@@ -1,0 +1,137 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { claudeCode, createWorktree } from '@ai-hero/sandcastle';
+import { noSandbox } from '@ai-hero/sandcastle/sandboxes/no-sandbox';
+import {
+  extractTag,
+  MODEL_OPUS,
+  MODEL_SONNET,
+  required,
+  verify,
+  writeGithubOutput,
+} from './shared';
+
+// Entry point for the review → commits flow, invoked by
+// .github/workflows/agent-address-review.yml.
+// See docs/adr/0009-agent-review-feedback.md.
+
+interface LineComment {
+  id: number;
+  path: string;
+  line: number | null;
+  body: string;
+  diffHunk: string;
+}
+
+const issueNumber = required('ISSUE_NUMBER');
+const reviewDataPath = process.env.REVIEW_DATA_PATH ?? '/tmp/review-context.json';
+
+if (!existsSync(reviewDataPath)) {
+  console.error(`Review data file not found at ${reviewDataPath}`);
+  process.exit(1);
+}
+
+const review = JSON.parse(readFileSync(reviewDataPath, 'utf-8')) as {
+  prNumber: number;
+  reviewBody: string;
+  lineComments: LineComment[];
+  issue: { number: number; title: string; body: string };
+};
+
+const useOpus = process.env.USE_OPUS === 'true';
+const model = useOpus ? MODEL_OPUS : MODEL_SONNET;
+const branch = `agent/issue-${issueNumber}`;
+
+console.log(`PR: #${review.prNumber} — addressing review on ${branch}`);
+console.log(`Model: ${model}`);
+console.log(`Line comments: ${review.lineComments.length}`);
+
+const wt = await createWorktree({
+  branchStrategy: { type: 'branch', branch },
+});
+
+const result = await wt.run({
+  agent: claudeCode(model),
+  sandbox: noSandbox(),
+  promptFile: '.sandcastle/prompts/address-review.md',
+  promptArgs: {
+    PR_NUMBER: String(review.prNumber),
+    ISSUE_NUMBER: String(review.issue.number),
+    ISSUE_TITLE: review.issue.title,
+    ISSUE_BODY: review.issue.body,
+    REVIEW_BODY: review.reviewBody || '(no summary text)',
+    LINE_COMMENTS: formatLineComments(review.lineComments),
+  },
+  hooks: {
+    sandbox: {
+      onSandboxReady: [{ command: 'pnpm install --frozen-lockfile' }],
+    },
+  },
+  maxIterations: 5,
+  idleTimeoutSeconds: 600,
+  name: `review-${review.prNumber}`,
+  logging: { type: 'stdout' },
+});
+
+const completed = result.completionSignal !== undefined;
+const commits = result.commits.length;
+
+console.log(`\nIterations: ${result.iterations.length}`);
+console.log(`Commits: ${commits}`);
+console.log(`Completion signal: ${completed ? 'yes' : 'no'}`);
+
+// has_replies is true only when the block parses as a JSON array — the
+// workflow posts replies by iterating it, so a malformed block is no replies.
+const replies = extractTag(result.stdout, 'review-replies');
+const hasReplies = replies !== null && isJsonArray(replies);
+if (hasReplies) {
+  writeFileToEnvPath('REVIEW_REPLIES_PATH', replies);
+} else if (replies !== null) {
+  console.log('<review-replies> block is not a JSON array — ignoring');
+} else {
+  console.log('No <review-replies> block found in agent output');
+}
+
+const summary = extractTag(result.stdout, 'review-summary');
+if (summary) {
+  writeFileToEnvPath('REVIEW_SUMMARY_PATH', summary);
+} else {
+  console.log('No <review-summary> block found in agent output');
+}
+
+// 0 commits is a legitimate "all skipped" outcome — nothing to verify.
+const verifyPassed = commits > 0 ? verify(wt.worktreePath) : true;
+
+writeGithubOutput({
+  branch: result.branch,
+  iterations: String(result.iterations.length),
+  commits: String(commits),
+  completed: String(completed),
+  verify_passed: String(verifyPassed),
+  has_replies: String(hasReplies),
+  model,
+});
+
+function formatLineComments(comments: LineComment[]): string {
+  if (comments.length === 0) return '(no line comments)';
+  return comments
+    .map((c) => {
+      const location = c.line ? `${c.path}:${c.line}` : c.path;
+      return `### Comment [id ${c.id}] — \`${location}\`\n\n\`\`\`diff\n${c.diffHunk}\n\`\`\`\n\n${c.body}`;
+    })
+    .join('\n\n');
+}
+
+function isJsonArray(text: string): boolean {
+  try {
+    return Array.isArray(JSON.parse(text));
+  } catch {
+    return false;
+  }
+}
+
+function writeFileToEnvPath(envName: string, content: string): void {
+  const path = process.env[envName];
+  if (!path) return;
+  writeFileSync(path, `${content}\n`);
+  console.log(`Wrote ${envName} → ${path}`);
+}

--- a/.sandcastle/prompts/address-review.md
+++ b/.sandcastle/prompts/address-review.md
@@ -1,0 +1,89 @@
+# Task
+
+You are addressing review feedback on an existing pull request in the Vata repository (a Tauri + React + TypeScript + SQLite genealogy desktop app).
+
+PR **#{{PR_NUMBER}}** implements GitHub issue **#{{ISSUE_NUMBER}}** — its branch is already checked out. The maintainer has reviewed the PR and requested changes. Your job is to address that feedback with new commits on this branch.
+
+## Original issue (the spec)
+
+**{{ISSUE_TITLE}}**
+
+{{ISSUE_BODY}}
+
+## Review summary
+
+{{REVIEW_BODY}}
+
+## Line comments
+
+Each block below is one review comment, with its `id`, location, the diff hunk it is anchored to, and the maintainer's text.
+
+{{LINE_COMMENTS}}
+
+# How to work
+
+Read `CLAUDE.md` at the repo root **before doing anything** — it defines all project conventions (architecture, i18n, DB rules, scope discipline, conventional commits). Treat its content as binding; do not restate or override it.
+
+The PR's branch is checked out — the code you previously wrote is in front of you. Use `git diff main...HEAD` to see what the PR currently contains.
+
+Address each piece of feedback:
+
+- If a comment asks for a change you agree with, make it.
+- If a comment **contradicts the original issue spec, is out of scope, or is factually wrong**, do not make the change — you will record it as skipped with a reason. Disagreeing is allowed; ignoring silently is not.
+
+Commit your changes with conventional commit messages. You may group related fixes into one commit.
+
+# Quality gate
+
+After each change, run the validation suite and fix anything it breaks:
+
+```bash
+pnpm verify
+```
+
+This runs `pnpm lint`, `pnpm format:check`, `pnpm build`, and `pnpm vitest run` in sequence. Do not signal completion until `pnpm verify` is green.
+
+# Environment-specific constraints
+
+These are particular to this CI run and are **not** in `CLAUDE.md`:
+
+- The Tauri desktop app cannot be launched here (no display server). `pnpm tauri:dev` / `pnpm tauri:build` are unavailable. UI verification is performed manually by the maintainer.
+- Do not modify anything under `.sandcastle/` or `.github/workflows/` unless the review explicitly asks for it.
+
+# Before completing
+
+You **must** emit two blocks before the completion signal.
+
+**1. Per-comment replies** — a JSON array, one entry per line comment above, wrapped in `<review-replies>` tags. For each comment use the `id` shown in its block. `sha` is the short commit hash that addressed it, or `null` if you skipped it; `note` is one concise sentence.
+
+```
+<review-replies>
+[
+  { "id": 123456, "sha": "abc1234", "note": "switched to the existing formatDate helper" },
+  { "id": 789012, "sha": null, "note": "out of scope — the issue spec explicitly excludes this" }
+]
+</review-replies>
+```
+
+**2. A summary** — short markdown, wrapped in `<review-summary>` tags, covering how you handled the review summary feedback and anything else the maintainer should know on re-review.
+
+```
+<review-summary>
+## Changes
+
+- Brief bullets on what you changed across the requested-changes review
+</review-summary>
+```
+
+# When you're done
+
+When all of these are true:
+
+1. `pnpm verify` is green on the final state of the branch
+2. Every line comment is either addressed or recorded as skipped with a reason
+3. All changes are committed (`git status` clean)
+4. You have emitted both the `<review-replies>` and `<review-summary>` blocks
+
+Then — and only then — emit `<promise>COMPLETE</promise>` on its own line.
+
+Do not emit this signal under any other condition.

--- a/.sandcastle/run.ts
+++ b/.sandcastle/run.ts
@@ -1,10 +1,17 @@
-import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { claudeCode, createWorktree } from '@ai-hero/sandcastle';
 import { noSandbox } from '@ai-hero/sandcastle/sandboxes/no-sandbox';
+import {
+  extractTag,
+  MODEL_OPUS,
+  MODEL_SONNET,
+  required,
+  verify,
+  writeGithubOutput,
+} from './shared';
 
-const MODEL_OPUS = 'claude-opus-4-7';
-const MODEL_SONNET = 'claude-sonnet-4-6';
+// Entry point for the issue → PR flow, invoked by .github/workflows/agent-run.yml.
+// See docs/adr/0008-autonomous-agent-execution.md.
 
 const issueNumber = required('ISSUE_NUMBER');
 const issueDataPath = process.env.ISSUE_DATA_PATH ?? '/tmp/issue.json';
@@ -81,38 +88,3 @@ writeGithubOutput({
   verify_passed: String(verifyPassed),
   model,
 });
-
-function verify(cwd: string): boolean {
-  console.log('\nVerifying branch quality...');
-  try {
-    execSync('pnpm verify', { cwd, stdio: 'inherit' });
-    console.log('Verify: passed');
-    return true;
-  } catch {
-    console.log('Verify: failed');
-    return false;
-  }
-}
-
-function extractTag(text: string, tag: string): string | null {
-  const match = text.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
-  return match ? match[1].trim() : null;
-}
-
-function required(name: string): string {
-  const value = process.env[name];
-  if (!value) {
-    console.error(`${name} env var is required`);
-    process.exit(1);
-  }
-  return value;
-}
-
-function writeGithubOutput(outputs: Record<string, string>) {
-  const path = process.env.GITHUB_OUTPUT;
-  if (!path) return;
-  const lines = Object.entries(outputs)
-    .map(([k, v]) => `${k}=${v}`)
-    .join('\n');
-  writeFileSync(path, `${lines}\n`, { flag: 'a' });
-}

--- a/.sandcastle/shared.ts
+++ b/.sandcastle/shared.ts
@@ -1,0 +1,43 @@
+import { execSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+// Helpers and constants shared by the two sandcastle entry points
+// (run.ts, address-review.ts).
+
+export const MODEL_OPUS = 'claude-opus-4-7';
+export const MODEL_SONNET = 'claude-sonnet-4-6';
+
+export function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`${name} env var is required`);
+    process.exit(1);
+  }
+  return value;
+}
+
+export function writeGithubOutput(outputs: Record<string, string>): void {
+  const path = process.env.GITHUB_OUTPUT;
+  if (!path) return;
+  const lines = Object.entries(outputs)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n');
+  writeFileSync(path, `${lines}\n`, { flag: 'a' });
+}
+
+export function extractTag(text: string, tag: string): string | null {
+  const match = text.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
+  return match ? match[1].trim() : null;
+}
+
+export function verify(cwd: string): boolean {
+  console.log('\nVerifying branch quality...');
+  try {
+    execSync('pnpm verify', { cwd, stdio: 'inherit' });
+    console.log('Verify: passed');
+    return true;
+  } catch {
+    console.log('Verify: failed');
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Implements [ADR-009](https://github.com/vata-apps/vata-app/blob/main/docs/adr/0009-agent-review-feedback.md). When the maintainer submits a **"Request changes"** review on an agent PR, the agent addresses the feedback on the same branch — closing the review→adjust loop without hand-editing or a from-scratch re-run.

## What's here

- **`.github/workflows/agent-address-review.yml`** — `pull_request_review`-triggered, two jobs:
  - `triage` — gates out empty "Request changes" misclicks (no body, no line comments)
  - `address` — runs the agent on the existing branch, pushes, posts per-thread replies (`Addressed in <sha>` / `Not addressed — reason`) and a summary comment
- **`.sandcastle/shared.ts`** — helpers + model constants shared by both entry points
- **`.sandcastle/run.ts`** — renamed from `main.ts`, imports `shared.ts`
- **`.sandcastle/address-review.ts`** — review → commits entry point
- **`.sandcastle/prompts/address-review.md`** — the review prompt

## Behaviour

- Triggers only on `changes_requested` reviews on open `vata-agent[bot]` PRs
- Model inherits the original issue's `agent:use-opus` label
- Outcomes mirror `agent-run.yml`: success / partial / failed; a 0-commit all-skipped run is a valid success
- No auto-resolution of threads — the maintainer resolves on re-review

## Test plan

- [ ] CI green on this PR
- [ ] After merge: open an agent PR, submit a "Request changes" review with a line comment, confirm the agent pushes commits + posts replies
- [ ] Submit an empty "Request changes" review, confirm the triage job posts the misclick comment and runs no agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)