### PR TITLE
fix(agent): link the commit SHA in per-thread review replies

### DIFF
--- a/.github/workflows/agent-address-review.yml
+++ b/.github/workflows/agent-address-review.yml
@@ -201,7 +201,7 @@ jobs:
             sha=$(echo "$entry" | jq -r '.sha // empty')
             note=$(echo "$entry" | jq -r '.note')
             if [ -n "$sha" ]; then
-              body="🤖 Addressed in \`$sha\` — $note"
+              body="🤖 Addressed in [\`$sha\`](${{ github.server_url }}/${REPO}/commit/$sha) — $note"
             else
               body="🤖 Not addressed — $note"
             fi


### PR DESCRIPTION
## Summary

Per-thread review replies posted by the agent show the SHA as backticked code (`aab7474`), which GitHub does not auto-link — so it isn't clickable. Wrap the SHA in a markdown link to the commit URL:

```
Addressed in [`aab7474`](https://github.com/vata-apps/vata-app/commit/aab7474) — …
```

Code styling preserved, the SHA becomes clickable to the commit diff.

## Test plan

- [ ] CI green
- [ ] Next review run: per-thread replies have a clickable short SHA