### PR TITLE
feat(events,places): list filters, sortable headers, page shell parity

### DIFF
--- a/src/components/events-filters.tsx
+++ b/src/components/events-filters.tsx
@@ -1,0 +1,122 @@
+import { Button, Card, Flex, Heading, Select, Text } from '@radix-ui/themes';
+import { useTranslation } from 'react-i18next';
+
+import { Icon } from '$components/icon';
+
+/** The set of filters applied to the Events list, all combined with AND. */
+export interface EventFilters {
+  /** Restrict to a single event-type id, or `'all'` for no restriction. */
+  type: string;
+  /** Restrict to a single place id, or `'all'` for no restriction. */
+  place: string;
+}
+
+/** The neutral state — no filtering. Also the target of the Clear action. */
+export const DEFAULT_EVENT_FILTERS: EventFilters = {
+  type: 'all',
+  place: 'all',
+};
+
+/**
+ * Whether any filter is set away from its default. Drives the visibility of
+ * the Clear affordance and the choice of empty-state copy.
+ */
+export function hasActiveFilters(filters: EventFilters): boolean {
+  return filters.type !== 'all' || filters.place !== 'all';
+}
+
+/** A selectable option for the Type and Place selects. */
+export interface EventFilterOption {
+  /** The id used as the filter value. */
+  value: string;
+  /** The user-visible label. */
+  label: string;
+}
+
+/** Props accepted by {@link EventsFilters}. */
+export interface EventsFiltersProps {
+  /** The current filter values (the page owns this state). */
+  value: EventFilters;
+  /** Called with the next filter values on any control change. */
+  onChange: (next: EventFilters) => void;
+  /** The event types present in the tree, offered in the Type select. */
+  types: EventFilterOption[];
+  /** The places present on the events, offered in the Place select. */
+  places: EventFilterOption[];
+}
+
+/**
+ * The Events-list filter card. A controlled component: it renders an
+ * event-type select and a place select — both populated from the values
+ * actually present in the loaded events — and reports edits through
+ * `onChange`. A Clear button appears only while at least one filter is active.
+ *
+ * Filtering itself happens in the page over the already-loaded list; this
+ * component holds no state of its own.
+ */
+export function EventsFilters({ value, onChange, types, places }: EventsFiltersProps): JSX.Element {
+  const { t } = useTranslation('events');
+  const { t: tCommon } = useTranslation('common');
+  const active = hasActiveFilters(value);
+
+  return (
+    <Card>
+      <Flex direction="column" gap="4">
+        <Flex align="center" justify="between">
+          <Heading size="3">{tCommon('filters.title')}</Heading>
+          {active && (
+            <Button
+              variant="ghost"
+              size="1"
+              color="gray"
+              onClick={() => onChange(DEFAULT_EVENT_FILTERS)}
+            >
+              <Icon name="x" />
+              {tCommon('filters.clear')}
+            </Button>
+          )}
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <Text size="1" color="gray">
+            {t('filters.type.label')}
+          </Text>
+          <Select.Root
+            value={value.type}
+            onValueChange={(next) => onChange({ ...value, type: next })}
+          >
+            <Select.Trigger />
+            <Select.Content>
+              <Select.Item value="all">{t('filters.type.all')}</Select.Item>
+              {types.map((option) => (
+                <Select.Item key={option.value} value={option.value}>
+                  {option.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <Text size="1" color="gray">
+            {t('filters.place.label')}
+          </Text>
+          <Select.Root
+            value={value.place}
+            onValueChange={(next) => onChange({ ...value, place: next })}
+          >
+            <Select.Trigger />
+            <Select.Content>
+              <Select.Item value="all">{t('filters.place.all')}</Select.Item>
+              {places.map((option) => (
+                <Select.Item key={option.value} value={option.value}>
+                  {option.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}

--- a/src/components/places-filters.tsx
+++ b/src/components/places-filters.tsx
@@ -1,0 +1,115 @@
+import { Button, Card, Flex, Heading, Select, Text, TextField } from '@radix-ui/themes';
+import { useTranslation } from 'react-i18next';
+
+import { Icon } from '$components/icon';
+
+/** The set of filters applied to the Places list, all combined with AND. */
+export interface PlaceFilters {
+  /** Free-text query matched against the name and the full hierarchical name. */
+  name: string;
+  /** Restrict to a single place-type id, or `'all'` for no restriction. */
+  type: string;
+}
+
+/** The neutral state — no filtering. Also the target of the Clear action. */
+export const DEFAULT_PLACE_FILTERS: PlaceFilters = {
+  name: '',
+  type: 'all',
+};
+
+/**
+ * Whether any filter is set away from its default. Drives the visibility of
+ * the Clear affordance and the choice of empty-state copy.
+ */
+export function hasActiveFilters(filters: PlaceFilters): boolean {
+  return filters.name.trim() !== '' || filters.type !== 'all';
+}
+
+/** A selectable place-type option for the Type filter. */
+export interface PlaceTypeOption {
+  /** The place-type id used as the filter value. */
+  value: string;
+  /** The user-visible label. */
+  label: string;
+}
+
+/** Props accepted by {@link PlacesFilters}. */
+export interface PlacesFiltersProps {
+  /** The current filter values (the page owns this state). */
+  value: PlaceFilters;
+  /** Called with the next filter values on any control change. */
+  onChange: (next: PlaceFilters) => void;
+  /** The place types present in the tree, offered in the Type select. */
+  types: PlaceTypeOption[];
+}
+
+/**
+ * The Places-list filter card. A controlled component: it renders a name
+ * search (matched against the name and full name) and a place-type select,
+ * reporting edits through `onChange`. A Clear button appears only while at
+ * least one filter is active.
+ *
+ * Filtering itself happens in the page over the already-loaded list; this
+ * component holds no state of its own.
+ */
+export function PlacesFilters({ value, onChange, types }: PlacesFiltersProps): JSX.Element {
+  const { t } = useTranslation('places');
+  const { t: tCommon } = useTranslation('common');
+  const active = hasActiveFilters(value);
+
+  return (
+    <Card>
+      <Flex direction="column" gap="4">
+        <Flex align="center" justify="between">
+          <Heading size="3">{tCommon('filters.title')}</Heading>
+          {active && (
+            <Button
+              variant="ghost"
+              size="1"
+              color="gray"
+              onClick={() => onChange(DEFAULT_PLACE_FILTERS)}
+            >
+              <Icon name="x" />
+              {tCommon('filters.clear')}
+            </Button>
+          )}
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <Text size="1" color="gray">
+            {t('filters.name.label')}
+          </Text>
+          <TextField.Root
+            value={value.name}
+            placeholder={t('filters.name.placeholder')}
+            onChange={(event) => onChange({ ...value, name: event.target.value })}
+          >
+            <TextField.Slot>
+              <Icon name="search" />
+            </TextField.Slot>
+          </TextField.Root>
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <Text size="1" color="gray">
+            {t('filters.type.label')}
+          </Text>
+          <Select.Root
+            value={value.type}
+            onValueChange={(next) => onChange({ ...value, type: next })}
+          >
+            <Select.Trigger />
+            <Select.Content>
+              <Select.Item value="all">{t('filters.type.all')}</Select.Item>
+              {types.map((option) => (
+                <Select.Item key={option.value} value={option.value}>
+                  {option.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}

--- a/src/hooks/usePlaceTypes.ts
+++ b/src/hooks/usePlaceTypes.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '$/lib/query-keys';
+import { getAllPlaceTypes } from '$db-tree/places';
+
+/** Every place type in the open tree, ordered by sort order. */
+export function usePlaceTypes() {
+  return useQuery({
+    queryKey: queryKeys.placeTypes,
+    queryFn: () => getAllPlaceTypes(),
+  });
+}

--- a/src/i18n/locales/en/events.json
+++ b/src/i18n/locales/en/events.json
@@ -1,5 +1,18 @@
 {
   "heading": "Event {{eventId}}",
+  "page": {
+    "addEvent": "Add event"
+  },
+  "filters": {
+    "type": {
+      "label": "Type",
+      "all": "All"
+    },
+    "place": {
+      "label": "Place",
+      "all": "All"
+    }
+  },
   "table": {
     "columns": {
       "type": "Type",
@@ -8,6 +21,7 @@
       "place": "Place"
     },
     "empty": "No events yet",
+    "noMatches": "No events match your filters",
     "unknownPrincipal": "Unknown",
     "dateUnknown": "Date unknown"
   },

--- a/src/i18n/locales/en/places.json
+++ b/src/i18n/locales/en/places.json
@@ -1,10 +1,25 @@
 {
   "heading": "Place {{placeId}}",
+  "page": {
+    "addPlace": "Add place"
+  },
+  "filters": {
+    "name": {
+      "label": "Name",
+      "placeholder": "Search by name"
+    },
+    "type": {
+      "label": "Type",
+      "all": "All"
+    }
+  },
   "table": {
     "columns": {
       "name": "Name",
+      "type": "Type",
       "parent": "Parent"
     },
-    "empty": "No places yet"
+    "empty": "No places yet",
+    "noMatches": "No places match your filters"
   }
 }

--- a/src/i18n/locales/fr/events.json
+++ b/src/i18n/locales/fr/events.json
@@ -1,5 +1,18 @@
 {
   "heading": "Événement {{eventId}}",
+  "page": {
+    "addEvent": "Ajouter un événement"
+  },
+  "filters": {
+    "type": {
+      "label": "Type",
+      "all": "Tous"
+    },
+    "place": {
+      "label": "Lieu",
+      "all": "Tous"
+    }
+  },
   "table": {
     "columns": {
       "type": "Type",
@@ -8,6 +21,7 @@
       "place": "Lieu"
     },
     "empty": "Aucun événement",
+    "noMatches": "Aucun événement ne correspond aux filtres",
     "unknownPrincipal": "Inconnu(e)",
     "dateUnknown": "Date inconnue"
   },

--- a/src/i18n/locales/fr/places.json
+++ b/src/i18n/locales/fr/places.json
@@ -1,10 +1,25 @@
 {
   "heading": "Lieu {{placeId}}",
+  "page": {
+    "addPlace": "Ajouter un lieu"
+  },
+  "filters": {
+    "name": {
+      "label": "Nom",
+      "placeholder": "Rechercher par nom"
+    },
+    "type": {
+      "label": "Type",
+      "all": "Tous"
+    }
+  },
   "table": {
     "columns": {
       "name": "Nom",
+      "type": "Type",
       "parent": "Parent"
     },
-    "empty": "Aucun lieu"
+    "empty": "Aucun lieu",
+    "noMatches": "Aucun lieu ne correspond aux filtres"
   }
 }

--- a/src/lib/placeTypeLabel.ts
+++ b/src/lib/placeTypeLabel.ts
@@ -1,0 +1,14 @@
+import type { PlaceType } from '$types/database';
+
+/**
+ * Resolves a PlaceType to its user-visible label string.
+ *
+ * Place types are not seeded and have no translation keys: a system type
+ * carries only a `tag` (e.g. `CITY`), a custom type only a `customName`.
+ * So the label is simply the custom name when present, otherwise the tag.
+ * Returns an empty string for the (schema-forbidden) case where both are
+ * absent, leaving the caller to apply its own fallback.
+ */
+export function placeTypeLabel(type: PlaceType): string {
+  return type.customName ?? type.tag ?? '';
+}

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -1,18 +1,33 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Link as RouterLink, useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
-import { Box, Link } from '@radix-ui/themes';
+import { Box, Button, Flex, Grid, Heading, Link } from '@radix-ui/themes';
 
 import { EntityTable, type EntityTableColumn } from '$components/entity-table';
+import {
+  DEFAULT_EVENT_FILTERS,
+  EventsFilters,
+  type EventFilterOption,
+  hasActiveFilters,
+} from '$components/events-filters';
+import { Icon } from '$components/icon';
 import { useEvents } from '$hooks/useEvents';
 import { eventTypeLabel } from '$lib/eventTypeLabel';
-import { sortByKey } from '$lib/sortByKey';
 import { formatName } from '$db-tree/names';
 import type { EventListEntry, EventPrincipal, Name } from '$types/database';
 
 interface EventsPageProps {
   treeId: string;
 }
+
+/**
+ * Column widths keyed by the kind of data each column holds, so columns of
+ * the same type stay visually uniform regardless of their contents.
+ */
+const COLUMN_WIDTH = {
+  type: '200px',
+  date: '160px',
+} as const;
 
 /** A single principal name, falling back to the unknown label. */
 function nameText(name: Name | null, unknownLabel: string): string {
@@ -33,6 +48,26 @@ function principalsText(principals: EventPrincipal[], unknownLabel: string): str
 }
 
 /**
+ * Build the select options for a filter: project each event to a
+ * `[value, label]` pair (or `null` to skip it), dedupe on the value, and
+ * sort by label. Both the Type and Place filters list only the values that
+ * actually occur in the loaded events.
+ */
+function toSortedOptions(
+  events: EventListEntry[],
+  project: (event: EventListEntry) => [string, string] | null
+): EventFilterOption[] {
+  const byId = new Map<string, string>();
+  for (const event of events) {
+    const pair = project(event);
+    if (pair) byId.set(pair[0], pair[1]);
+  }
+  return Array.from(byId, ([value, label]) => ({ value, label })).sort((a, b) =>
+    a.label.localeCompare(b.label)
+  );
+}
+
+/**
  * The Events section page — the full-width table of every event in the
  * open tree. A row click opens that event's detail route.
  */
@@ -42,7 +77,38 @@ export function EventsPage({ treeId }: EventsPageProps): JSX.Element {
   const navigate = useNavigate();
   const { data, isLoading, isError } = useEvents();
 
-  const rows = useMemo(() => (data ? sortByKey(data, (event) => event.dateSort) : []), [data]);
+  const [filters, setFilters] = useState(DEFAULT_EVENT_FILTERS);
+
+  // The Type filter offers every event type present in the loaded events,
+  // by label; deduped on the type id.
+  const typeOptions = useMemo<EventFilterOption[]>(
+    () =>
+      toSortedOptions(data ?? [], (event) => [
+        event.eventType.id,
+        eventTypeLabel(event.eventType, t),
+      ]),
+    [data, t]
+  );
+
+  // The Place filter offers every place present on the loaded events.
+  const placeOptions = useMemo<EventFilterOption[]>(
+    () =>
+      toSortedOptions(data ?? [], (event) =>
+        event.place ? [event.place.id, event.place.name] : null
+      ),
+    [data]
+  );
+
+  // Filter the already-loaded list client-side by type and place (AND-ed).
+  // The list arrives chronological from the manager; the Date column is not
+  // sortable, so that natural order is preserved.
+  const visibleRows = useMemo(() => {
+    return (data ?? []).filter((event) => {
+      if (filters.type !== 'all' && event.eventType.id !== filters.type) return false;
+      if (filters.place !== 'all' && event.place?.id !== filters.place) return false;
+      return true;
+    });
+  }, [data, filters.type, filters.place]);
 
   const columns = useMemo<EntityTableColumn<EventListEntry>[]>(() => {
     const unknownPrincipal = t('table.unknownPrincipal');
@@ -52,18 +118,29 @@ export function EventsPage({ treeId }: EventsPageProps): JSX.Element {
         key: 'type',
         header: t('table.columns.type'),
         rowHeader: true,
+        width: COLUMN_WIDTH.type,
+        // A keyboard-focusable link (styled as plain text — no color/underline)
+        // so the list is navigable without a pointer; the whole row is also
+        // clickable via `onRowClick`, so the link stops propagation.
         cell: (event) => (
-          <Link asChild onClick={(domEvent) => domEvent.stopPropagation()}>
+          <Link
+            asChild
+            color="gray"
+            highContrast
+            underline="none"
+            onClick={(domEvent) => domEvent.stopPropagation()}
+          >
             <RouterLink to="/tree/$treeId/event/$eventId" params={{ treeId, eventId: event.id }}>
               {eventTypeLabel(event.eventType, t)}
             </RouterLink>
           </Link>
         ),
+        sortValue: (event) => eventTypeLabel(event.eventType, t) || null,
       },
       {
         key: 'date',
         header: t('table.columns.date'),
-        width: '160px',
+        width: COLUMN_WIDTH.date,
         cell: (event) =>
           event.dateOriginal ?? (event.dateSort ? event.dateSort.slice(0, 4) : dateUnknown),
       },
@@ -71,30 +148,59 @@ export function EventsPage({ treeId }: EventsPageProps): JSX.Element {
         key: 'principals',
         header: t('table.columns.principals'),
         cell: (event) => principalsText(event.principals, unknownPrincipal),
+        sortValue: (event) =>
+          event.principals.length === 0 ? null : principalsText(event.principals, unknownPrincipal),
       },
       {
         key: 'place',
         header: t('table.columns.place'),
         cell: (event) => event.place?.name ?? '—',
+        sortValue: (event) => event.place?.name ?? null,
       },
     ];
   }, [t, treeId]);
 
   return (
     <Box p="4">
-      <EntityTable
-        label={tCommon('nav.events')}
-        columns={columns}
-        rows={rows}
-        getRowKey={(event) => event.id}
-        onRowClick={(event) =>
-          navigate({ to: '/tree/$treeId/event/$eventId', params: { treeId, eventId: event.id } })
-        }
-        isLoading={isLoading}
-        isError={isError}
-        errorMessage={tCommon('errors.loadFailed')}
-        emptyMessage={t('table.empty')}
-      />
+      <Flex direction="column" gap="4">
+        <Flex align="center" justify="between" pt="2" pb="3">
+          <Flex align="center" gap="3">
+            <Icon name="calendar" size={28} />
+            <Heading size="7" trim="both">
+              {tCommon('nav.events')}
+            </Heading>
+          </Flex>
+          <Button disabled>
+            <Icon name="plus" />
+            {t('page.addEvent')}
+          </Button>
+        </Flex>
+
+        <Grid columns="280px 1fr" gap="4" align="start">
+          <EventsFilters
+            value={filters}
+            onChange={setFilters}
+            types={typeOptions}
+            places={placeOptions}
+          />
+          <EntityTable
+            label={tCommon('nav.events')}
+            columns={columns}
+            rows={visibleRows}
+            getRowKey={(event) => event.id}
+            onRowClick={(event) =>
+              navigate({
+                to: '/tree/$treeId/event/$eventId',
+                params: { treeId, eventId: event.id },
+              })
+            }
+            isLoading={isLoading}
+            isError={isError}
+            errorMessage={tCommon('errors.loadFailed')}
+            emptyMessage={hasActiveFilters(filters) ? t('table.noMatches') : t('table.empty')}
+          />
+        </Grid>
+      </Flex>
     </Box>
   );
 }

--- a/src/pages/PlacesPage.tsx
+++ b/src/pages/PlacesPage.tsx
@@ -1,16 +1,34 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Link as RouterLink, useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
-import { Box, Link } from '@radix-ui/themes';
+import { Box, Button, Flex, Grid, Heading, Link } from '@radix-ui/themes';
 
 import { EntityTable, type EntityTableColumn } from '$components/entity-table';
+import { Icon } from '$components/icon';
+import {
+  DEFAULT_PLACE_FILTERS,
+  hasActiveFilters,
+  PlacesFilters,
+  type PlaceTypeOption,
+} from '$components/places-filters';
+import { useDebouncedValue } from '$hooks/useDebouncedValue';
 import { usePlaces } from '$hooks/usePlaces';
-import { sortByKey } from '$lib/sortByKey';
+import { usePlaceTypes } from '$hooks/usePlaceTypes';
+import { placeTypeLabel } from '$lib/placeTypeLabel';
 import type { Place } from '$types/database';
 
 interface PlacesPageProps {
   treeId: string;
 }
+
+/**
+ * Column widths keyed by the kind of data each column holds, so columns of
+ * the same type stay visually uniform regardless of their contents.
+ */
+const COLUMN_WIDTH = {
+  name: '280px',
+  type: '180px',
+} as const;
 
 /**
  * The Places section page — the full-width table of every place in the
@@ -21,13 +39,49 @@ export function PlacesPage({ treeId }: PlacesPageProps): JSX.Element {
   const { t: tCommon } = useTranslation('common');
   const navigate = useNavigate();
   const { data, isLoading, isError } = usePlaces();
+  const { data: placeTypes } = usePlaceTypes();
 
-  const rows = useMemo(() => (data ? sortByKey(data, (place) => place.name) : []), [data]);
+  const [filters, setFilters] = useState(DEFAULT_PLACE_FILTERS);
+  const debouncedName = useDebouncedValue(filters.name, 200);
 
+  // The place name keyed by id, for resolving the Parent column.
   const nameById = useMemo<Map<string, string>>(
     () => (data ? new Map(data.map((place) => [place.id, place.name])) : new Map()),
     [data]
   );
+
+  // The place-type label keyed by type id, for the Type column and select.
+  const typeLabelById = useMemo<Map<string, string>>(
+    () => new Map((placeTypes ?? []).map((type) => [type.id, placeTypeLabel(type)])),
+    [placeTypes]
+  );
+
+  // The Type filter offers every place type present in the tree, by label.
+  const typeOptions = useMemo<PlaceTypeOption[]>(
+    () =>
+      (placeTypes ?? [])
+        .map((type) => ({ value: type.id, label: placeTypeLabel(type) }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [placeTypes]
+  );
+
+  // Filter the already-loaded list client-side: name search (name + full
+  // name) and place type (both AND-ed). Ordering is handled by the table
+  // (sortable headers); see `defaultSort`.
+  const visibleRows = useMemo(() => {
+    const query = debouncedName.trim().toLowerCase();
+    return (data ?? []).filter((place) => {
+      if (filters.type !== 'all' && place.placeTypeId !== filters.type) return false;
+      if (
+        query &&
+        !place.name.toLowerCase().includes(query) &&
+        !place.fullName.toLowerCase().includes(query)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [data, filters.type, debouncedName]);
 
   const columns = useMemo<EntityTableColumn<Place>[]>(
     () => [
@@ -35,38 +89,82 @@ export function PlacesPage({ treeId }: PlacesPageProps): JSX.Element {
         key: 'name',
         header: t('table.columns.name'),
         rowHeader: true,
+        width: COLUMN_WIDTH.name,
+        // A keyboard-focusable link (styled as plain text — no color/underline)
+        // so the list is navigable without a pointer; the whole row is also
+        // clickable via `onRowClick`, so the link stops propagation.
         cell: (place) => (
-          <Link asChild onClick={(event) => event.stopPropagation()}>
+          <Link
+            asChild
+            color="gray"
+            highContrast
+            underline="none"
+            onClick={(domEvent) => domEvent.stopPropagation()}
+          >
             <RouterLink to="/tree/$treeId/place/$placeId" params={{ treeId, placeId: place.id }}>
               {place.name}
             </RouterLink>
           </Link>
         ),
+        sortValue: (place) => place.name || null,
+      },
+      {
+        key: 'type',
+        header: t('table.columns.type'),
+        width: COLUMN_WIDTH.type,
+        cell: (place) =>
+          place.placeTypeId !== null ? (typeLabelById.get(place.placeTypeId) ?? '—') : '—',
+        sortValue: (place) =>
+          place.placeTypeId !== null ? (typeLabelById.get(place.placeTypeId) ?? null) : null,
       },
       {
         key: 'parent',
         header: t('table.columns.parent'),
         cell: (place) => (place.parentId !== null ? (nameById.get(place.parentId) ?? '—') : '—'),
+        sortValue: (place) =>
+          place.parentId !== null ? (nameById.get(place.parentId) ?? null) : null,
       },
     ],
-    [t, treeId, nameById]
+    [t, treeId, nameById, typeLabelById]
   );
 
   return (
     <Box p="4">
-      <EntityTable
-        label={tCommon('nav.places')}
-        columns={columns}
-        rows={rows}
-        getRowKey={(place) => place.id}
-        onRowClick={(place) =>
-          navigate({ to: '/tree/$treeId/place/$placeId', params: { treeId, placeId: place.id } })
-        }
-        isLoading={isLoading}
-        isError={isError}
-        errorMessage={tCommon('errors.loadFailed')}
-        emptyMessage={t('table.empty')}
-      />
+      <Flex direction="column" gap="4">
+        <Flex align="center" justify="between" pt="2" pb="3">
+          <Flex align="center" gap="3">
+            <Icon name="map-pin" size={28} />
+            <Heading size="7" trim="both">
+              {tCommon('nav.places')}
+            </Heading>
+          </Flex>
+          <Button disabled>
+            <Icon name="plus" />
+            {t('page.addPlace')}
+          </Button>
+        </Flex>
+
+        <Grid columns="280px 1fr" gap="4" align="start">
+          <PlacesFilters value={filters} onChange={setFilters} types={typeOptions} />
+          <EntityTable
+            label={tCommon('nav.places')}
+            columns={columns}
+            rows={visibleRows}
+            getRowKey={(place) => place.id}
+            onRowClick={(place) =>
+              navigate({
+                to: '/tree/$treeId/place/$placeId',
+                params: { treeId, placeId: place.id },
+              })
+            }
+            isLoading={isLoading}
+            isError={isError}
+            errorMessage={tCommon('errors.loadFailed')}
+            emptyMessage={hasActiveFilters(filters) ? t('table.noMatches') : t('table.empty')}
+            defaultSort={{ columnKey: 'name', direction: 'asc' }}
+          />
+        </Grid>
+      </Flex>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

Brings the **Events** and **Places** list pages up to the same UX as the People (#180) and Families (#181) pages: a page header (icon + heading + disabled Add button), a two-pane layout with a filter `Card`, and sortable `EntityTable` columns with gray plain-text row links.

### Events
- Header with `calendar` icon + disabled **Add event** button.
- Filter card with **Type** and **Place** dropdowns, both built dynamically from the values present in the loaded events (no text search, by design).
- Columns: **Type** (row-header link, sortable) · **Date** (not sortable) · **Principals** (sortable) · **Place** (sortable).
- Date intentionally stays unsorted so the manager's chronological order is preserved.

### Places
- Header with `map-pin` icon + disabled **Add place** button.
- Filter card with a **name/full-name** search (debounced) and a **Type** select.
- New **Type** column; columns **Name / Type / Parent** all sortable, default Name ascending.
- Adds a `usePlaceTypes` hook (over the reserved `queryKeys.placeTypes`) and a `placeTypeLabel` helper (`customName ?? tag`) — place types are unseeded and untranslated.

### Out of scope
No new DB queries beyond loading place types, no `getAll` signature changes, no create flows.

## Test plan
- `pnpm build` (tsc + vite) — passes
- `pnpm lint` — clean
- `pnpm vitest run src/db/trees/places.test.ts` — 55 passing
- Pre-PR `/simplify` (4 agents) and `/code-review` (high effort) run; only low-severity cosmetic notes, no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)