### PR TITLE
chore(agent): bump Node-20 actions and trim verbose review summary

### DIFF
--- a/.github/workflows/agent-address-review.yml
+++ b/.github/workflows/agent-address-review.yml
@@ -74,18 +74,18 @@ jobs:
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -34,18 +34,18 @@ jobs:
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
 
       - name: Checkout main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 9
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.sandcastle/prompts/address-review.md
+++ b/.sandcastle/prompts/address-review.md
@@ -65,13 +65,11 @@ You **must** emit two blocks before the completion signal.
 </review-replies>
 ```
 
-**2. A summary** — short markdown, wrapped in `<review-summary>` tags, covering how you handled the review summary feedback and anything else the maintainer should know on re-review.
+**2. A brief summary** — wrapped in `<review-summary>` tags. One or two sentences, no headings, no bullet lists. Cover only the review's _summary-level_ feedback (the review body) and anything cross-cutting the maintainer should know on re-review — the per-comment work is already covered by the replies above, so do not restate it. If there was nothing beyond the line comments, a single sentence is correct. Match the length of the summary to the size of the change.
 
 ```
 <review-summary>
-## Changes
-
-- Brief bullets on what you changed across the requested-changes review
+Switched the debug-drawer copy to i18n keys as requested; no changes beyond the inline comments.
 </review-summary>
 ```
 


### PR DESCRIPTION
## Summary

Two small fixes to the agent workflow system, both surfaced while testing the review-feedback loop on PR #150.

- **Node 20 deprecation** — `actions/checkout`, `pnpm/action-setup`, and `actions/setup-node` were pinned to versions that run on Node 20. GitHub forces Node 24 on 2026-06-02 and removes Node 20 on 2026-09-16. Bumped all three to current majors (re-pinned to commit SHAs) across `ci.yml`, `agent-run.yml`, `agent-address-review.yml`.
- **Verbose review summary** — `address-review.md` asked the agent for a `## Changes` heading + bullet list in the `<review-summary>` block, which produced a heavy comment even for a one-commit fix ([example](https://github.com/vata-apps/vata-app/pull/150#issuecomment-4522763716)). Now asks for one or two sentences, no headings, sized to the change — the per-comment replies already carry the detail.

## Not in this PR

The `app-id` → `client-id` deprecation on `actions/create-github-app-token` is left out — it needs a new repo secret (the App's Client ID), which is a maintainer action. Tracked separately.

## Test plan

- [ ] CI green on this PR (exercises the bumped actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)