### PR TITLE
feat(agent): agent-authored PR title in conventional-commits format

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 45
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number }}
+      PR_TITLE_PATH: /tmp/agent-pr-title.txt
       PR_BODY_PATH: /tmp/agent-pr-body.md
 
     steps:
@@ -135,7 +136,11 @@ jobs:
         run: |
           git push origin "$BRANCH"
 
-          ISSUE_TITLE=$(jq -r .title /tmp/issue.json)
+          if [ -f "$PR_TITLE_PATH" ]; then
+            TITLE=$(cat "$PR_TITLE_PATH")
+          else
+            TITLE=$(jq -r .title /tmp/issue.json)
+          fi
           DRAFT_FLAG=""
           TITLE_PREFIX=""
           NOTE=""
@@ -161,7 +166,7 @@ jobs:
           gh pr create $DRAFT_FLAG \
             --head "$BRANCH" \
             --base main \
-            --title "${TITLE_PREFIX}${ISSUE_TITLE}" \
+            --title "${TITLE_PREFIX}${TITLE}" \
             --body "$BODY"
 
       - name: Comment on failure

--- a/.sandcastle/prompts/default.md
+++ b/.sandcastle/prompts/default.md
@@ -35,9 +35,19 @@ These are particular to this CI run and are **not** in `CLAUDE.md`:
 
 You **must commit your changes** with `git add` + `git commit` before signaling completion. Sandcastle collects commits from the branch — uncommitted edits are lost. Make one or more commits with conventional commit messages (`feat:`, `fix:`, `refactor:`, …) as described in `CLAUDE.md`. After committing, confirm `git status` shows a clean working tree.
 
-# Pull request description
+# Pull request title and description
 
-Before signaling completion, write a pull request description and wrap it in `<pr-description>` tags so the workflow can extract it. Example shape:
+Before signaling completion, emit two blocks the workflow extracts to open the PR.
+
+**1. A PR title** — a single line in conventional-commits format (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `perf:`, optionally scoped: `feat(individuals): …`). Match the type to the actual change; keep it under ~70 characters.
+
+```
+<pr-title>
+feat(individuals): add birthdate column to the people sidebar
+</pr-title>
+```
+
+**2. A PR description** — wrapped in `<pr-description>` tags. Do **not** include a `Closes #` line — the workflow adds that. Focus on what a reviewer needs to know, not a blow-by-blow of every edit.
 
 ```
 <pr-description>
@@ -51,8 +61,6 @@ Trade-offs, follow-ups, or areas that need extra scrutiny. Omit this section if 
 </pr-description>
 ```
 
-Write it in markdown. Do **not** include a `Closes #` line — the workflow adds that. Focus on what a reviewer needs to know, not a blow-by-blow of every edit.
-
 # When you're done
 
 When all of these are true:
@@ -60,7 +68,7 @@ When all of these are true:
 1. `pnpm verify` is green on the final state of the branch
 2. The change matches the issue body
 3. `git status` shows no uncommitted changes (everything is committed)
-4. You have emitted the `<pr-description>` block
+4. You have emitted both the `<pr-title>` and `<pr-description>` blocks
 
 Then — and only then — emit `<promise>COMPLETE</promise>` on its own line.
 

--- a/.sandcastle/run.ts
+++ b/.sandcastle/run.ts
@@ -68,6 +68,21 @@ console.log(`\nIterations: ${result.iterations.length}`);
 console.log(`Commits: ${commits}`);
 console.log(`Completion signal: ${completed ? 'yes' : 'no'}`);
 
+const prTitleRaw = extractTag(result.stdout, 'pr-title');
+const prTitle = prTitleRaw
+  ?.split('\n')
+  .map((l) => l.trim())
+  .find((l) => l.length > 0);
+if (prTitle) {
+  const prTitlePath = process.env.PR_TITLE_PATH;
+  if (prTitlePath) {
+    writeFileSync(prTitlePath, prTitle);
+    console.log(`PR title written to ${prTitlePath}: ${prTitle}`);
+  }
+} else {
+  console.log('No <pr-title> block found in agent output — falling back to issue title');
+}
+
 const prDescription = extractTag(result.stdout, 'pr-description');
 if (prDescription) {
   const prBodyPath = process.env.PR_BODY_PATH;


### PR DESCRIPTION
## Summary

Until now, the agent reused the **issue title** verbatim as the PR title — issue titles are user-facing prose (e.g. "Debug Drawer with content + ⌘D shortcut"), not conventional-commits format. PRs landed with non-conformant titles.

This PR has the agent author its own PR title:

- The prompt now asks for a `<pr-title>` block alongside `<pr-description>`: a single line in conventional-commits format (`feat:`, `fix:`, …, optional scope).
- `run.ts` extracts the block, takes the first non-empty line, and writes it to `PR_TITLE_PATH`.
- `agent-run.yml` reads that file in the Open PR step and falls back to the issue title when the block is absent (older runs, malformed output).

`address-review.yml` doesn't open PRs, so no change there.

## Test plan

- [ ] CI green
- [ ] Next agent-opened PR has a `feat:` / `fix:` / etc. title