### PR TITLE
chore(pnpm): move build-script allow-list to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,12 +62,6 @@
       "eslint --fix"
     ]
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild"
-    ]
-  },
   "devDependencies": {
     "@ai-hero/sandcastle": "^0.5.11",
     "@eslint/js": "^9.39.3",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 allowBuilds:
   '@parcel/watcher': false
   better-sqlite3: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@parcel/watcher': false
+  better-sqlite3: true
+  esbuild: true
+  msgpackr-extract: false
+  msw: false


### PR DESCRIPTION
## Summary
- pnpm 11 stopped reading the `"pnpm"` field in `package.json`, so the existing `onlyBuiltDependencies` config was silently ignored and `pnpm install` failed with `ERR_PNPM_IGNORED_BUILDS`.
- Move the config to `pnpm-workspace.yaml` using the `allowBuilds:` map (`better-sqlite3` and `esbuild` set to `true`, the rest to `false`).
- Drop the now-dead `"pnpm"` block from `package.json`.

## Test plan
- [x] `pnpm install` runs clean and executes postinstall scripts for `better-sqlite3` + `esbuild`
- [ ] `pnpm tauri:dev` still launches the desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)