### PR TITLE
chore(agent): switch create-github-app-token to client-id

### DIFF
--- a/.github/workflows/agent-address-review.yml
+++ b/.github/workflows/agent-address-review.yml
@@ -31,7 +31,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.AGENT_APP_ID }}
+          client-id: ${{ secrets.AGENT_APP_CLIENT_ID }}
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
 
       - name: Check for actionable feedback
@@ -70,7 +70,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.AGENT_APP_ID }}
+          client-id: ${{ secrets.AGENT_APP_CLIENT_ID }}
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -30,7 +30,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.AGENT_APP_ID }}
+          client-id: ${{ secrets.AGENT_APP_CLIENT_ID }}
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
 
       - name: Checkout main

--- a/docs/adr/0008-autonomous-agent-execution.md
+++ b/docs/adr/0008-autonomous-agent-execution.md
@@ -87,7 +87,7 @@ Project Status (Icebox / Todo / In Progress / Done) is **not piloted by the work
 
 Label cleanup before each run is performed inline in `agent-run.yml` via a batched `gh issue edit --remove-label … --remove-label …` call — no separate script.
 
-In CI, `ANTHROPIC_API_KEY`, `AGENT_APP_ID`, and `AGENT_APP_PRIVATE_KEY` are supplied from repo secrets — no `.env` file is created. `.sandcastle/.env` and `.sandcastle/logs/` are gitignored for any future local-debug use.
+In CI, `ANTHROPIC_API_KEY`, `AGENT_APP_CLIENT_ID`, and `AGENT_APP_PRIVATE_KEY` are supplied from secrets — no `.env` file is created. `.sandcastle/.env` and `.sandcastle/logs/` are gitignored for any future local-debug use.
 
 ## Why
 

--- a/docs/dev-tools/agent-workflow.md
+++ b/docs/dev-tools/agent-workflow.md
@@ -103,9 +103,9 @@ The workflow's job is the boring middle: read, execute, check, package as a PR. 
 
 2. Create a dedicated Anthropic API key (`vata-sandcastle-prod`) with a $100/month spend limit in the Anthropic Console. Store as repo secret `ANTHROPIC_API_KEY`.
 3. Create a GitHub App (`vata-agent`) on the org with **Contents: Read and write**, **Pull requests: Read and write**, **Issues: Read and write** (webhook disabled). Install it on this repo. The workflow mints a token from it instead of `GITHUB_TOKEN` so the agent's PR triggers `ci.yml`, and instead of a PAT so all activity is attributed to `vata-agent[bot]` rather than a person. Store as repo secrets:
-   - `AGENT_APP_ID` — the App ID
+   - `AGENT_APP_CLIENT_ID` — the App's Client ID (App settings → General → About)
    - `AGENT_APP_PRIVATE_KEY` — the full contents of the App's generated `.pem` private key
-4. Confirm `.sandcastle/main.ts` and `.sandcastle/prompts/default.md` are present (scaffolded during installation).
+4. Confirm `.sandcastle/run.ts` and `.sandcastle/prompts/default.md` are present (scaffolded during installation).
 5. Confirm `.github/workflows/agent-run.yml` is present (added during configuration).
 6. Dry-test on a small `Task`-type issue (rename, doc fix) before pointing it at anything substantive.
 


### PR DESCRIPTION
## Summary

`actions/create-github-app-token` deprecated the `app-id` input in favour of `client-id`. Both agent workflows now use `client-id: ${{ secrets.AGENT_APP_CLIENT_ID }}` instead of `app-id: ${{ secrets.AGENT_APP_ID }}` — clears the last deprecation warning.

- `agent-run.yml`, `agent-address-review.yml` (×2 token steps) — `app-id` → `client-id`
- Docs updated for the new secret name; also fixes a stale `.sandcastle/main.ts` reference (renamed to `run.ts` in #152)

## Maintainer action (done)

`AGENT_APP_CLIENT_ID` secret added with the App's Client ID.

## Validation

This repo's `ci.yml` does not exercise the agent workflows, so the real test is the next agent run (issue-labelled or review-triggered). If `client-id` is wrong/empty, `create-github-app-token` fails loudly at the first step.

After this merges and an agent run confirms it works, the old `AGENT_APP_ID` secret can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)