### PR TITLE
fix(tree): clear query cache on tree close to prevent stale data

### DIFF
--- a/src/routes/tree/$treeId.tsx
+++ b/src/routes/tree/$treeId.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Outlet, useNavigate } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
@@ -19,6 +19,7 @@ export const Route = createFileRoute('/tree/$treeId')({
     const { t } = useTranslation(['common', 'trees']);
     const { treeId } = Route.useParams();
     const navigate = useNavigate();
+    const queryClient = useQueryClient();
     const [dbReady, setDbReady] = useState(false);
     const [dbError, setDbError] = useState(false);
     const [debugOpen, setDebugOpen] = useState(false);
@@ -71,11 +72,16 @@ export const Route = createFileRoute('/tree/$treeId')({
       };
     }, [tree]);
 
+    // Entity query keys (individuals, families, events, places, …) are not
+    // tree-scoped, so the cache from one tree would be served for the next.
+    // Vata is single-tree-at-a-time: when the open tree closes, its cached
+    // data is void — clear it so the next tree fetches fresh.
     useEffect(() => {
       return () => {
         void closeTreeDb();
+        queryClient.clear();
       };
-    }, []);
+    }, [queryClient]);
 
     useEffect(() => {
       let unlisten: UnlistenFn | undefined;


### PR DESCRIPTION
## Problem

Opening a second tree showed the **first tree's data**:

1. Open tree A → data correct
2. Close tree A
3. Open tree B → data shown is the same as tree A

## Root cause

The DB connection switching (`openTreeDb`/`closeTreeDb`) was correct. The bug was in the **TanStack Query cache**: entity query keys in `src/lib/query-keys.ts` (`['individuals']`, `['families']`, `['events']`, `['places']`, …) are **global, not tree-scoped**. Closing a tree left the cache intact, so opening another tree served the previous tree's cached rows.

## Fix

Vata is single-tree-at-a-time, so the open tree's cache is void once that tree closes. Clear the query cache on tree-shell unmount, alongside the existing `closeTreeDb()` call in `src/routes/tree/$treeId.tsx`.

The alternative — tree-scoping every entity query key — was considered but rejected: it touches ~12 hooks plus every mutation's invalidation and buys little for a single-tree app.

## Testing

- Build ✅ and lint ✅ pass.
- Manually verified the reported repro (open A → close → open B) now shows tree B's data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)