### PR TITLE
feat(agent): log estimated run cost at the end

### DIFF
--- a/.sandcastle/address-review.ts
+++ b/.sandcastle/address-review.ts
@@ -3,6 +3,7 @@ import { claudeCode, createWorktree } from '@ai-hero/sandcastle';
 import { noSandbox } from '@ai-hero/sandcastle/sandboxes/no-sandbox';
 import {
   extractTag,
+  logCost,
   MODEL_OPUS,
   MODEL_SONNET,
   required,
@@ -100,6 +101,8 @@ if (summary) {
 
 // 0 commits is a legitimate "all skipped" outcome — nothing to verify.
 const verifyPassed = commits > 0 ? verify(wt.worktreePath) : true;
+
+logCost(model, result.iterations);
 
 writeGithubOutput({
   branch: result.branch,

--- a/.sandcastle/run.ts
+++ b/.sandcastle/run.ts
@@ -3,6 +3,7 @@ import { claudeCode, createWorktree } from '@ai-hero/sandcastle';
 import { noSandbox } from '@ai-hero/sandcastle/sandboxes/no-sandbox';
 import {
   extractTag,
+  logCost,
   MODEL_OPUS,
   MODEL_SONNET,
   required,
@@ -79,6 +80,8 @@ if (prDescription) {
 }
 
 const verifyPassed = commits > 0 ? verify(wt.worktreePath) : false;
+
+logCost(model, result.iterations);
 
 writeGithubOutput({
   branch: result.branch,

--- a/.sandcastle/shared.ts
+++ b/.sandcastle/shared.ts
@@ -1,11 +1,22 @@
 import { execSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
+import type { IterationResult } from '@ai-hero/sandcastle';
 
 // Helpers and constants shared by the two sandcastle entry points
 // (run.ts, address-review.ts).
 
 export const MODEL_OPUS = 'claude-opus-4-7';
 export const MODEL_SONNET = 'claude-sonnet-4-6';
+
+// Anthropic list prices ($/Mtok) — 5-minute cache TTL (sandcastle default).
+// Update when Anthropic changes them.
+const RATES_PER_MTOK: Record<
+  string,
+  { input: number; output: number; cacheRead: number; cacheWrite: number }
+> = {
+  [MODEL_OPUS]: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+  [MODEL_SONNET]: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+};
 
 export function required(name: string): string {
   const value = process.env[name];
@@ -28,6 +39,42 @@ export function writeGithubOutput(outputs: Record<string, string>): void {
 export function extractTag(text: string, tag: string): string | null {
   const match = text.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
   return match ? match[1].trim() : null;
+}
+
+export function logCost(model: string, iterations: readonly IterationResult[]): void {
+  const totals = iterations.reduce(
+    (acc, it) => {
+      if (!it.usage) return acc;
+      return {
+        input: acc.input + it.usage.inputTokens,
+        output: acc.output + it.usage.outputTokens,
+        cacheRead: acc.cacheRead + it.usage.cacheReadInputTokens,
+        cacheWrite: acc.cacheWrite + it.usage.cacheCreationInputTokens,
+      };
+    },
+    { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+  );
+
+  const fmt = (n: number) => n.toLocaleString('en-US');
+  console.log('\nRun cost (estimate)');
+  console.log(`  Model:        ${model}`);
+  console.log(`  Input:        ${fmt(totals.input)} tokens`);
+  console.log(`  Output:       ${fmt(totals.output)} tokens`);
+  console.log(`  Cache read:   ${fmt(totals.cacheRead)} tokens`);
+  console.log(`  Cache write:  ${fmt(totals.cacheWrite)} tokens`);
+
+  const rates = RATES_PER_MTOK[model];
+  if (!rates) {
+    console.log(`  Estimated:    (no rate table for ${model})`);
+    return;
+  }
+  const dollars =
+    (totals.input * rates.input +
+      totals.output * rates.output +
+      totals.cacheRead * rates.cacheRead +
+      totals.cacheWrite * rates.cacheWrite) /
+    1_000_000;
+  console.log(`  Estimated:    $${dollars.toFixed(4)}`);
 }
 
 export function verify(cwd: string): boolean {


### PR DESCRIPTION
## Summary

Adds a "Run cost (estimate)" block at the end of each agent run's log:

```
Run cost (estimate)
  Model:        claude-sonnet-4-6
  Input:        12,345 tokens
  Output:       2,345 tokens
  Cache read:   45,678 tokens
  Cache write:  6,789 tokens
  Estimated:    $0.3421
```

- Sums per-iteration `usage` from sandcastle's `IterationResult` (sandcastle starts a fresh Claude Code session per iteration, so summing is correct)
- Multiplies by Anthropic list prices ($/Mtok) — Sonnet 4.6: `3 / 15 / 0.3 / 3.75`, Opus 4.7: `15 / 75 / 1.5 / 18.75`. 5-minute cache TTL (sandcastle's default)
- Rate table lives in `shared.ts`; update there when Anthropic changes pricing
- Both `run.ts` (issue→PR) and `address-review.ts` (review→commits) emit the block

## Limits

- It's an _estimate_ — list prices, not invoice. Promotions, batch API, etc. not modelled
- No-rate models log usage only, no dollar figure
- Log only for now — if you want it in PR/issue comments or the Actions step summary, easy follow-up

## Test plan

- [ ] CI green
- [ ] Next agent run shows the cost block in its log