### PR TITLE
docs(skills): fix stale references and simplify skills to source-of-truth pointers

### DIFF
--- a/.claude/skills/design-system-standards/SKILL.md
+++ b/.claude/skills/design-system-standards/SKILL.md
@@ -5,7 +5,7 @@ description: Conventions for vata-app's UI — when to reuse a Radix Themes comp
 
 # Design System Standards — Vata
 
-Vata's UI is **Radix Themes** (`@radix-ui/themes`), consumed directly at call sites. ADR-007 removed the in-house wrapper layer (`src/components/ui/`); this skill keeps it removed.
+Vata's UI is **Radix Themes** (`@radix-ui/themes`), consumed directly at call sites — no `src/components/ui/` wrapper layer. Current source of truth: [ADR-010](../../docs/adr/0010-pure-radix-themes.md) (pure Radix Themes — no brand overrides, no custom CSS). ADR-007 is the earlier decision it supersedes in part.
 
 ## Decision tree
 
@@ -14,17 +14,19 @@ For any UI element, take the first step that fits:
 1. **Reuse a Radix Themes component** — the default. Import it directly and pick its `variant` / `size` / `color` props.
 2. **Compose Radix Themes inline** — when the need is a layout of known components (a header is `Avatar` + `Heading` + a `Button` row in a `Flex`). Build it in the page, no new file. Layout uses Radix primitives (`Flex`, `Grid`, `Box`) and spacing props.
 3. **Add an internal application organism** in `src/components/` — only for a component used across the app that composes Radix Themes and adds applicative behaviour (the tree shell, navigation, a dropzone). Never a restyled atom or molecule: reaching for a "styled Button" means stop and use Radix's. A new organism ships in the same commit with JSDoc and a colocated `*.test.tsx`.
-4. **Bespoke surface, scoped local CSS** — rare; only when Radix Themes covers nothing for the need (e.g. a pedigree graph). Document why in JSDoc.
 
-## Customization is token-level only
+There is **no custom-CSS escape hatch**: ADR-010 bans scoped local CSS. If Radix Themes genuinely covers nothing (e.g. a pedigree graph), that is an ADR-010 amendment — raise it, don't add a `.css` file.
 
-Brand tokens (`accentColor`, `grayColor`, `radius`, scaling) live on the single `<Theme>` provider. Component anatomy — heights, padding, density — is Radix's, never tuned per component.
+## No brand overrides, no custom CSS (ADR-010)
 
-Reject in review:
+The single `<Theme>` provider (`src/components/app-theme.tsx`) sets **only `appearance`** (light/dark). No `accentColor` / `grayColor` / `radius` / scaling overrides — everything falls to Radix defaults. Component anatomy — heights, padding, density — is Radix's, never tuned per component.
 
-- Hardcoded colour literals (`oklch()`, hex, `rgb()`) — colour comes from the Radix accent/gray scales and the `color` prop.
-- CSS-framework leftovers (`tailwind`, `tv(`, stray `className` on a non-Radix element) — removed by ADR-007.
-- Per-component theme overrides — appearance is set once at the provider.
+Reject in review (these are grep-gated by ADR-010):
+
+- Hardcoded colour literals (`oklch()`, hex, `rgb()`) — colour comes from the Radix accent/gray scales via the `color` prop.
+- Inline `style={{}}` escapes and raw `var(--…)` token references.
+- New `.css` files — only `src/styles/app.css` exists; adding CSS needs an ADR-010 amendment.
+- CSS-framework leftovers (`tailwind`, `tv(`, stray `className` on a non-Radix element).
 
 ## Duplication
 

--- a/.claude/skills/design-system-standards/SKILL.md
+++ b/.claude/skills/design-system-standards/SKILL.md
@@ -5,7 +5,7 @@ description: Conventions for vata-app's UI — when to reuse a Radix Themes comp
 
 # Design System Standards — Vata
 
-Vata's UI is **Radix Themes** (`@radix-ui/themes`), consumed directly at call sites — no `src/components/ui/` wrapper layer. Current source of truth: [ADR-010](../../docs/adr/0010-pure-radix-themes.md) (pure Radix Themes — no brand overrides, no custom CSS). ADR-007 is the earlier decision it supersedes in part.
+Vata's UI is **Radix Themes** (`@radix-ui/themes`), consumed directly at call sites — no `src/components/ui/` wrapper layer. Current source of truth: [ADR-010](../../../docs/adr/0010-pure-radix-themes.md) (pure Radix Themes — no brand overrides, no custom CSS). ADR-007 is the earlier decision it supersedes in part.
 
 ## Decision tree
 

--- a/.claude/skills/gedcom-standards/SKILL.md
+++ b/.claude/skills/gedcom-standards/SKILL.md
@@ -16,10 +16,14 @@ Apply this skill when writing or reviewing any GEDCOM-related code or documentat
 
 ---
 
-## 1. External Libraries
+## 1. Parsing & Date Libraries
 
-- **`gedcom-parser`**: All parsing, serialization, and validation. Check `package.json` for the current package. Never write custom GEDCOM parsing logic.
-- **`gedcom-date`**: All date parsing, formatting, and sort-date generation. Check `package.json` for the current package. Never write custom GEDCOM date parsing.
+Two **in-app modules** own all GEDCOM parsing and date logic — never write custom parsing or date handling:
+
+- **`@vata-apps/gedcom-parser`** (`src/gedcom-parser/`): parsing, serialization, validation, BOM stripping, CONC/CONT continuation, and name-part splitting (given/surname/prefix/suffix).
+- **`@vata-apps/gedcom-date`** (`src/gedcom-date/`): date parsing, formatting, sort-date generation.
+
+These are local source resolved via path alias (see [ADR-004](../../docs/adr/0004-gedcom-libraries.md)), **not** npm packages — don't look for them in `package.json`.
 
 ---
 
@@ -48,6 +52,7 @@ Never import families before all individuals are created.
 
 - Maintain a `placeCache: Map<string, string>` to avoid creating duplicate places
 - Check cache first, then database, then create a new place
+- Store the `PLAC` value **verbatim** as both `name` and `full_name` with `parent_id` null — no hierarchy split on import; dedupe on `full_name`
 
 ### Error Reporting
 
@@ -166,10 +171,8 @@ For a concise review checklist, see [checklist.md](checklist.md).
 
 ## 10. Common Mistakes to Avoid
 
-- **Strip BOM (`\uFEFF`) before any string checks on GEDCOM content**: Files from Windows editors often include a UTF-8 BOM. Strip it before checking `isGedcom()` or validating.
-- **Parse name suffix separately from given names**: The suffix after `/SURNAME/` (e.g., "Jr.") must be returned as a separate field, not appended to `givenNames`.
-- **Support ALL GEDCOM 5.5.1 individual event and attribute tags**: See §5 for the complete list. Missing tags cause silent data loss on import.
 - **Skip families with zero linked members in privacy export**: When `includePrivate` is false, families whose members are all excluded (living) must be skipped entirely.
+- **Don't re-implement parser concerns in import code**: BOM stripping, CONC/CONT, and name-part splitting all live in `@vata-apps/gedcom-parser` (§1) — consume its output, never redo it.
 
 ---
 

--- a/.claude/skills/gedcom-standards/SKILL.md
+++ b/.claude/skills/gedcom-standards/SKILL.md
@@ -23,7 +23,7 @@ Two **in-app modules** own all GEDCOM parsing and date logic — never write cus
 - **`@vata-apps/gedcom-parser`** (`src/gedcom-parser/`): parsing, serialization, validation, BOM stripping, CONC/CONT continuation, and name-part splitting (given/surname/prefix/suffix).
 - **`@vata-apps/gedcom-date`** (`src/gedcom-date/`): date parsing, formatting, sort-date generation.
 
-These are local source resolved via path alias (see [ADR-004](../../docs/adr/0004-gedcom-libraries.md)), **not** npm packages — don't look for them in `package.json`.
+These are local source resolved via path alias (see [ADR-004](../../../docs/adr/0004-gedcom-libraries.md)), **not** npm packages — don't look for them in `package.json`.
 
 ---
 
@@ -176,4 +176,4 @@ For a concise review checklist, see [checklist.md](checklist.md).
 
 ---
 
-For the full GEDCOM-to-Vata mapping, see [docs/references/gedcom-551-mapping.md](../../docs/references/gedcom-551-mapping.md).
+For the full GEDCOM-to-Vata mapping, see [docs/references/gedcom-551-mapping.md](../../../docs/references/gedcom-551-mapping.md).

--- a/.claude/skills/gedcom-standards/checklist.md
+++ b/.claude/skills/gedcom-standards/checklist.md
@@ -5,8 +5,8 @@ Use this checklist when reviewing GEDCOM-related code or documentation.
 ## General
 
 - [ ] GEDCOM version is 5.5.1 only
-- [ ] Parsing done via `gedcom-parser` (no custom parsing)
-- [ ] Date parsing done via `gedcom-date` (no custom date logic)
+- [ ] Parsing done via `@vata-apps/gedcom-parser` (no custom parsing)
+- [ ] Date parsing done via `@vata-apps/gedcom-date` (no custom date logic)
 
 ## Import
 
@@ -31,8 +31,7 @@ Use this checklist when reviewing GEDCOM-related code or documentation.
 
 - [ ] Gender values: `M`, `F`, or `U` only
 - [ ] Family member roles: `husband`, `wife`, `child` only
-- [ ] Name tags mapped correctly (GIVN, SURN, NPFX, NSFX, NICK, TYPE, SPFX)
-- [ ] SPFX merged into surname field
+- [ ] Name tags (GIVN, SURN, NPFX, NSFX, NICK, TYPE, SPFX) mapped per the gedcom-551-mapping doc
 
 ## Event Types
 

--- a/.claude/skills/link-task/SKILL.md
+++ b/.claude/skills/link-task/SKILL.md
@@ -48,7 +48,7 @@ gh api graphql -f query='
 
 Substitute `<query>` with each search term. Stop once you have 5–10 candidates across all queries — don't enumerate the entire backlog. Repo (`vata-apps/vata-app`) is hardcoded for this project; that's fine because this skill lives in the Vata repo.
 
-If the GraphQL call fails with an auth error, surface it and tell the user to run `gh auth refresh -s read:org`.
+If the GraphQL call fails with an auth error, surface it and tell the user to run `gh auth refresh -s read:org,project` (the "create new" path delegates to `capture-idea`, which needs `project`).
 
 ### 3. Present candidates
 
@@ -80,7 +80,7 @@ Tell the user in one sentence which issue is linked, e.g. _"Linked to #42 — wi
 
 ## Phase B — Inject the magic word (PR creation)
 
-Run this whenever you're about to call `gh pr create` (directly, via `/commit-push-pr`, or any other path).
+Run this whenever you're about to call `gh pr create` (directly, via `/commit-push-pr`, or any other path) — **after** the mandatory Pre-PR Review (`/simplify` + `/review`) that CLAUDE.md requires, immediately before the PR is opened.
 
 ### 1. Read the link
 

--- a/.claude/skills/new-route/SKILL.md
+++ b/.claude/skills/new-route/SKILL.md
@@ -39,114 +39,33 @@ For nested routes with a dynamic ID (e.g., `/tree/$treeId/entity/$entityId`):
 
 ## 2. Page Component
 
-Location: `src/pages/<Entity>Page.tsx`
+Location: `src/pages/<Entity>Page.tsx`. **Copy the shape of an existing page** — `src/pages/IndividualsPage.tsx` is the canonical example. Invariants:
 
-```typescript
-import React, { useRef, useState } from 'react';
-import { Link } from '@tanstack/react-router';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from '$/lib/query-keys';
-
-interface EntityPageProps {
-  treeId: string;
-}
-
-export function EntityPage({ treeId }: EntityPageProps): JSX.Element {
-  const [modalOpen, setModalOpen] = useState(false);
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const queryClient = useQueryClient();
-
-  // React Query hooks for data
-  // const { data, isLoading, isError } = useEntities();
-
-  // Mutation for create/update/delete
-  // const { mutate, isPending } = useMutation({ ... });
-
-  return (
-    <div>
-      <h2>Entities</h2>
-      {/* List, search, create button */}
-    </div>
-  );
-}
-```
+- Receives `{ treeId }` (list page) or `{ treeId, entityId }` (detail page); returns `JSX.Element`.
+- Built from Radix Themes primitives (`Box`, `Flex`, `Heading`, `Button`, …) — never raw HTML tags for layout.
+- All user-facing text via `useTranslation()` — never hardcode strings (project i18n rule).
+- Data via TanStack Query hooks in `src/hooks/use<Entity>.ts`; handle `isLoading` / `isError`.
 
 ## 3. Conventions
 
-### Imports — Use path aliases
+Path aliases, the query-key factory, `staleTime`, and naming are cross-cutting rules owned by [typescript-standards](../typescript-standards/SKILL.md) — follow it (the checklist below chains to it). Route/page-specific notes only:
 
-```typescript
-import { something } from '$/pages/SomePage'; // src/pages/
-import { useHook } from '$hooks/useHook'; // src/hooks/
-import { dbFunction } from '$db-tree/entity'; // src/db/trees/
-import { queryKeys } from '$/lib/query-keys'; // src/lib/
-import type { Entity } from '$types'; // src/types/
-```
+### Modal dialogs (create/edit forms)
 
-### React Query pattern
+Modals are standalone organism components in `src/components/trees/` (e.g. `new-tree-modal.tsx`), built on Radix Themes **`Dialog`** (`Dialog.Root` / `Dialog.Content` / `Dialog.Title`) — which provides focus trap, Escape handling, and ARIA out of the box. The page composes one via `open` / `onOpenChange` props. **Never hand-roll** `role="dialog"`, Escape listeners, or focus management.
 
-- Use `queryKeys` factory from `$/lib/query-keys` (add entries if needed)
-- Invalidate queries on mutation success: `queryClient.invalidateQueries({ queryKey: queryKeys.entities })`
-- Custom hooks go in `src/hooks/use<Entity>.ts`
+### Error handling
 
-### Modal dialogs (required for create/edit forms)
-
-Every modal **must** have:
-
-- `role="dialog"`
-- `aria-modal="true"`
-- `aria-labelledby` pointing to a heading inside the dialog
-- Escape key handler to close
-- Focus management (auto-focus first input on open)
-
-```typescript
-useEffect(() => {
-  if (modalOpen) {
-    titleInputRef.current?.focus();
-  }
-}, [modalOpen]);
-
-useEffect(() => {
-  function handleEscape(e: KeyboardEvent) {
-    if (e.key === 'Escape') setModalOpen(false);
-  }
-  if (modalOpen) document.addEventListener('keydown', handleEscape);
-  return () => document.removeEventListener('keydown', handleEscape);
-}, [modalOpen]);
-```
-
-### React lists
-
-When returning a Fragment from `.map()`, always use `<React.Fragment key={...}>`, never `<>`.
-
-### Error handling pattern
-
-```typescript
-const { mutate, isPending } = useMutation({
-  mutationFn: (input: CreateEntityInput) => createEntity(input),
-  onSuccess: () => {
-    void queryClient.invalidateQueries({ queryKey: queryKeys.entities });
-    setModalOpen(false);
-    setForm(EMPTY_FORM);
-    setSubmitError(null);
-  },
-  onError: (err: unknown) => {
-    const message = err instanceof Error ? err.message : 'An unexpected error occurred.';
-    setSubmitError(message);
-  },
-});
-```
+Surface `isError` from queries in the UI, and show mutation errors via an i18n message (never a hardcoded English string). See `IndividualsPage.tsx` for the pattern.
 
 ## Checklist
 
 Before finishing:
 
 - [ ] Route file uses `createFileRoute()` with correct path
-- [ ] Page component receives `treeId` prop
+- [ ] Page component receives `treeId` (and `entityId` for detail views)
 - [ ] `routeTree.gen.ts` was NOT edited
-- [ ] Path aliases used (not relative paths from outside `src/db/`)
-- [ ] Modal has `role="dialog"`, `aria-modal`, `aria-labelledby`, Escape handler
-- [ ] `.map()` uses `<React.Fragment key={}>` not `<>`
+- [ ] Page uses Radix Themes primitives + `useTranslation()` (no raw HTML layout, no hardcoded strings)
+- [ ] Modal is a Radix `Dialog` organism composed via `open` / `onOpenChange` (no hand-rolled a11y)
 - [ ] Query key added to `$/lib/query-keys` if new entity
-- [ ] Debug UI guarded with `import.meta.env.DEV`
 - [ ] Also apply the [typescript-standards](../typescript-standards/SKILL.md) checklist

--- a/.claude/skills/sqlite-standards/SKILL.md
+++ b/.claude/skills/sqlite-standards/SKILL.md
@@ -119,7 +119,7 @@ When creating a new entity's database layer in `src/db/trees/`, follow this stru
 ```typescript
 import { getTreeDb } from '../connection';
 import { formatEntityId, parseEntityId } from '$/lib/entityId';
-import type { Entity, CreateEntityInput, UpdateEntityInput } from '$/types/database';
+import type { Entity, CreateEntityInput, UpdateEntityInput } from '$types/database';
 ```
 
 **2. Raw type** (snake_case, matching DB columns)

--- a/.claude/skills/tauri-standards/SKILL.md
+++ b/.claude/skills/tauri-standards/SKILL.md
@@ -27,6 +27,8 @@ Check these files for the canonical source of truth:
 
 The Rust backend is **intentionally thin**. It serves as a bridge for native capabilities only. Business logic belongs in the TypeScript layer (`src/`), not in Rust.
 
+The standing exceptions already in `lib.rs` are the native app menu (`build_app_menu`) and its React-shell coupling (the `set_close_tree_enabled` command + emitted menu events). When touching the menu, keep the Rust builder and the React mount-time sync in step.
+
 ---
 
 ## 2. Tauri v2 Capabilities
@@ -35,21 +37,9 @@ Capabilities are defined in `src-tauri/capabilities/`. Each capability file gran
 
 - **Principle of least privilege**: Only grant the permissions actually needed.
 - **Format**: JSON files in `src-tauri/capabilities/`. Each file has `identifier`, `windows`, and `permissions` fields.
-- **Scoping**: Use `allow-*` permissions for specific operations, not blanket `allow-all`.
+- **Scoping**: grant specific `allow-*` permissions, never blanket `allow-all`.
 
-```json
-// ✅ GOOD — scoped permissions
-{
-  "identifier": "main-window",
-  "windows": ["main"],
-  "permissions": [
-    "sql:allow-execute",
-    "sql:allow-select",
-    "fs:allow-read-text-file",
-    "dialog:allow-open"
-  ]
-}
-```
+The project has a **single** capability file — `src-tauri/capabilities/default.json`. Read it for the canonical, current permission set rather than trusting an inline example here (an example drifts; the file does not).
 
 ---
 
@@ -109,6 +99,6 @@ try {
 
 ## 7. Common Mistakes to Avoid
 
-- **Never grant `$HOME/**` filesystem scope**: This gives the app access to the entire home directory. Only scope to `$APPDATA`, `$DOCUMENT`, and `$DOWNLOAD` as needed.
-- **Only request permissions for plugins actively imported in source code**: If a plugin (e.g., `store`) is registered in `lib.rs` but never imported in TypeScript, remove its permissions from capabilities.
+- **Never grant whole-home filesystem scope** (`$HOME` and below): scope only to `$APPDATA`, `$DOCUMENT`, and `$DOWNLOAD` as needed.
+- **Only request permissions for plugins actually used from TypeScript**: e.g. `tauri_plugin_store` is registered in `lib.rs` but has no TS import today — a real cleanup candidate. Drop unused plugins' permissions (and ideally the registration itself).
 - **Audit permissions when removing features**: If you remove code that used a plugin, also remove the corresponding capability permissions.

--- a/.claude/skills/testing-standards/SKILL.md
+++ b/.claude/skills/testing-standards/SKILL.md
@@ -11,7 +11,7 @@ This skill says **what to test and why** — not how to write a test.
 
 A test earns its place by catching a real regression. There are **no coverage thresholds**: 20 tests that catch bugs beat 100 that break on every refactor.
 
-Test **observable behavior, not implementation**. The check: if the implementation is rewritten but the behavior is unchanged, the test must still pass. Asserting on SQL strings, mock call counts, CSS classes, `data-testid`, or rendered HTML fails that check — it tests the wrong thing.
+Test **observable behavior, not implementation**. The check: if the implementation is rewritten but the behavior is unchanged, the test must still pass. Asserting on SQL strings, CSS classes, `data-testid`, or rendered HTML fails that check — it tests the wrong thing.
 
 ## TDD
 
@@ -19,14 +19,14 @@ Tests are written **before** the implementation and committed with it (red → g
 
 ## What to test, per layer
 
-| Layer               | What to test                                                                          | Approach                                                         |
-| ------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `src/db/**`         | Every public CRUD function — input/output behavior                                    | Integration test against real in-memory SQLite, never mocked SQL |
-| `src/managers/**`   | Orchestration and end-to-end workflows                                                | Integration test, in-memory SQLite                               |
-| `src/components/**` | **Application organism** behavior — interactions, conditional rendering, error states | Vitest + React Testing Library (jsdom)                           |
-| `src/hooks/**`      | Data flow and state transitions                                                       | Vitest + RTL                                                     |
-| `src/lib/**`        | Pure logic, edge cases, round-trips                                                   | Unit test, no mocks                                              |
-| `src-tauri/src/**`  | Non-trivial command logic, data mapping, Rust-owned DB queries                        | Rust `#[cfg(test)]`, in-memory SQLite via `rusqlite`             |
+| Layer               | What to test                                                                          | Approach                                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `src/db/**`         | Every public CRUD function — input/output behavior                                    | Integration test via `createInMemoryDb` / `createTreeInMemoryDb` (`$/test/sqlite-memory`), never mocked SQL |
+| `src/managers/**`   | Orchestration and end-to-end workflows                                                | Integration test, in-memory SQLite                                                                          |
+| `src/components/**` | **Application organism** behavior — interactions, conditional rendering, error states | Vitest + React Testing Library (jsdom)                                                                      |
+| `src/hooks/**`      | Data flow and state transitions                                                       | Vitest + RTL; mock the DB-access boundary and assert the hook calls it correctly                            |
+| `src/lib/**`        | Pure logic, edge cases, round-trips                                                   | Unit test, no mocks                                                                                         |
+| `src-tauri/src/**`  | Non-trivial command logic / data mapping — **none yet** (the backend is thin)         | Rust `#[cfg(test)]` unit tests, when logic earns it                                                         |
 
 Co-locate every test with its source. `describe` names the feature; `it` states what the caller observes in plain English (no "should", English only).
 
@@ -40,7 +40,7 @@ Co-locate every test with its source. `describe` names the feature; `it` states 
 
 ## Correctness invariant
 
-In-memory test databases do **not** inherit PRAGMAs. Every test DB must run `PRAGMA foreign_keys = ON` before the schema, or constraint violations silently pass in tests and fail in production.
+Test DBs must enforce foreign keys, or constraint violations silently pass in tests and fail in production. You get this **for free** by going through `createInMemoryDb` / `createTreeInMemoryDb` (`src/test/sqlite-memory.ts`), which apply `PRAGMA foreign_keys = ON` — never instantiate a raw in-memory DB yourself.
 
 ## E2E
 

--- a/.claude/skills/typescript-standards/SKILL.md
+++ b/.claude/skills/typescript-standards/SKILL.md
@@ -114,6 +114,4 @@ const store = useAppStore();
 - **Use union types for entity ID prefixes**: Use `EntityPrefix` (`'I' | 'F' | 'E' | 'P' | 'S' | 'R'`) from `src/lib/entityId.ts`, not bare `string`.
 - **Wrap `navigator.clipboard` calls in try/catch**: The Clipboard API may not be available in all contexts (e.g., non-secure origins, Tauri webview restrictions).
 - **Async `useEffect` must use a mounted flag or `AbortController`**: Prevent state updates after unmount by checking a `mounted` flag before calling `setState`.
-- **No unused hooks/exports for future features**: Do not pre-create mutation hooks, utilities, or components that nothing imports yet. Add them when they're needed.
-- **React Fragment keys in `.map()`**: When returning a Fragment from `.map()`, always use `<React.Fragment key={...}>`, never bare `<>`. The key must be on the outermost element.
-- **Guard debug UI**: Wrap debug-only sections with `{import.meta.env.DEV && (...)}` so they are tree-shaken in production builds.
+- **Shared pitfalls live in CLAUDE.md**: the React.Fragment `key` rule, the `import.meta.env.DEV` debug-UI guard, and the no-unused-exports rule are in CLAUDE.md "Common Pitfalls" — not repeated here.


### PR DESCRIPTION
## Why

An audit of the 9 project skills under `.claude/skills/` found drift: skills had embedded concrete copies (capability examples, page templates, library names, modal code, IDs) that diverged from the real code. Copies drift; the source of truth doesn't. This rewrites the drifted parts as **pointers to the source of truth** and dedupes rules already covered by `CLAUDE.md`.

Every pointer added was verified to resolve against the current repo (ADRs, files, exported symbols, aliases).

## Changes

- **gedcom-standards** — `@vata-apps/gedcom-{parser,date}` are in-app modules (`src/gedcom-parser/`, `src/gedcom-date/`, ADR-004), not npm packages; drop the stale BOM/suffix "common mistakes" the parser already owns; add the PLAC-verbatim storage rule.
- **design-system-standards** — align theming with ADR-010 (only `appearance` on `<Theme>`, no brand overrides, no custom CSS); drop the scoped-CSS escape hatch.
- **new-route** — page template → pointer at `IndividualsPage.tsx`; modals are Radix `Dialog` organisms, not hand-rolled a11y; remove the hardcoded English error string; defer cross-cutting TS rules to `typescript-standards` (removed a duplicated alias example that also contained a broken `$types` import).
- **tauri-standards** — capability example → pointer at the single `default.json`; note the menu/IPC coupling and the registered-but-unused `store` plugin.
- **testing-standards** — drop the fictional Rust/`rusqlite` row; name the real in-memory DB helpers; carve out the hook boundary-mock pattern.
- **sqlite-standards** — fix the `$types/database` alias.
- **typescript-standards** — defer the React.Fragment / DEV-guard / no-unused-exports pitfalls to `CLAUDE.md`.
- **link-task** — note the Pre-PR Review gate before `gh pr create`; align the auth-scope hint with the `capture-idea` delegation.

Net: **+56 / −145** lines. Pure documentation; no code or behavior change.

## Verification

- All new file/symbol/ADR/alias pointers confirmed to resolve against the repo.
- `/simplify` (reuse/dedup pass) applied — collapsed `new-route` §3 duplication.
- `/code-review` (correctness) — clean (docs-only).
- Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vata-apps/vata-app/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

