### PR TITLE
feat(families): list filters, Husband/Wife columns, sortable headers

### DIFF
--- a/src/components/families-filters.tsx
+++ b/src/components/families-filters.tsx
@@ -1,0 +1,130 @@
+import { Button, Card, Flex, Heading, Select, Text, TextField } from '@radix-ui/themes';
+import { useTranslation } from 'react-i18next';
+
+import { Icon } from '$components/icon';
+
+/** The set of filters applied to the Families list, all combined with AND. */
+export interface FamilyFilters {
+  /** Free-text query matched against both spouses' names (given + surname). */
+  name: string;
+  /** Restrict by which spouse slots are filled, or `'all'` for no restriction. */
+  spouses: 'all' | 'both' | 'missingHusband' | 'missingWife' | 'none';
+  /** Restrict by whether the family has children, or `'all'` for no restriction. */
+  children: 'all' | 'with' | 'without';
+}
+
+/** The neutral state — no filtering. Also the target of the Clear action. */
+export const DEFAULT_FAMILY_FILTERS: FamilyFilters = {
+  name: '',
+  spouses: 'all',
+  children: 'all',
+};
+
+/**
+ * Whether any filter is set away from its default. Drives the visibility of
+ * the Clear affordance and the choice of empty-state copy.
+ */
+export function hasActiveFilters(filters: FamilyFilters): boolean {
+  return filters.name.trim() !== '' || filters.spouses !== 'all' || filters.children !== 'all';
+}
+
+/** Props accepted by {@link FamiliesFilters}. */
+export interface FamiliesFiltersProps {
+  /** The current filter values (the page owns this state). */
+  value: FamilyFilters;
+  /** Called with the next filter values on any control change. */
+  onChange: (next: FamilyFilters) => void;
+}
+
+/**
+ * The Families-list filter card. A controlled component: it renders a name
+ * search (matched against both spouses' names), a spouse-completeness select,
+ * and a has-children select, reporting edits through `onChange`. A Clear
+ * button appears only while at least one filter is active.
+ *
+ * Filtering itself happens in the page over the already-loaded list; this
+ * component holds no state of its own.
+ */
+export function FamiliesFilters({ value, onChange }: FamiliesFiltersProps): JSX.Element {
+  const { t } = useTranslation('families');
+  const { t: tCommon } = useTranslation('common');
+  const active = hasActiveFilters(value);
+
+  return (
+    <Card>
+      <Flex direction="column" gap="4">
+        <Flex align="center" justify="between">
+          <Heading size="3">{tCommon('filters.title')}</Heading>
+          {active && (
+            <Button
+              variant="ghost"
+              size="1"
+              color="gray"
+              onClick={() => onChange(DEFAULT_FAMILY_FILTERS)}
+            >
+              <Icon name="x" />
+              {tCommon('filters.clear')}
+            </Button>
+          )}
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <Text size="1" color="gray">
+            {t('filters.name.label')}
+          </Text>
+          <TextField.Root
+            value={value.name}
+            placeholder={t('filters.name.placeholder')}
+            onChange={(event) => onChange({ ...value, name: event.target.value })}
+          >
+            <TextField.Slot>
+              <Icon name="search" />
+            </TextField.Slot>
+          </TextField.Root>
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <Text size="1" color="gray">
+            {t('filters.spouses.label')}
+          </Text>
+          <Select.Root
+            value={value.spouses}
+            onValueChange={(next) =>
+              onChange({ ...value, spouses: next as FamilyFilters['spouses'] })
+            }
+          >
+            <Select.Trigger />
+            <Select.Content>
+              <Select.Item value="all">{t('filters.spouses.all')}</Select.Item>
+              <Select.Item value="both">{t('filters.spouses.both')}</Select.Item>
+              <Select.Item value="missingHusband">
+                {t('filters.spouses.missingHusband')}
+              </Select.Item>
+              <Select.Item value="missingWife">{t('filters.spouses.missingWife')}</Select.Item>
+              <Select.Item value="none">{t('filters.spouses.none')}</Select.Item>
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <Text size="1" color="gray">
+            {t('filters.children.label')}
+          </Text>
+          <Select.Root
+            value={value.children}
+            onValueChange={(next) =>
+              onChange({ ...value, children: next as FamilyFilters['children'] })
+            }
+          >
+            <Select.Trigger />
+            <Select.Content>
+              <Select.Item value="all">{t('filters.children.all')}</Select.Item>
+              <Select.Item value="with">{t('filters.children.with')}</Select.Item>
+              <Select.Item value="without">{t('filters.children.without')}</Select.Item>
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}

--- a/src/components/individuals-filters.tsx
+++ b/src/components/individuals-filters.tsx
@@ -48,13 +48,14 @@ export interface IndividualsFiltersProps {
  */
 export function IndividualsFilters({ value, onChange }: IndividualsFiltersProps): JSX.Element {
   const { t } = useTranslation('individuals');
+  const { t: tCommon } = useTranslation('common');
   const active = hasActiveFilters(value);
 
   return (
     <Card>
       <Flex direction="column" gap="4">
         <Flex align="center" justify="between">
-          <Heading size="3">{t('filters.title')}</Heading>
+          <Heading size="3">{tCommon('filters.title')}</Heading>
           {active && (
             <Button
               variant="ghost"
@@ -63,7 +64,7 @@ export function IndividualsFilters({ value, onChange }: IndividualsFiltersProps)
               onClick={() => onChange(DEFAULT_INDIVIDUAL_FILTERS)}
             >
               <Icon name="x" />
-              {t('filters.clear')}
+              {tCommon('filters.clear')}
             </Button>
           )}
         </Flex>

--- a/src/db/trees/names.ts
+++ b/src/db/trees/names.ts
@@ -461,3 +461,18 @@ export function formatName(name: Name | null): NameDisplay {
 export function formatNameSimple(name: Name | null): string {
   return formatName(name).short;
 }
+
+/**
+ * Whether any of `names` matches a free-text search `query`. Each name is
+ * tested as `"<given names> <surname>"`, case-insensitively, with a substring
+ * match. The `query` is expected to be already lower-cased and trimmed by the
+ * caller (filtering loops lower-case it once before iterating).
+ *
+ * Shared by the People and Families list filters so both search names the same
+ * way.
+ */
+export function nameMatchesQuery(names: Name[], query: string): boolean {
+  return names.some((name) =>
+    `${name.givenNames ?? ''} ${name.surname ?? ''}`.toLowerCase().includes(query)
+  );
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -2,6 +2,10 @@
   "app": {
     "title": "Vata"
   },
+  "filters": {
+    "title": "Filters",
+    "clear": "Clear"
+  },
   "nav": {
     "home": "Home",
     "individuals": "People",

--- a/src/i18n/locales/en/families.json
+++ b/src/i18n/locales/en/families.json
@@ -1,12 +1,38 @@
 {
   "heading": "Family {{familyId}}",
+  "page": {
+    "addFamily": "Add family"
+  },
+  "filters": {
+    "name": {
+      "label": "Name",
+      "placeholder": "Search by spouse name"
+    },
+    "spouses": {
+      "label": "Spouses",
+      "all": "All",
+      "both": "Both spouses",
+      "missingHusband": "Missing husband",
+      "missingWife": "Missing wife",
+      "none": "No spouses"
+    },
+    "children": {
+      "label": "Children",
+      "all": "All",
+      "with": "With children",
+      "without": "Childless"
+    }
+  },
   "table": {
     "columns": {
-      "husband": "Husband",
-      "wife": "Wife",
+      "husbandSurname": "Husband surname",
+      "husbandFirstName": "Husband first name",
+      "wifeSurname": "Wife surname",
+      "wifeFirstName": "Wife first name",
       "children": "Children"
     },
     "empty": "No families yet",
-    "unknownSpouse": "Unknown"
+    "noMatches": "No families match your filters",
+    "unknownName": "Unknown"
   }
 }

--- a/src/i18n/locales/en/families.json
+++ b/src/i18n/locales/en/families.json
@@ -25,10 +25,8 @@
   },
   "table": {
     "columns": {
-      "husbandSurname": "Husband surname",
-      "husbandFirstName": "Husband first name",
-      "wifeSurname": "Wife surname",
-      "wifeFirstName": "Wife first name",
+      "husband": "Husband",
+      "wife": "Wife",
       "children": "Children"
     },
     "empty": "No families yet",

--- a/src/i18n/locales/en/individuals.json
+++ b/src/i18n/locales/en/individuals.json
@@ -4,8 +4,6 @@
     "addPerson": "Add person"
   },
   "filters": {
-    "title": "Filters",
-    "clear": "Clear",
     "name": {
       "label": "Name",
       "placeholder": "Search by name"

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -2,6 +2,10 @@
   "app": {
     "title": "Vata"
   },
+  "filters": {
+    "title": "Filtres",
+    "clear": "Effacer"
+  },
   "nav": {
     "home": "Accueil",
     "individuals": "Personnes",

--- a/src/i18n/locales/fr/families.json
+++ b/src/i18n/locales/fr/families.json
@@ -1,12 +1,38 @@
 {
   "heading": "Famille {{familyId}}",
+  "page": {
+    "addFamily": "Ajouter une famille"
+  },
+  "filters": {
+    "name": {
+      "label": "Nom",
+      "placeholder": "Rechercher par nom d'époux"
+    },
+    "spouses": {
+      "label": "Époux",
+      "all": "Tous",
+      "both": "Les deux époux",
+      "missingHusband": "Mari manquant",
+      "missingWife": "Épouse manquante",
+      "none": "Aucun époux"
+    },
+    "children": {
+      "label": "Enfants",
+      "all": "Tous",
+      "with": "Avec enfants",
+      "without": "Sans enfant"
+    }
+  },
   "table": {
     "columns": {
-      "husband": "Mari",
-      "wife": "Épouse",
+      "husbandSurname": "Nom du mari",
+      "husbandFirstName": "Prénom du mari",
+      "wifeSurname": "Nom de l'épouse",
+      "wifeFirstName": "Prénom de l'épouse",
       "children": "Enfants"
     },
     "empty": "Aucune famille",
-    "unknownSpouse": "Inconnu(e)"
+    "noMatches": "Aucune famille ne correspond aux filtres",
+    "unknownName": "Inconnu(e)"
   }
 }

--- a/src/i18n/locales/fr/families.json
+++ b/src/i18n/locales/fr/families.json
@@ -25,10 +25,8 @@
   },
   "table": {
     "columns": {
-      "husbandSurname": "Nom du mari",
-      "husbandFirstName": "Prénom du mari",
-      "wifeSurname": "Nom de l'épouse",
-      "wifeFirstName": "Prénom de l'épouse",
+      "husband": "Mari",
+      "wife": "Épouse",
       "children": "Enfants"
     },
     "empty": "Aucune famille",

--- a/src/i18n/locales/fr/families.json
+++ b/src/i18n/locales/fr/families.json
@@ -25,7 +25,7 @@
   },
   "table": {
     "columns": {
-      "husband": "Mari",
+      "husband": "Époux",
       "wife": "Épouse",
       "children": "Enfants"
     },

--- a/src/i18n/locales/fr/individuals.json
+++ b/src/i18n/locales/fr/individuals.json
@@ -4,8 +4,6 @@
     "addPerson": "Ajouter une personne"
   },
   "filters": {
-    "title": "Filtres",
-    "clear": "Effacer",
     "name": {
       "label": "Nom",
       "placeholder": "Rechercher par nom"

--- a/src/pages/FamiliesPage.tsx
+++ b/src/pages/FamiliesPage.tsx
@@ -113,7 +113,9 @@ export function FamiliesPage({ treeId }: FamiliesPageProps): JSX.Element {
         header: t('table.columns.wife'),
         width: COLUMN_WIDTH.name,
         cell: (family) =>
-          family.wife?.primaryName ? formatName(family.wife.primaryName).surnameFirst : '—',
+          family.wife?.primaryName
+            ? formatName(family.wife.primaryName).surnameFirst
+            : t('table.unknownName'),
         sortValue: (family) => formatName(family.wife?.primaryName ?? null).sortable || null,
       },
       {

--- a/src/pages/FamiliesPage.tsx
+++ b/src/pages/FamiliesPage.tsx
@@ -1,16 +1,40 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Link as RouterLink, useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
-import { Box, Link } from '@radix-ui/themes';
+import { Box, Button, Flex, Grid, Heading, Link } from '@radix-ui/themes';
 
 import { EntityTable, type EntityTableColumn } from '$components/entity-table';
+import {
+  DEFAULT_FAMILY_FILTERS,
+  FamiliesFilters,
+  hasActiveFilters,
+} from '$components/families-filters';
+import { Icon } from '$components/icon';
+import { useDebouncedValue } from '$hooks/useDebouncedValue';
 import { useFamilies } from '$hooks/useFamilies';
-import { sortByKey } from '$lib/sortByKey';
 import { formatName } from '$db-tree/names';
-import type { FamilyWithMembers, Name } from '$types/database';
+import type { FamilyWithMembers, IndividualWithDetails } from '$types/database';
 
 interface FamiliesPageProps {
   treeId: string;
+}
+
+/**
+ * Column widths keyed by the kind of data each column holds, so columns of
+ * the same type (the four spouse-name columns) stay visually uniform
+ * regardless of their individual contents.
+ */
+const COLUMN_WIDTH = {
+  name: '200px',
+  children: '120px',
+} as const;
+
+/** Whether any of the spouse's names matches the (lower-cased) query. */
+function spouseMatches(spouse: IndividualWithDetails | null, query: string): boolean {
+  if (!spouse) return false;
+  return spouse.names.some((name) =>
+    `${name.givenNames ?? ''} ${name.surname ?? ''}`.toLowerCase().includes(query)
+  );
 }
 
 /**
@@ -23,68 +47,131 @@ export function FamiliesPage({ treeId }: FamiliesPageProps): JSX.Element {
   const navigate = useNavigate();
   const { data, isLoading, isError } = useFamilies();
 
-  const rows = useMemo(
-    () =>
-      data
-        ? sortByKey(data, (family) =>
-            family.husband ? formatName(family.husband.primaryName).sortable || null : null
-          )
-        : [],
-    [data]
-  );
+  const [filters, setFilters] = useState(DEFAULT_FAMILY_FILTERS);
+  const debouncedName = useDebouncedValue(filters.name, 200);
 
-  const columns = useMemo<EntityTableColumn<FamilyWithMembers>[]>(() => {
-    const unknownSpouse = t('table.unknownSpouse');
-    const spouseDisplay = (name: Name | null): string =>
-      name ? formatName(name).surnameFirst : unknownSpouse;
-    return [
+  // Filter the already-loaded list client-side: spouse-name search (both
+  // spouses), spouse completeness, and children presence (all AND-ed).
+  // Ordering is handled by the table (sortable headers); see `defaultSort`.
+  const visibleRows = useMemo(() => {
+    const query = debouncedName.trim().toLowerCase();
+    return (data ?? []).filter((family) => {
+      const hasHusband = family.husband !== null;
+      const hasWife = family.wife !== null;
+      if (filters.spouses === 'both' && !(hasHusband && hasWife)) return false;
+      if (filters.spouses === 'missingHusband' && !(!hasHusband && hasWife)) return false;
+      if (filters.spouses === 'missingWife' && !(hasHusband && !hasWife)) return false;
+      if (filters.spouses === 'none' && (hasHusband || hasWife)) return false;
+
+      const hasChildren = family.children.length > 0;
+      if (filters.children === 'with' && !hasChildren) return false;
+      if (filters.children === 'without' && hasChildren) return false;
+
+      if (query && !spouseMatches(family.husband, query) && !spouseMatches(family.wife, query)) {
+        return false;
+      }
+      return true;
+    });
+  }, [data, filters.spouses, filters.children, debouncedName]);
+
+  const columns = useMemo<EntityTableColumn<FamilyWithMembers>[]>(
+    () => [
       {
-        key: 'husband',
-        header: t('table.columns.husband'),
+        key: 'husbandSurname',
+        header: t('table.columns.husbandSurname'),
         rowHeader: true,
+        width: COLUMN_WIDTH.name,
+        // A keyboard-focusable link (styled as plain text) so the list is
+        // navigable without a pointer; the whole row is also clickable via
+        // `onRowClick`, so the link stops propagation.
         cell: (family) => (
-          <Link asChild onClick={(event) => event.stopPropagation()}>
+          <Link
+            asChild
+            color="gray"
+            highContrast
+            underline="none"
+            onClick={(domEvent) => domEvent.stopPropagation()}
+          >
             <RouterLink
               to="/tree/$treeId/family/$familyId"
               params={{ treeId, familyId: family.id }}
             >
-              {spouseDisplay(family.husband?.primaryName ?? null)}
+              {family.husband?.primaryName?.surname?.trim() || t('table.unknownName')}
             </RouterLink>
           </Link>
         ),
+        // Sort by "Surname, Given" so same-surname spouses fall in given order.
+        sortValue: (family) => formatName(family.husband?.primaryName ?? null).sortable || null,
       },
       {
-        key: 'wife',
-        header: t('table.columns.wife'),
-        cell: (family) => spouseDisplay(family.wife?.primaryName ?? null),
+        key: 'husbandFirstName',
+        header: t('table.columns.husbandFirstName'),
+        width: COLUMN_WIDTH.name,
+        cell: (family) => family.husband?.primaryName?.givenNames?.trim() || '—',
+        sortValue: (family) => family.husband?.primaryName?.givenNames?.trim() || null,
+      },
+      {
+        key: 'wifeSurname',
+        header: t('table.columns.wifeSurname'),
+        width: COLUMN_WIDTH.name,
+        cell: (family) => family.wife?.primaryName?.surname?.trim() || '—',
+        sortValue: (family) => formatName(family.wife?.primaryName ?? null).sortable || null,
+      },
+      {
+        key: 'wifeFirstName',
+        header: t('table.columns.wifeFirstName'),
+        width: COLUMN_WIDTH.name,
+        cell: (family) => family.wife?.primaryName?.givenNames?.trim() || '—',
+        sortValue: (family) => family.wife?.primaryName?.givenNames?.trim() || null,
       },
       {
         key: 'children',
         header: t('table.columns.children'),
-        width: '120px',
+        width: COLUMN_WIDTH.children,
         cell: (family) => family.children.length,
+        sortValue: (family) => family.children.length,
       },
-    ];
-  }, [t, treeId]);
+    ],
+    [t, treeId]
+  );
 
   return (
     <Box p="4">
-      <EntityTable
-        label={tCommon('nav.families')}
-        columns={columns}
-        rows={rows}
-        getRowKey={(family) => family.id}
-        onRowClick={(family) =>
-          navigate({
-            to: '/tree/$treeId/family/$familyId',
-            params: { treeId, familyId: family.id },
-          })
-        }
-        isLoading={isLoading}
-        isError={isError}
-        errorMessage={tCommon('errors.loadFailed')}
-        emptyMessage={t('table.empty')}
-      />
+      <Flex direction="column" gap="4">
+        <Flex align="center" justify="between" pt="2" pb="3">
+          <Flex align="center" gap="3">
+            <Icon name="users" size={28} />
+            <Heading size="7" trim="both">
+              {tCommon('nav.families')}
+            </Heading>
+          </Flex>
+          <Button disabled>
+            <Icon name="plus" />
+            {t('page.addFamily')}
+          </Button>
+        </Flex>
+
+        <Grid columns="280px 1fr" gap="4" align="start">
+          <FamiliesFilters value={filters} onChange={setFilters} />
+          <EntityTable
+            label={tCommon('nav.families')}
+            columns={columns}
+            rows={visibleRows}
+            getRowKey={(family) => family.id}
+            onRowClick={(family) =>
+              navigate({
+                to: '/tree/$treeId/family/$familyId',
+                params: { treeId, familyId: family.id },
+              })
+            }
+            isLoading={isLoading}
+            isError={isError}
+            errorMessage={tCommon('errors.loadFailed')}
+            emptyMessage={hasActiveFilters(filters) ? t('table.noMatches') : t('table.empty')}
+            defaultSort={{ columnKey: 'husbandSurname', direction: 'asc' }}
+          />
+        </Grid>
+      </Flex>
     </Box>
   );
 }

--- a/src/pages/FamiliesPage.tsx
+++ b/src/pages/FamiliesPage.tsx
@@ -99,7 +99,7 @@ export function FamiliesPage({ treeId }: FamiliesPageProps): JSX.Element {
               to="/tree/$treeId/family/$familyId"
               params={{ treeId, familyId: family.id }}
             >
-              {family.husband
+              {family.husband?.primaryName
                 ? formatName(family.husband.primaryName).surnameFirst
                 : t('table.unknownName')}
             </RouterLink>
@@ -112,7 +112,8 @@ export function FamiliesPage({ treeId }: FamiliesPageProps): JSX.Element {
         key: 'wife',
         header: t('table.columns.wife'),
         width: COLUMN_WIDTH.name,
-        cell: (family) => (family.wife ? formatName(family.wife.primaryName).surnameFirst : '—'),
+        cell: (family) =>
+          family.wife?.primaryName ? formatName(family.wife.primaryName).surnameFirst : '—',
         sortValue: (family) => formatName(family.wife?.primaryName ?? null).sortable || null,
       },
       {

--- a/src/pages/FamiliesPage.tsx
+++ b/src/pages/FamiliesPage.tsx
@@ -21,12 +21,11 @@ interface FamiliesPageProps {
 }
 
 /**
- * Column widths keyed by the kind of data each column holds, so columns of
- * the same type (the four spouse-name columns) stay visually uniform
- * regardless of their individual contents.
+ * Column widths keyed by the kind of data each column holds, so the two
+ * spouse-name columns stay visually uniform regardless of their contents.
  */
 const COLUMN_WIDTH = {
-  name: '200px',
+  name: '280px',
   children: '120px',
 } as const;
 
@@ -81,8 +80,8 @@ export function FamiliesPage({ treeId }: FamiliesPageProps): JSX.Element {
   const columns = useMemo<EntityTableColumn<FamilyWithMembers>[]>(
     () => [
       {
-        key: 'husbandSurname',
-        header: t('table.columns.husbandSurname'),
+        key: 'husband',
+        header: t('table.columns.husband'),
         rowHeader: true,
         width: COLUMN_WIDTH.name,
         // A keyboard-focusable link (styled as plain text) so the list is
@@ -100,7 +99,9 @@ export function FamiliesPage({ treeId }: FamiliesPageProps): JSX.Element {
               to="/tree/$treeId/family/$familyId"
               params={{ treeId, familyId: family.id }}
             >
-              {family.husband?.primaryName?.surname?.trim() || t('table.unknownName')}
+              {family.husband
+                ? formatName(family.husband.primaryName).surnameFirst
+                : t('table.unknownName')}
             </RouterLink>
           </Link>
         ),
@@ -108,25 +109,11 @@ export function FamiliesPage({ treeId }: FamiliesPageProps): JSX.Element {
         sortValue: (family) => formatName(family.husband?.primaryName ?? null).sortable || null,
       },
       {
-        key: 'husbandFirstName',
-        header: t('table.columns.husbandFirstName'),
+        key: 'wife',
+        header: t('table.columns.wife'),
         width: COLUMN_WIDTH.name,
-        cell: (family) => family.husband?.primaryName?.givenNames?.trim() || '—',
-        sortValue: (family) => family.husband?.primaryName?.givenNames?.trim() || null,
-      },
-      {
-        key: 'wifeSurname',
-        header: t('table.columns.wifeSurname'),
-        width: COLUMN_WIDTH.name,
-        cell: (family) => family.wife?.primaryName?.surname?.trim() || '—',
+        cell: (family) => (family.wife ? formatName(family.wife.primaryName).surnameFirst : '—'),
         sortValue: (family) => formatName(family.wife?.primaryName ?? null).sortable || null,
-      },
-      {
-        key: 'wifeFirstName',
-        header: t('table.columns.wifeFirstName'),
-        width: COLUMN_WIDTH.name,
-        cell: (family) => family.wife?.primaryName?.givenNames?.trim() || '—',
-        sortValue: (family) => family.wife?.primaryName?.givenNames?.trim() || null,
       },
       {
         key: 'children',
@@ -172,7 +159,7 @@ export function FamiliesPage({ treeId }: FamiliesPageProps): JSX.Element {
             isError={isError}
             errorMessage={tCommon('errors.loadFailed')}
             emptyMessage={hasActiveFilters(filters) ? t('table.noMatches') : t('table.empty')}
-            defaultSort={{ columnKey: 'husbandSurname', direction: 'asc' }}
+            defaultSort={{ columnKey: 'husband', direction: 'asc' }}
           />
         </Grid>
       </Flex>

--- a/src/pages/FamiliesPage.tsx
+++ b/src/pages/FamiliesPage.tsx
@@ -7,12 +7,13 @@ import { EntityTable, type EntityTableColumn } from '$components/entity-table';
 import {
   DEFAULT_FAMILY_FILTERS,
   FamiliesFilters,
+  type FamilyFilters,
   hasActiveFilters,
 } from '$components/families-filters';
 import { Icon } from '$components/icon';
 import { useDebouncedValue } from '$hooks/useDebouncedValue';
 import { useFamilies } from '$hooks/useFamilies';
-import { formatName } from '$db-tree/names';
+import { formatName, nameMatchesQuery } from '$db-tree/names';
 import type { FamilyWithMembers, IndividualWithDetails } from '$types/database';
 
 interface FamiliesPageProps {
@@ -31,10 +32,7 @@ const COLUMN_WIDTH = {
 
 /** Whether any of the spouse's names matches the (lower-cased) query. */
 function spouseMatches(spouse: IndividualWithDetails | null, query: string): boolean {
-  if (!spouse) return false;
-  return spouse.names.some((name) =>
-    `${name.givenNames ?? ''} ${name.surname ?? ''}`.toLowerCase().includes(query)
-  );
+  return spouse !== null && nameMatchesQuery(spouse.names, query);
 }
 
 /**
@@ -58,10 +56,16 @@ export function FamiliesPage({ treeId }: FamiliesPageProps): JSX.Element {
     return (data ?? []).filter((family) => {
       const hasHusband = family.husband !== null;
       const hasWife = family.wife !== null;
-      if (filters.spouses === 'both' && !(hasHusband && hasWife)) return false;
-      if (filters.spouses === 'missingHusband' && !(!hasHusband && hasWife)) return false;
-      if (filters.spouses === 'missingWife' && !(hasHusband && !hasWife)) return false;
-      if (filters.spouses === 'none' && (hasHusband || hasWife)) return false;
+      // Positive predicate per option — reads as the plain definition of each
+      // choice, avoiding the double-negation of an "if X and not X" chain.
+      const spouseOk: Record<FamilyFilters['spouses'], boolean> = {
+        all: true,
+        both: hasHusband && hasWife,
+        missingHusband: !hasHusband && hasWife,
+        missingWife: hasHusband && !hasWife,
+        none: !hasHusband && !hasWife,
+      };
+      if (!spouseOk[filters.spouses]) return false;
 
       const hasChildren = family.children.length > 0;
       if (filters.children === 'with' && !hasChildren) return false;

--- a/src/pages/IndividualsPage.tsx
+++ b/src/pages/IndividualsPage.tsx
@@ -12,7 +12,7 @@ import {
 } from '$components/individuals-filters';
 import { useDebouncedValue } from '$hooks/useDebouncedValue';
 import { useIndividuals } from '$hooks/useIndividuals';
-import { formatName } from '$db-tree/names';
+import { formatName, nameMatchesQuery } from '$db-tree/names';
 import type { EventWithDetails, Gender, IndividualWithDetails } from '$types/database';
 
 interface IndividualsPageProps {
@@ -75,12 +75,7 @@ export function IndividualsPage({ treeId }: IndividualsPageProps): JSX.Element {
       if (filters.sex !== 'all' && person.gender !== filters.sex) return false;
       if (filters.status === 'living' && !person.isLiving) return false;
       if (filters.status === 'deceased' && person.isLiving) return false;
-      if (query) {
-        const match = person.names.some((name) =>
-          `${name.givenNames ?? ''} ${name.surname ?? ''}`.toLowerCase().includes(query)
-        );
-        if (!match) return false;
-      }
+      if (query && !nameMatchesQuery(person.names, query)) return false;
       return true;
     });
   }, [data, filters.sex, filters.status, debouncedName]);


### PR DESCRIPTION
Brings the Families list to parity with the People list (#180).

## What

- **Filters sidebar** (`FamiliesFilters`, client-side, page-owned state):
  - **Name** — debounced free-text search over **both spouses'** names.
  - **Spouses** — All / Both spouses / Missing husband / Missing wife / No spouses.
  - **Children** — All / With children / Childless.
- **Sortable columns** (via `EntityTable`'s `sortValue`): **Husband** (row header, default sort ↑) · **Wife** · **Children** (count). Each spouse cell shows the full "Surname, Given" name; husband/wife sort by the surname-first key.
- **Page header** — families icon + "Families" heading + disabled "Add family" button (no create route yet).
- **Dual empty states** — "No families yet" vs "No families match your filters".

## Shared cleanup

- "Filters" / "Clear" labels moved to the shared `common` i18n namespace; `IndividualsFilters` now reads them from there too.
- Extracted `nameMatchesQuery()` into `names.ts`, used by both the People and Families filters (removes a duplicated inline predicate).
- Spouse-completeness uses a positive per-option lookup record instead of a double-negation `if`-chain.

## Verification

- `tsc --noEmit`, ESLint, Prettier — clean.
- Full Vitest suite — 586 passing.
- Pre-PR `/simplify` and `/review` (high effort) applied; cubic review pass — localized-fallback fix applied (identified by cubic). en/fr i18n parity confirmed.

> Note: an earlier iteration split each spouse into separate surname/first-name columns; per review feedback these were merged back into single **Husband** and **Wife** columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)