### PR TITLE
refactor(gedcom): store PLAC verbatim without splitting on import

### DIFF
--- a/docs/references/gedcom-551-mapping.md
+++ b/docs/references/gedcom-551-mapping.md
@@ -47,9 +47,11 @@ This document describes the correspondence between GEDCOM 5.5.1 structures and t
 | BIRT       | events         | -               | event_type_id = BIRT           |
 | DEAT       | events         | -               | event_type_id = DEAT           |
 | DATE       | events         | date_original   | Original text                  |
-| PLAC       | places, events | place_id        | Creates place if needed        |
+| PLAC       | places, events | place_id        | Stored verbatim (see below)    |
 | FAMC       | family_members | -               | role = 'child'                 |
 | FAMS       | family_members | -               | role = 'husband' or 'wife'     |
+
+> **PLAC handling:** the `PLAC` value is stored verbatim as both `places.name` and `places.full_name`; import does **not** decompose it into a hierarchy (`parent_id` stays null). Places are deduplicated on `full_name`. Splitting a place into a parent chain or deriving a shorter display name is left to in-app editing tools.
 
 ### FAM (Family)
 

--- a/src/lib/gedcom/importer.ts
+++ b/src/lib/gedcom/importer.ts
@@ -382,12 +382,10 @@ async function getOrCreatePlace(fullName: string, ctx: ImportContext): Promise<s
     return id;
   }
 
-  // Create new place
-  const parts = fullName.split(',').map((p) => p.trim());
-  const name = parts[0] || fullName;
-
+  // Create new place. The PLAC value is stored verbatim as both name and
+  // full_name — no hierarchy decomposition happens on import.
   const result = await db.execute('INSERT INTO places (name, full_name) VALUES ($1, $2)', [
-    name,
+    fullName,
     fullName,
   ]);
   if (result.lastInsertId === undefined) {


### PR DESCRIPTION
## What

GEDCOM import no longer splits the `PLAC` value to derive a place name. The full place string is now stored verbatim in both `places.name` and `places.full_name`.

Before: `name` = first comma segment (`"Montréal"`), `full_name` = whole string (`"Montréal, Québec, Canada"`).
After: `name` = `full_name` = the whole string.

## Why

The first-segment heuristic produced a misleading short label and never reflected the "hierarchical" Place concept (the importer never built a `parent_id` chain anyway). Storing the value verbatim is honest; splitting into a hierarchy and deriving shorter display names will be handled by dedicated in-app tools later.

## Scope / impact

- Isolated to `getOrCreatePlace` in `src/lib/gedcom/importer.ts`.
- Export is unaffected — it already sources `PLAC` from `full_name`.
- Dedup behavior unchanged (still keyed on `full_name`).
- Place columns in the Events / Individuals / Places tables now show the full path until shortening tooling lands (expected).
- Doc note added to `gedcom-551-mapping.md`; glossary untouched (Place is still conceptually hierarchical).

No migration needed (pre-alpha, no users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)