### PR TITLE
feat(individual): rebuild Person editor on Base UI + Vanilla Extract (ADR-0014)

### DIFF
--- a/.githooks/sql-guard.sh
+++ b/.githooks/sql-guard.sh
@@ -5,30 +5,33 @@
 # no -P, so -P patterns silently never match.
 #
 # Usage: sql-guard.sh <file> [<file> ...]
-# Reads each file path from disk (staged content can be fetched via
-# `git show :<file>` when called from pre-commit for staged versions).
+# Reads staged content via `git show :<file>` (what will actually be
+# committed), falling back to the worktree copy for unstaged paths.
 
 ERRORS=""
 WARNINGS=""
 
 for FILE_PATH in "$@"; do
   [ -z "$FILE_PATH" ] && continue
-  [ -f "$FILE_PATH" ] || continue
+
+  # Read staged content (what will actually be committed); fall back to the
+  # worktree copy for unstaged-but-tracked paths. Checking the staged blob
+  # first means a file deleted from the worktree after staging is still
+  # validated.
+  CONTENT=$(git show :"$FILE_PATH" 2>/dev/null || cat "$FILE_PATH" 2>/dev/null)
+  [ -z "$CONTENT" ] && continue
 
   # Only process relevant files: src/db/**, *.sql, or TS files containing SQL keywords.
   is_db_file=0
   case "$FILE_PATH" in
     */src/db/*|*.sql) is_db_file=1 ;;
     *.ts|*.tsx)
-      if grep -qiE "(SELECT|INSERT|UPDATE|DELETE|CREATE TABLE|DROP TABLE)[[:space:]]" "$FILE_PATH" 2>/dev/null; then
+      if echo "$CONTENT" | grep -qiE "(SELECT|INSERT|UPDATE|DELETE|CREATE TABLE|DROP TABLE)[[:space:]]"; then
         is_db_file=1
       fi
       ;;
   esac
   [ $is_db_file -eq 0 ] && continue
-
-  CONTENT=$(git show :"$FILE_PATH" 2>/dev/null || cat "$FILE_PATH" 2>/dev/null)
-  [ -z "$CONTENT" ] && continue
 
   # --- HARD BLOCK: SELECT * ---
   if echo "$CONTENT" | grep -qiE "SELECT[[:space:]]+[*]"; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,6 +5,6 @@ pnpm tsc --noEmit || exit 1
 git diff --cached --name-only -z -- 'src/db/**' '*.sql' | xargs -0 "$(git rev-parse --show-toplevel)/.githooks/sql-guard.sh" || exit 1
 
 # cargo check only when Rust or tauri config changed
-if git diff --cached --name-only | grep -qE '\.rs$|tauri\.conf\.json'; then
+if git diff --cached --name-only | grep -qE '\.rs$|tauri\.conf\.json$|(^|/)Cargo\.(toml|lock)$'; then
   ( cd src-tauri && cargo check ) || exit 1
 fi

--- a/.opencode/agents/execute-issue.md
+++ b/.opencode/agents/execute-issue.md
@@ -148,7 +148,7 @@ Do NOT run `gh pr create`. Do NOT comment on the issue. Do NOT close anything. T
 ## Rules
 
 - English only in all artifacts, code, commits, and the report.
-- Never edit `*.gen.ts`, `*.gen.tsx`, lockfiles, or `.env` (blocked by permission.ed config too).
+- Never edit `*.gen.ts`, `*.gen.tsx`, lockfiles, or `.env` (blocked by permission.edit config too).
 - One worktree per issue — never work in the main repo working tree.
 - If you cannot complete an acceptance criterion, note it honestly in the report rather than fudging.
 - Co-locate tests with source, follow the testing-standards skill.

--- a/docs/adr/0014-headless-baseui-vanilla-extract.md
+++ b/docs/adr/0014-headless-baseui-vanilla-extract.md
@@ -1,0 +1,56 @@
+# ADR-0014: Headless UI Foundation — Base UI + Vanilla Extract, Restoring the Warm-Earth Brand
+
+**Status**: Accepted
+**Date**: 2026-07-11
+
+## Context
+
+The UI foundation has swung between two extremes:
+
+- [ADR-007](./0007-adopt-radix-themes.md) adopted **Radix Themes** (a styled, opinionated component library) but deliberately kept a brand layer: self-hosted **Geist / Fraunces / Geist Mono** fonts, a **terracotta accent + warm sand** oklch palette, and **scoped local CSS as an escape hatch** for bespoke surfaces.
+- [ADR-010](./0010-pure-radix-themes.md) found that escape hatch had drifted — `app.css` grew back to 431 lines of custom palette, `@font-face`, and per-component decoration — and went the other way: **pure Radix Themes**, dropping the fonts, the terracotta palette, motion, and all custom CSS. It explicitly accepted the cost: "the terracotta brand, Fraunces serif identity, and all micro-interactions are lost; some surfaces look generic," judging a drift-proof, maintenance-free UI "more valuable than a bespoke visual identity at this stage."
+
+Building real screens against that decision reversed the bet. As soon as a screen needs anything past a stock pattern — the Person editor, the relations organism, the pedigree chart — you either fight Radix Themes or drop to a custom organism that sits visibly beside stock components. That visible boundary (a "seam") is structural to a styled library, and it is worst for Vata specifically: our bespoke surface (pedigree, timelines, relation editors, family sheets) is large, which is exactly where a styled library's value is smallest and its seams most frequent. Meanwhile the generic indigo/system-font look ADR-010 accepted became a real product drag — the app lacks personality.
+
+The precise lesson from ADR-010 is that **the brand was never the problem; the escape hatch was.** A 431-line hand-authored `app.css` is a drift vector. A **typed, zero-runtime token contract is not an escape hatch — it is a structured foundation.** That distinction is what makes restoring the brand safe this time.
+
+## Decision
+
+Move off Radix Themes to a **headless** foundation and re-author the visual layer over a typed token contract.
+
+- **Behavior layer: Base UI** (`@base-ui/react`). Dialog, Select, Switch, Popover, etc. supply accessibility, focus management, and keyboard behavior — the expensive, generic parts — with no imposed styling.
+- **Styling / token layer: Vanilla Extract** (`@vanilla-extract/css`). A typed, zero-runtime token contract (`src/design/theme.css.ts`, light + dark) is the single source of visual truth. Every component styles itself from `vars.*`. No hand-authored global CSS palette, no `app.css` escape hatch.
+- **Brand restored.** The warm-earth identity ADR-010 removed comes back, as tokens: **terracotta (clay) accent, warm sand neutrals, moss / ink secondaries**, all in `oklch`. **Geist Sans** for UI and body, **Geist Mono** for data (dates, IDs). **Fraunces (italic)** is the signature, spent with restraint on lineage moments only — a person's name, the home hero, empty states, display-scale section titles — never on dense UI chrome. Fonts are self-hosted via `@fontsource/*`.
+- **No inherited token architecture.** We do **not** carry over shadcn's or Radix's semantic token sprawl. The contract holds only what the product uses now and grows as screens demand it — MVP, adjusted in flight.
+- **Coexistence, then migration.** Radix Themes and Base UI coexist during the transition; screens migrate one at a time, the real wired `PersonEditorDialog` first. No big-bang rewrite.
+
+## Why
+
+- **It answers ADR-010's actual concern without paying its cost.** ADR-010 closed drift by forbidding brand. Vanilla Extract closes drift by making the brand a typed contract with zero runtime — a structured foundation, not the scoped-CSS escape hatch that drifted. Personality and drift-resistance stop being a trade-off.
+- **It removes the seam entirely.** With everything authored over one token contract, there is no "stock" layer left for a custom organism to clash with. The seam class of problem — the thing that made the current relations UI look bolted-on — disappears.
+- **It fits Vata's shape.** A large bespoke surface is precisely where headless wins: you own every organism anyway, so inheriting a styled library only imposes a look you must then fight.
+- **It fits the maintainer.** Authoring the visual layer is a capability here, not a cost — and the warm-earth system already existed and was well-liked before ADR-010 removed it.
+- **Validated by a spike (2026-07-11).** The Person editor modal was rebuilt on Base UI + Vanilla Extract at the DEV route `/ds-spike`, reproducing the recovered prototype in light and dark with the Relations organism fully integrated and no seam.
+
+## Alternatives Considered
+
+- **Stay pure Radix Themes (ADR-010).** Rejected — the genericness is now a concrete product problem, and the seam surfaces wherever bespoke meets stock, which for Vata is nearly everywhere.
+- **Radix Themes + custom organisms on Radix Primitives.** Rejected — this _is_ the seam (your organism's visual DNA against Radix's defaults); the spike showed the goal must be to eliminate it, not manage it.
+- **shadcn/ui.** Rejected — its Tailwind + copy-paste-components paradigm is one the maintainer explicitly does not want.
+- **Restore brand via Radix named scales** (`accentColor="brown"`, a self-hosted-font carve-out). Rejected — token-level theming can neither remove the seam nor give full control of bespoke organisms; it is still a styled library underneath.
+
+## Consequences
+
+**Positive**: a distinctive, owned visual identity is restored; drift is closed by a typed contract rather than by banning brand; bespoke organisms are fully controllable with no seams; zero-runtime CSS suits the Tauri webview (no FOUC).
+
+**Negative / Trade-offs**: a cross-app migration off Radix Themes, screen by screen; two UI systems coexist during the transition; the team owns a styling layer it previously outsourced (the deliberate point); Base UI is younger and less battle-tested than Radix Themes.
+
+**Supersedes** [ADR-007](./0007-adopt-radix-themes.md) (Radix Themes adoption) and [ADR-010](./0010-pure-radix-themes.md) (pure Radix Themes / no brand). ADR-0011's full-width shell and the Lucide icon registry are unaffected.
+
+## References
+
+- [ADR-007: Adopt Radix Themes](./0007-adopt-radix-themes.md) — superseded
+- [ADR-010: Pure Radix Themes](./0010-pure-radix-themes.md) — superseded
+- Spike: DEV route `/ds-spike`, `src/design/theme.css.ts`, `src/design/person-modal-spike.css.ts`
+- Recovered design prototypes: `docs/design/prototypes/person-modal-layout-b.html`
+- Source design system: the maintainer's `claude.ai/design` project (warm-earth oklch tokens, Fraunces + Geist)

--- a/docs/design/prototypes/person-modal-layout-b.html
+++ b/docs/design/prototypes/person-modal-layout-b.html
@@ -1,0 +1,351 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Person modal — Layout B, staged</title>
+<!--
+  Recovered from Claude artifact 05a400f8-e55f-4483-b54a-9bd3a6db1ce2 (updated 2026-07-05).
+  Chosen visual direction for the Person editor: Layout B (Wide + dense rail), staged delivery.
+  This is the design source of truth for the Base UI + Vanilla Extract migration — the :root
+  custom properties below become the Vanilla Extract theme; the component styles become the
+  styled Base UI components. Standalone: open directly in a browser.
+-->
+<style>:root{color-scheme:light}body{margin:0;padding:0;font:14px -apple-system,BlinkMacSystemFont,sans-serif;background:#faf9f5;color:#141413}img{max-width:100%}</style>
+<style>
+  :root{
+    --ground:#fbfbfc; --panel:#ffffff; --panel-2:#f7f7f9; --subtle:#f0f0f3;
+    --border:#e5e5ea; --border-strong:#d6d6de;
+    --text:#1b1d22; --muted:#63666e; --faint:#8b8e97;
+    --accent:#3e63dd; --accent-hover:#3a5bca; --accent-soft:#ecf0fe; --accent-border:#c6d1f6;
+    --success:#2b9a66; --warn:#b8860b; --danger:#d93b3b;
+    --scrim:rgba(11,11,15,.55);
+    --shadow-sm:0 1px 2px rgba(20,22,30,.06);
+    --shadow-lg:0 1px 2px rgba(20,22,30,.06), 0 26px 60px -18px rgba(20,22,30,.4);
+    --radius:10px; --radius-sm:7px;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --ground:#0e0e10; --panel:#161719; --panel-2:#1b1c1f; --subtle:#202124;
+    --border:#2a2b2f; --border-strong:#3a3b41; --text:#ecedf0; --muted:#a5a9b2; --faint:#71757e;
+    --accent:#6a83ef; --accent-hover:#7d93f1; --accent-soft:#1d2233; --accent-border:#323a5d;
+    --success:#40b27f; --warn:#e0b44a; --danger:#f06a6a; --scrim:rgba(0,0,0,.66);
+    --shadow-sm:0 1px 2px rgba(0,0,0,.5);
+    --shadow-lg:0 1px 2px rgba(0,0,0,.5), 0 28px 64px -18px rgba(0,0,0,.82);
+  }}
+  :root[data-theme="dark"]{
+    --ground:#0e0e10; --panel:#161719; --panel-2:#1b1c1f; --subtle:#202124;
+    --border:#2a2b2f; --border-strong:#3a3b41; --text:#ecedf0; --muted:#a5a9b2; --faint:#71757e;
+    --accent:#6a83ef; --accent-hover:#7d93f1; --accent-soft:#1d2233; --accent-border:#323a5d;
+    --success:#40b27f; --warn:#e0b44a; --danger:#f06a6a; --scrim:rgba(0,0,0,.66);
+    --shadow-sm:0 1px 2px rgba(0,0,0,.5);
+    --shadow-lg:0 1px 2px rgba(0,0,0,.5), 0 28px 64px -18px rgba(0,0,0,.82);
+  }
+  :root[data-theme="light"]{
+    --ground:#fbfbfc; --panel:#ffffff; --panel-2:#f7f7f9; --subtle:#f0f0f3;
+    --border:#e5e5ea; --border-strong:#d6d6de; --text:#1b1d22; --muted:#63666e; --faint:#8b8e97;
+    --accent:#3e63dd; --accent-hover:#3a5bca; --accent-soft:#ecf0fe; --accent-border:#c6d1f6;
+    --success:#2b9a66; --warn:#b8860b; --danger:#d93b3b; --scrim:rgba(11,11,15,.55);
+    --shadow-sm:0 1px 2px rgba(20,22,30,.06);
+    --shadow-lg:0 1px 2px rgba(20,22,30,.06), 0 26px 60px -18px rgba(20,22,30,.4);
+  }
+
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--ground);color:var(--text);font-family:var(--sans);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+  h1,h3,p{margin:0}
+  input,button,textarea{font-family:inherit}
+  :focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-radius:3px}
+  .wrap{max-width:1000px;margin:0 auto;padding:28px 24px 72px}
+
+  .masthead{padding-bottom:16px;border-bottom:1px solid var(--border)}
+  .eyebrow{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);font-weight:600}
+  .masthead h1{font-size:25px;font-weight:680;letter-spacing:-.02em;margin-top:8px}
+  .masthead p{color:var(--muted);max-width:70ch;margin-top:7px}
+  .kbd{font-family:var(--mono);font-size:11px;background:var(--subtle);border:1px solid var(--border);border-bottom-width:2px;border-radius:4px;padding:1px 5px;color:var(--muted)}
+  .masthead p b{color:var(--text)}
+
+  .stages{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:22px}
+  .stage-card{border:1px solid var(--border);border-radius:12px;padding:14px 15px;background:var(--panel)}
+  .stage-card .sh{display:flex;align-items:center;gap:8px;margin-bottom:9px}
+  .stage-card .pill{font-size:10px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;padding:3px 8px;border-radius:99px}
+  .pill.v1{background:color-mix(in srgb,var(--success) 15%,transparent);color:var(--success)}
+  .pill.next{background:var(--subtle);color:var(--muted)}
+  .stage-card h3{font-size:13px;font-weight:660}
+  .stage-card ul{margin:0;padding-left:16px;color:var(--muted);font-size:12.5px;display:flex;flex-direction:column;gap:3px}
+  @media (max-width:720px){.stages{grid-template-columns:1fr}}
+
+  .launch{margin-top:20px;display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigopen{height:44px;border-radius:10px;border:1px solid var(--accent);background:var(--accent);color:#fff;font-size:14px;font-weight:650;cursor:pointer;padding:0 20px;display:inline-flex;align-items:center;gap:9px}
+  .bigopen:hover{background:var(--accent-hover)}
+  .launch .lh{font-size:12.5px;color:var(--faint)}
+
+  /* controls */
+  .field{display:flex;flex-direction:column;gap:5px;min-width:0}
+  label.fl{font-size:11.5px;font-weight:600;color:var(--muted)}
+  .input{height:34px;border:1px solid var(--border-strong);background:var(--panel);color:var(--text);border-radius:var(--radius-sm);padding:0 10px;font-size:13.5px;width:100%;box-shadow:inset 0 1px 1px rgba(0,0,0,.03)}
+  .input:hover{border-color:var(--faint)}.input::placeholder{color:var(--faint)}
+  textarea.input{height:auto;min-height:62px;padding:8px 10px;line-height:1.45;resize:vertical}
+  .tnum{font-variant-numeric:tabular-nums}
+  .w-date{max-width:150px}
+  .fgrid{display:grid;gap:10px 12px}.fgrid.c2{grid-template-columns:1fr 1fr}.fgrid.c3{grid-template-columns:1fr 1fr 1fr}
+  .seg{display:inline-flex;background:var(--subtle);border-radius:8px;padding:3px;gap:2px;width:max-content}
+  .seg span{padding:6px 13px;border-radius:6px;font-size:12.5px;font-weight:600;color:var(--muted);cursor:pointer}
+  .seg span.on{background:var(--panel);color:var(--text);box-shadow:var(--shadow-sm)}
+  .switchrow{display:flex;align-items:center;gap:10px}
+  .switch{width:38px;height:22px;border-radius:99px;background:var(--border-strong);position:relative;flex:0 0 auto;cursor:pointer}
+  .switch.on{background:var(--accent)}
+  .switch::after{content:"";position:absolute;top:2px;left:2px;width:18px;height:18px;border-radius:50%;background:#fff;box-shadow:var(--shadow-sm);transition:left .15s}
+  .switch.on::after{left:18px}
+  @media (prefers-reduced-motion:reduce){.switch::after{transition:none}}
+  .switch-label{font-size:13px;font-weight:600}
+  .iconbtn{width:30px;height:30px;border-radius:6px;border:1px solid transparent;background:transparent;color:var(--faint);cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:14px;flex:0 0 auto}
+  .iconbtn:hover{background:var(--subtle);color:var(--danger)}
+  .addbtn{align-self:flex-start;background:transparent;border:1px dashed var(--border-strong);color:var(--muted);border-radius:var(--radius-sm);height:32px;padding:0 12px;font-size:12.5px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:7px}
+  .addbtn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn{height:34px;border-radius:var(--radius-sm);padding:0 16px;font-size:13px;font-weight:600;cursor:pointer;border:1px solid transparent;display:inline-flex;align-items:center;gap:8px}
+  .btn.solid{background:var(--accent);color:#fff}.btn.solid:hover{background:var(--accent-hover)}
+  .btn.ghost{background:transparent;color:var(--muted)}.btn.ghost:hover{color:var(--text)}
+  .altrow{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr) 128px 30px;gap:8px;align-items:center}
+  .selbox{height:34px;border:1px solid var(--border-strong);background:var(--panel);border-radius:var(--radius-sm);display:flex;align-items:center;gap:6px;padding:0 10px;font-size:12.5px;color:var(--text);cursor:pointer;white-space:nowrap}
+  .selbox::after{content:"▾";margin-left:auto;font-size:9px;color:var(--faint)}
+  .pfield{height:34px;border:1px solid var(--border-strong);background:var(--panel);border-radius:var(--radius-sm);display:flex;align-items:center;gap:9px;padding:0 6px 0 10px;max-width:300px}
+  .pfield .av{width:22px;height:22px;border-radius:50%;background:var(--accent-soft);color:var(--accent);font-size:9px;font-weight:700;display:flex;align-items:center;justify-content:center;flex:0 0 auto}
+  .pfield .pn{flex:1;font-size:13px;font-weight:550;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .subhead{font-size:11.5px;font-weight:650;color:var(--muted);margin:0 0 8px}.subhead.mt{margin-top:14px}
+  .sectitle{font-size:11px;letter-spacing:.09em;text-transform:uppercase;color:var(--faint);font-weight:650;display:flex;align-items:center;margin-bottom:12px}
+  .stack{display:flex;flex-direction:column;gap:8px}
+  .rrow{display:grid;grid-template-columns:88px minmax(0,1fr);gap:10px;align-items:center;padding:3px 0}
+  .rrow > .rl{font-size:12px;color:var(--muted)}.rrow .input{max-width:270px}.rrow .input.w-date{max-width:150px}
+  .statusrow{display:flex;align-items:center;gap:10px}.statusrow .rl{font-size:12px;color:var(--muted);width:88px}
+
+  .eventlist{display:flex;flex-direction:column;gap:8px}
+  .eventrow{display:grid;grid-template-columns:148px 150px 1fr 30px;gap:8px;align-items:center;max-width:560px}
+  .eplace{font-size:12px;color:var(--faint);display:inline-flex;align-items:center;gap:6px;justify-self:start;white-space:nowrap;opacity:.7}
+  .eplace .soon{font-size:9px;text-transform:uppercase;letter-spacing:.04em;color:var(--faint);border:1px solid var(--border);border-radius:99px;padding:1px 5px}
+  .addwrap{margin-top:2px}
+  .typegrid{display:none;margin-top:9px;grid-template-columns:repeat(3,1fr);gap:6px;max-width:430px;border:1px solid var(--border);background:var(--panel-2);border-radius:10px;padding:8px}
+  .typegrid.open{display:grid}
+  .typegrid button{border:1px solid var(--border);background:var(--panel);border-radius:7px;padding:8px 9px;font-size:12.5px;cursor:pointer;color:var(--text);text-align:left}
+  .typegrid button:hover{border-color:var(--accent);color:var(--accent);background:var(--accent-soft)}
+
+  .relrow2{display:grid;grid-template-columns:78px minmax(0,1fr);gap:10px;align-items:start;padding:4px 0}
+  .relrow2 > .rl{font-size:12px;color:var(--muted);padding-top:8px}
+  .relanchor{position:relative;min-width:0}
+  .relslot{height:34px;border:1px dashed var(--border-strong);background:transparent;color:var(--faint);border-radius:var(--radius-sm);display:inline-flex;align-items:center;gap:8px;padding:0 12px;font-size:12.5px;font-weight:600;cursor:pointer;max-width:300px;width:100%}
+  .relslot:hover{border-color:var(--accent);color:var(--accent)}
+  .childstack{display:flex;flex-direction:column;gap:8px;min-width:0}
+  .picker{display:none;margin-top:8px;border:1px solid var(--border-strong);border-radius:11px;background:var(--panel-2);padding:9px;max-width:320px;box-shadow:var(--shadow-sm)}
+  .picker.open{display:block}
+  .picker .ppsearch{margin-bottom:8px;background:var(--panel)}
+  .pplist{display:flex;flex-direction:column;gap:2px;max-height:172px;overflow:auto}
+  .ppitem{display:flex;align-items:center;gap:9px;border:0;background:transparent;text-align:left;padding:7px 8px;border-radius:7px;cursor:pointer;color:var(--text);font-size:13px;width:100%}
+  .ppitem:hover{background:var(--subtle)}
+  .ppitem .av{width:24px;height:24px;border-radius:50%;background:var(--accent-soft);color:var(--accent);font-size:9px;font-weight:700;display:flex;align-items:center;justify-content:center;flex:0 0 auto}
+  .ppitem .nm{flex:1;font-weight:550}.ppitem .yr{font-size:11px;color:var(--faint)}
+  .ppcreate{margin-top:6px;width:100%;border:0;border-top:1px solid var(--border);background:transparent;color:var(--accent);font-weight:650;font-size:12.5px;padding:9px 8px 3px;cursor:pointer;text-align:left;display:flex;gap:6px;align-items:center;flex-wrap:wrap}
+
+  /* staged / disabled */
+  .later-badge{font-size:9.5px;letter-spacing:.04em;text-transform:uppercase;color:var(--warn);background:color-mix(in srgb,var(--warn) 14%,transparent);border:1px solid color-mix(in srgb,var(--warn) 35%,transparent);border-radius:99px;padding:2px 8px;font-weight:700;margin-left:8px}
+  .later-note{font-size:11.5px;color:var(--faint);margin:-4px 0 10px}
+  .modal:not(.preview) .later-body{opacity:.5;pointer-events:none;filter:grayscale(.2)}
+  .modal.preview .later-only{display:none}
+
+  .mbody-pad{padding:14px 18px 18px}
+  .demohint{display:flex;align-items:center;gap:10px;font-size:12px;color:var(--muted);background:var(--accent-soft);border:1px solid var(--accent-border);border-radius:8px;padding:8px 12px;margin-bottom:14px}
+  .demohint b{color:var(--accent)}
+  .previewbtn{margin-left:auto;border:1px solid var(--border-strong);background:var(--panel);color:var(--muted);border-radius:7px;height:28px;padding:0 11px;font-size:12px;font-weight:600;cursor:pointer;white-space:nowrap}
+  .previewbtn:hover{border-color:var(--accent);color:var(--accent)}
+  .modal.preview .previewbtn{background:var(--accent-soft);color:var(--accent);border-color:var(--accent-border)}
+  .cols{display:grid;gap:14px;align-items:start;grid-template-columns:1.5fr 1fr}
+  .col{display:flex;flex-direction:column;gap:14px;min-width:0}
+  .ecard{background:var(--panel);border:1px solid var(--border);border-radius:11px;padding:14px 15px}
+
+  .overlay{position:fixed;inset:0;z-index:100;display:none;align-items:center;justify-content:center;padding:32px 22px 22px;background:var(--scrim)}
+  .overlay.open{display:flex;animation:ov .16s ease}
+  @keyframes ov{from{opacity:0}to{opacity:1}}
+  @media (prefers-reduced-motion:reduce){.overlay.open{animation:none}}
+  .modal{width:100%;max-width:1040px;background:var(--panel);border:1px solid var(--border-strong);border-radius:14px;box-shadow:var(--shadow-lg);display:none;flex-direction:column;overflow:hidden;max-height:calc(100vh - 54px)}
+  .modal.show{display:flex}
+  .mhead{display:flex;align-items:center;gap:12px;padding:14px 18px;border-bottom:1px solid var(--border);flex:0 0 auto}
+  .mhead .avatar{width:38px;height:38px;border-radius:10px;background:var(--accent-soft);color:var(--accent);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:13px;flex:0 0 auto}
+  .mhead .t{font-size:15px;font-weight:650}.mhead .s{font-size:12px;color:var(--faint)}
+  .mhead .grow{flex:1}
+  .mbody{flex:1;min-height:0;overflow:auto}
+  .mfoot{display:flex;align-items:center;gap:12px;padding:11px 18px;border-top:1px solid var(--border);flex:0 0 auto;background:color-mix(in srgb,var(--panel) 92%,transparent)}
+  .dirty{display:inline-flex;align-items:center;gap:8px;font-size:12.5px;color:var(--warn);font-weight:600}
+  .dirty::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--warn)}
+  .mfoot .grow{flex:1}
+  @media (max-width:900px){.cols{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<svg style="display:none" aria-hidden="true">
+  <symbol id="i-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="6.5"/><path d="M20 20l-4-4"/></symbol>
+</svg>
+
+<div class="wrap">
+  <div class="masthead">
+    <div class="eyebrow">Vata · Person editor · Layout B · staged</div>
+    <h1>The person modal, and what ships when</h1>
+    <p>Chosen direction: <b>Layout B (Wide + dense rail)</b>, delivered in stages — but the full UI is present from day one, with not-yet-built parts shown <b>disabled</b>. Open the editor and toggle <b>Preview later-stage</b> to see relations live.</p>
+  </div>
+
+  <div class="stages">
+    <div class="stage-card"><div class="sh"><span class="pill v1">v1 · active</span></div><h3>Identity, names, events, notes</h3>
+      <ul><li>Primary name + other names</li><li>Sex &amp; living status</li><li>Life events (birth, death, +typed events)</li><li>Notes</li></ul></div>
+    <div class="stage-card"><div class="sh"><span class="pill next">v1.1 · disabled</span></div><h3>Relations</h3>
+      <ul><li>Parents, spouse, children</li><li>Person search / create</li><li>Family (union) mutations</li></ul></div>
+    <div class="stage-card"><div class="sh"><span class="pill next">v1.2 · disabled</span></div><h3>Places</h3>
+      <ul><li>Place on each event</li><li>Needs a Place picker first</li></ul></div>
+  </div>
+
+  <div class="launch">
+    <button class="bigopen" id="openbtn">▶ Open the person editor</button>
+    <span class="lh">Real modal · <span class="kbd">Esc</span> to close</span>
+  </div>
+</div>
+
+<div class="overlay" id="overlay" role="dialog" aria-modal="true">
+  <div class="modal" id="modal">
+    <div class="mhead"><div class="avatar">LP</div><div><div class="t">Edit person</div><div class="s">Lily J. Potter</div></div><span class="grow"></span><button class="iconbtn mx">✕</button></div>
+    <div class="mbody mbody-pad">
+      <div class="demohint">
+        <span><b>v1 preview.</b> Try <b>＋ Add event</b>. Relations &amp; places are shown disabled (later stages).</span>
+        <button class="previewbtn" id="previewbtn">Preview later-stage ▸</button>
+      </div>
+      <div class="cols">
+        <div class="col">
+          <div class="ecard"><span class="sectitle">Names</span>
+            <div class="subhead">Primary name</div>
+            <div class="fgrid c2"><div class="field"><label class="fl">Given names</label><input class="input" value="Lily J."></div><div class="field"><label class="fl">Surname</label><input class="input" value="Potter"></div></div>
+            <div style="height:10px"></div>
+            <div class="fgrid c3"><div class="field"><label class="fl">Prefix</label><input class="input" placeholder="—"></div><div class="field"><label class="fl">Suffix</label><input class="input" placeholder="—"></div><div class="field"><label class="fl">Nickname</label><input class="input" placeholder="—"></div></div>
+            <div class="subhead mt">Other names</div>
+            <div class="stack"><div class="altrow" style="max-width:none"><input class="input" value="Lily"><input class="input" value="Evans"><div class="selbox">Birth name</div><button class="iconbtn">✕</button></div><button class="addbtn">＋ Add name</button></div>
+          </div>
+
+          <div class="ecard"><span class="sectitle">Life events</span>
+            <div class="eventlist">
+              <div class="eventrow"><div class="selbox etype">Birth</div><input class="input tnum w-date" value="30 Jan 1960"><span class="eplace">＋ place <span class="soon">soon</span></span><button class="iconbtn erm">✕</button></div>
+              <div class="eventrow"><div class="selbox etype">Baptism</div><input class="input tnum w-date" value="1 Mar 1960"><span class="eplace">＋ place <span class="soon">soon</span></span><button class="iconbtn erm">✕</button></div>
+              <div class="eventrow"><div class="selbox etype">Death</div><input class="input tnum w-date" value="31 Oct 1981"><span class="eplace">＋ place <span class="soon">soon</span></span><button class="iconbtn erm">✕</button></div>
+              <div class="addwrap"><button class="addbtn addevent">＋ Add event</button><div class="typegrid"></div></div>
+            </div>
+            <div class="statusrow" style="margin-top:12px"><span class="rl">Status</span><span class="switch"></span><span class="switch-label">Deceased</span></div>
+          </div>
+
+          <div class="ecard"><span class="sectitle">Notes</span><textarea class="input" style="min-height:78px">Muggle-born witch; protected her son.</textarea></div>
+        </div>
+
+        <div class="col">
+          <div class="ecard"><span class="sectitle">Attributes</span>
+            <div class="rrow"><span class="rl">Sex</span><div class="seg"><span class="on">Female</span><span>Male</span><span>Unknown</span></div></div>
+          </div>
+
+          <div class="ecard"><span class="sectitle">Relations <span class="later-badge">later stage</span></span>
+            <div class="later-note later-only">Shown for the layout — parents, spouse &amp; children arrive in v1.1.</div>
+            <div class="later-body">
+              <div class="subhead">Parents</div>
+              <div class="relrow2"><span class="rl">Father</span><div class="anchor relanchor" data-role="Father" data-add="＋ Add father"><button class="relslot" type="button">＋ Add father</button></div></div>
+              <div class="relrow2"><span class="rl">Mother</span><div class="anchor relanchor" data-role="Mother" data-add="＋ Add mother"><button class="relslot" type="button">＋ Add mother</button></div></div>
+              <div class="subhead mt">Family</div>
+              <div class="relrow2"><span class="rl">Spouse</span><div class="anchor relanchor" data-role="Spouse" data-add="＋ Add spouse"><div class="pfield"><span class="av">JP</span><span class="pn">James Potter</span><button class="iconbtn relrm">✕</button></div></div></div>
+              <div class="relrow2"><span class="rl">Children</span><div class="childstack">
+                <div class="anchor relanchor" data-role="Child" data-add="＋ Add child"><div class="pfield"><span class="av">HP</span><span class="pn">Harry Potter</span><button class="iconbtn relrm">✕</button></div></div>
+                <div class="anchor relanchor" data-role="Child" data-add="＋ Add child"><button class="relslot" type="button">＋ Add child</button></div>
+              </div></div>
+              <div class="famhost"><button class="addbtn addfamily" style="margin-top:12px">＋ Add another family</button></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="mfoot"><span class="dirty">Unsaved changes</span><span class="grow"></span><button class="btn ghost mx">Cancel</button><button class="btn solid">Save</button></div>
+  </div>
+</div>
+
+<script>
+  var EVENT_TYPES=['Baptism','Christening','Burial','Cremation','Residence','Occupation','Education','Immigration','Census','Marriage','Religion','Other'];
+  var PEOPLE=[
+    {n:'James Potter',av:'JP',y:'b. 1960'},{n:'Fleamont Potter',av:'FP',y:'b. 1901'},
+    {n:'Euphemia Potter',av:'EP',y:'b. 1905'},{n:'Harry Potter',av:'HP',y:'b. 1980'},
+    {n:'Petunia Evans',av:'PE',y:'b. 1958'},{n:'Severus Snape',av:'SS',y:'b. 1960'}
+  ];
+  var overlay=document.getElementById('overlay'), modal=document.getElementById('modal');
+
+  function esc(s){return String(s).replace(/[&<>"]/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});}
+  function initials(s){return (s.trim().split(/\s+/).slice(0,2).map(function(w){return w[0]||'';}).join('')||'?').toUpperCase();}
+
+  function open(){ overlay.classList.add('open'); modal.classList.add('show'); document.body.style.overflow='hidden'; }
+  function close(){ overlay.classList.remove('open'); modal.classList.remove('show'); document.body.style.overflow=''; }
+
+  document.querySelector('.typegrid').innerHTML=EVENT_TYPES.map(function(t){return '<button type="button">'+t+'</button>';}).join('');
+
+  function addEventRow(list,type){
+    var row=document.createElement('div'); row.className='eventrow';
+    row.innerHTML='<div class="selbox etype">'+esc(type)+'</div><input class="input tnum w-date" placeholder="date…"><span class="eplace">＋ place <span class="soon">soon</span></span><button class="iconbtn erm" aria-label="Remove">✕</button>';
+    list.insertBefore(row, list.querySelector('.addwrap')); row.querySelector('input').focus();
+  }
+  function buildPicker(){
+    var p=document.createElement('div'); p.className='picker open';
+    p.innerHTML='<input class="input ppsearch" placeholder="Search people…">'
+      +'<div class="pplist">'+PEOPLE.map(function(x){return '<button class="ppitem" type="button" data-name="'+esc(x.n)+'" data-av="'+x.av+'"><span class="av">'+x.av+'</span><span class="nm">'+esc(x.n)+'</span><span class="yr">'+x.y+'</span></button>';}).join('')+'</div>'
+      +'<button class="ppcreate" type="button">＋ Create new person <span class="ppq">…</span></button>';
+    return p;
+  }
+  function contentOf(a){ return a.querySelector(':scope > .relslot, :scope > .pfield'); }
+  function fillSlot(a,name,av){
+    var p=a.querySelector(':scope > .picker'); if(p) p.remove();
+    var pf=document.createElement('div'); pf.className='pfield';
+    pf.innerHTML='<span class="av">'+esc(av)+'</span><span class="pn">'+esc(name)+'</span><button class="iconbtn relrm" aria-label="Remove">✕</button>';
+    a.replaceChild(pf, contentOf(a));
+  }
+  function emptySlot(a){ var b=document.createElement('button'); b.type='button'; b.className='relslot'; b.textContent=a.dataset.add; a.replaceChild(b, contentOf(a)); }
+  function openPicker(a){ closeAll(a); var p=a.querySelector(':scope > .picker'); if(p){ p.classList.toggle('open'); return; } p=buildPicker(); a.appendChild(p); var s=p.querySelector('.ppsearch'); if(s) s.focus(); }
+  function addFamily(btn){
+    var fam=document.createElement('div');
+    fam.innerHTML='<div class="subhead mt">Family</div>'
+      +'<div class="relrow2"><span class="rl">Spouse</span><div class="anchor relanchor" data-role="Spouse" data-add="＋ Add spouse"><button class="relslot" type="button">＋ Add spouse</button></div></div>'
+      +'<div class="relrow2"><span class="rl">Children</span><div class="childstack"><div class="anchor relanchor" data-role="Child" data-add="＋ Add child"><button class="relslot" type="button">＋ Add child</button></div></div></div>';
+    while(fam.firstChild){ btn.parentElement.insertBefore(fam.firstChild, btn); }
+  }
+  function closeAll(except){
+    document.querySelectorAll('.picker').forEach(function(p){ if(except&&except.contains(p)) return; if(p.classList.contains('open')) p.classList.remove('open'); else p.remove(); });
+    document.querySelectorAll('.typegrid.open').forEach(function(g){ g.classList.remove('open'); });
+  }
+
+  document.addEventListener('click',function(e){
+    var t=e.target;
+    if(t.closest('#openbtn')){ open(); return; }
+    if(t.closest('.mx')){ close(); return; }
+    if(t===overlay){ close(); return; }
+    if(!overlay.classList.contains('open')) return;
+    if(t.closest('#previewbtn')){ var pb=t.closest('#previewbtn'); modal.classList.toggle('preview'); pb.textContent=modal.classList.contains('preview')?'◂ Back to v1 view':'Preview later-stage ▸'; return; }
+    var ae=t.closest('.addevent'); if(ae){ var g=ae.parentElement.querySelector('.typegrid'); var was=g.classList.contains('open'); closeAll(); if(!was) g.classList.add('open'); return; }
+    var tb=t.closest('.typegrid button'); if(tb){ addEventRow(tb.closest('.eventlist'), tb.textContent); tb.closest('.typegrid').classList.remove('open'); return; }
+    if(t.closest('.erm')){ t.closest('.eventrow').remove(); return; }
+    if(t.closest('.relslot')){ openPicker(t.closest('.relanchor')); return; }
+    var it=t.closest('.ppitem'); if(it){ fillSlot(it.closest('.relanchor'), it.dataset.name, it.dataset.av); return; }
+    var cr=t.closest('.ppcreate'); if(cr){ var a=cr.closest('.relanchor'); var q=(a.querySelector('.ppsearch').value||'').trim(); fillSlot(a, q||'New person', initials(q||'New person')); return; }
+    if(t.closest('.relrm')){ emptySlot(t.closest('.relanchor')); return; }
+    if(t.closest('.addfamily')){ addFamily(t.closest('.addfamily')); return; }
+    if(t.closest('.picker')||t.closest('.typegrid')) return;
+    closeAll();
+  });
+  document.addEventListener('input',function(e){
+    if(e.target.classList.contains('ppsearch')){
+      var q=e.target.value.toLowerCase(), pop=e.target.closest('.picker');
+      pop.querySelectorAll('.ppitem').forEach(function(it){ it.style.display = it.dataset.name.toLowerCase().indexOf(q)>=0?'':'none'; });
+      var qq=pop.querySelector('.ppq'); if(qq) qq.textContent = e.target.value ? ('“'+e.target.value+'”') : '…';
+    }
+  });
+  document.addEventListener('keydown', function(e){
+    if(!overlay.classList.contains('open')) return;
+    if(e.key==='Escape'){ if(document.querySelector('.picker.open, .typegrid.open')){ closeAll(); } else { close(); } }
+  });
+</script>
+
+</body>
+</html>

--- a/docs/design/prototypes/relations-tab-table.html
+++ b/docs/design/prototypes/relations-tab-table.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Relations tab — table mockup</title>
+<!--
+  Recovered from Claude artifact dc8b254d-1d95-4adc-b53c-e062f7f1bd36 (updated 2026-07-04).
+  Direction for the Relations tab: reuse EntityTable — a single flat, column-sortable list
+  (like every other page), NOT bespoke grouped rows. Default sort = hidden family rank
+  (Parents → Siblings → Half-siblings → Spouses → Children), shown by the arrow on "Name".
+-->
+<style>
+  :root {
+    --gray-1: #fcfcfc; --gray-2: #f9f9f9; --gray-3: #f0f0f0; --gray-4: #e8e8e8;
+    --gray-5: #e0e0e0; --gray-6: #d9d9d9; --gray-7: #cecece; --gray-8: #bbbbbb;
+    --gray-9: #8d8d8d; --gray-10: #838383; --gray-11: #646464; --gray-12: #202020;
+    --indigo-3: #e1e6fb; --indigo-9: #3e63dd; --indigo-11: #3a5bc7;
+    --card-bg: #ffffff;
+    --page-bg: var(--gray-1);
+    --radius: 8px;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --gray-1: #111111; --gray-2: #191919; --gray-3: #222222; --gray-4: #2a2a2a;
+      --gray-5: #313131; --gray-6: #3a3a3a; --gray-7: #484848; --gray-8: #606060;
+      --gray-9: #6e6e6e; --gray-10: #7b7b7b; --gray-11: #b4b4b4; --gray-12: #eeeeee;
+      --indigo-3: #1f2c4d; --indigo-9: #5472e4; --indigo-11: #9eb1f7;
+      --card-bg: #191919;
+      --page-bg: var(--gray-1);
+    }
+  }
+  :root[data-theme="dark"] {
+    --gray-1: #111111; --gray-2: #191919; --gray-3: #222222; --gray-4: #2a2a2a;
+    --gray-5: #313131; --gray-6: #3a3a3a; --gray-7: #484848; --gray-8: #606060;
+    --gray-9: #6e6e6e; --gray-10: #7b7b7b; --gray-11: #b4b4b4; --gray-12: #eeeeee;
+    --indigo-3: #1f2c4d; --indigo-9: #5472e4; --indigo-11: #9eb1f7;
+    --card-bg: #191919;
+    --page-bg: var(--gray-1);
+  }
+  :root[data-theme="light"] {
+    --gray-1: #fcfcfc; --gray-2: #f9f9f9; --gray-3: #f0f0f0; --gray-4: #e8e8e8;
+    --gray-5: #e0e0e0; --gray-6: #d9d9d9; --gray-7: #cecece; --gray-8: #bbbbbb;
+    --gray-9: #8d8d8d; --gray-10: #838383; --gray-11: #646464; --gray-12: #202020;
+    --indigo-3: #e1e6fb; --indigo-9: #3e63dd; --indigo-11: #3a5bc7;
+    --card-bg: #ffffff;
+    --page-bg: var(--gray-1);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--page-bg);
+    color: var(--gray-12);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, system-ui, sans-serif;
+    padding: 32px 20px 64px;
+  }
+  .wrap { max-width: 720px; margin: 0 auto; }
+
+  .annot {
+    border: 1px dashed var(--gray-7);
+    border-radius: var(--radius);
+    padding: 12px 16px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--gray-11);
+    margin-bottom: 24px;
+  }
+  .annot b { color: var(--gray-12); }
+
+  .table-card {
+    background: var(--card-bg);
+    border: 1px solid var(--gray-5);
+    border-radius: var(--radius);
+    overflow: hidden;
+  }
+  .scroller { overflow-x: auto; }
+
+  table { width: 100%; border-collapse: collapse; font-size: 14px; }
+  thead th {
+    text-align: left;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+    color: var(--gray-10);
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--gray-5);
+    white-space: nowrap;
+  }
+  thead th.sortable { cursor: pointer; user-select: none; }
+  thead th .arrow { display: inline-block; margin-left: 4px; color: var(--indigo-11); }
+  tbody td { padding: 11px 16px; border-bottom: 1px solid var(--gray-4); vertical-align: middle; line-height: 1.5; }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr:hover td { background: var(--gray-2); }
+
+  .name { font-weight: 500; }
+  .badge {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 700;
+    color: var(--indigo-11);
+    background: var(--indigo-3);
+    border-radius: 999px;
+    padding: 2px 7px;
+    margin-left: 6px;
+  }
+  .via { color: var(--gray-10); font-size: 12px; margin-top: 4px; }
+  .nums { font-variant-numeric: tabular-nums; color: var(--gray-11); white-space: nowrap; }
+</style>
+</head>
+<body>
+
+<div class="wrap">
+  <div class="annot">
+    <b>Option 1 — <code>EntityTable</code> réutilisé, mockup v3.</b> Focal person : Thomas Hayes.
+    Plus d'en-têtes de groupe : une seule liste plate, triable par colonne (comme toutes les autres
+    pages de l'app). Tri par défaut = rang familial caché (Parents → Siblings → Half-siblings →
+    Spouses → Children), indiqué ici par la flèche sur "Name". Cliquer "Born"/"Died" re-trie
+    normalement, comme n'importe quelle autre <code>EntityTable</code>.
+  </div>
+
+  <div class="table-card">
+    <div class="scroller">
+      <table>
+        <thead>
+          <tr>
+            <th class="sortable">Name <span class="arrow">↑</span></th>
+            <th>Relation</th>
+            <th class="sortable">Born</th>
+            <th class="sortable">Died</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td class="name">Robert Hayes</td><td>Father</td><td class="nums">1930</td><td class="nums">1995</td></tr>
+          <tr><td class="name">Susan Doyle</td><td>Mother</td><td class="nums">1935</td><td class="nums">2010</td></tr>
+
+          <tr><td class="name">Margaret Hayes</td><td>Sister</td><td class="nums">1958</td><td class="nums">—</td></tr>
+          <tr><td class="name">David Hayes</td><td>Brother</td><td class="nums">1960</td><td class="nums">—</td></tr>
+          <tr><td class="name">Helen Hayes</td><td>Sister</td><td class="nums">1965</td><td class="nums">—</td></tr>
+
+          <tr>
+            <td class="name">James Hayes</td>
+            <td>Half-brother<span class="badge">Paternal</span><div class="via">via Robert Hayes &amp; Eleanor Finch</div></td>
+            <td class="nums">1954</td><td class="nums">—</td>
+          </tr>
+          <tr>
+            <td class="name">Anne Cole</td>
+            <td>Half-sister<span class="badge">Maternal</span><div class="via">via Susan Doyle &amp; William Cole</div></td>
+            <td class="nums">1975</td><td class="nums">—</td>
+          </tr>
+          <tr>
+            <td class="name">Peter Cole</td>
+            <td>Half-brother<span class="badge">Maternal</span><div class="via">via Susan Doyle &amp; William Cole</div></td>
+            <td class="nums">1978</td><td class="nums">—</td>
+          </tr>
+
+          <tr><td class="name">Linda Marsh</td><td>Wife</td><td class="nums">1964</td><td class="nums">—</td></tr>
+          <tr><td class="name">Carol Reyes</td><td>Wife</td><td class="nums">1970</td><td class="nums">—</td></tr>
+
+          <tr><td class="name">Oliver Hayes</td><td>Son<div class="via">via Linda Marsh</div></td><td class="nums">1990</td><td class="nums">—</td></tr>
+          <tr><td class="name">Grace Hayes</td><td>Daughter<div class="via">via Linda Marsh</div></td><td class="nums">1993</td><td class="nums">—</td></tr>
+          <tr><td class="name">Ethan Hayes</td><td>Son<div class="via">via Carol Reyes</div></td><td class="nums">2003</td><td class="nums">—</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
     "prepare": "husky && git config core.hooksPath .husky"
   },
   "dependencies": {
+    "@base-ui/react": "^1.6.0",
+    "@fontsource/fraunces": "^5.2.9",
+    "@fontsource/geist-mono": "^5.2.8",
+    "@fontsource/geist-sans": "^5.2.5",
     "@radix-ui/themes": "^3.3.0",
     "@tanstack/react-query": "^5.0.0",
     "@tanstack/react-router": "^1.0.0",
@@ -48,6 +52,7 @@
     "@tauri-apps/plugin-fs": "^2.0.0",
     "@tauri-apps/plugin-sql": "^2.0.0",
     "@tauri-apps/plugin-store": "^2.0.0",
+    "@vanilla-extract/css": "^1.21.1",
     "d3-hierarchy": "^3.1.2",
     "i18next": "^26.0.3",
     "i18next-browser-languagedetector": "^8.2.1",
@@ -81,6 +86,7 @@
     "@types/react-dom": "^18.3.1",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
+    "@vanilla-extract/vite-plugin": "^5.2.4",
     "@vitejs/plugin-react": "^4.3.1",
     "@vitest/coverage-v8": "^3.2.4",
     "better-sqlite3": "^12.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.6.0
+        version: 1.6.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fontsource/fraunces':
+        specifier: ^5.2.9
+        version: 5.2.9
+      '@fontsource/geist-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/geist-sans':
+        specifier: ^5.2.5
+        version: 5.2.5
       '@radix-ui/themes':
         specifier: ^3.3.0
         version: 3.3.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -32,6 +44,9 @@ importers:
       '@tauri-apps/plugin-store':
         specifier: ^2.0.0
         version: 2.4.2
+      '@vanilla-extract/css':
+        specifier: ^1.21.1
+        version: 1.21.1
       d3-hierarchy:
         specifier: ^3.1.2
         version: 3.1.2
@@ -108,6 +123,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.0.0
         version: 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      '@vanilla-extract/vite-plugin':
+        specifier: ^5.2.4
+        version: 5.2.4(@types/node@22.19.11)(vite@5.4.21(@types/node@22.19.11))
       '@vitejs/plugin-react':
         specifier: ^4.3.1
         version: 4.7.0(vite@5.4.21(@types/node@22.19.11))
@@ -291,6 +309,33 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@base-ui/react@1.6.0':
+    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
@@ -428,6 +473,9 @@ packages:
       '@effect/platform': ^0.95.0
       '@effect/rpc': ^0.74.0
       effect: ^3.20.0
+
+  '@emotion/hash@0.9.2':
+    resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -784,6 +832,15 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/fraunces@5.2.9':
+    resolution: {integrity: sha512-XDzuddBtoC7BZgZdBn6b7hsFZY2+V1hgN7yca5fBTKuHjb/lOd45a0Ji8dTUgFhPoL7RdGupo+bC2BFSt6UH8Q==}
+
+  '@fontsource/geist-mono@5.2.8':
+    resolution: {integrity: sha512-YqZUb3X42GjRaHkibUNyE8K4Rk9A6I9Ez81YpJYiuJN4ggmTW2ixoQpa9EWCPfXZtIsCQJTyrDoV9OJOZO/UcA==}
+
+  '@fontsource/geist-sans@5.2.5':
+    resolution: {integrity: sha512-anllOHyJbElRs9fV15TeDRqAeb1IKm4bSknPl6ZMoyPTx1BBy7logudcUwpNjmQLkzn4Q0JGQLRCUKJYoyST6A==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2101,6 +2158,26 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vanilla-extract/babel-plugin-debug-ids@1.2.2':
+    resolution: {integrity: sha512-MeDWGICAF9zA/OZLOKwhoRlsUW+fiMwnfuOAqFVohL31Agj7Q/RBWAYweqjHLgFBCsdnr6XIfwjJnmb2znEWxw==}
+
+  '@vanilla-extract/compiler@0.7.1':
+    resolution: {integrity: sha512-mOokbA2k1Lx3BO1/Qa9rpSWiIWeOHBt4aRHX0e5WMDu53//ifojeZJAvdXj/YkZI8z2AruxXYaLX6YlL8jfzyQ==}
+
+  '@vanilla-extract/css@1.21.1':
+    resolution: {integrity: sha512-T6z6oeT+o0OwqukE6kLs9w5ooB75b8NPRadyU9pPTml83l40TPN+mscPt2OQ9P9cYfwEBMfsfivwiJujs2mzmg==}
+
+  '@vanilla-extract/integration@8.0.10':
+    resolution: {integrity: sha512-01IB5gbrgTe8IIrtfRXXTmACl5D8Enzqp2cKbCWaMKXmnoilXXVCPbJoA96q88PXkNDXsXepCxUugMvEmL3c7A==}
+
+  '@vanilla-extract/private@1.0.9':
+    resolution: {integrity: sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA==}
+
+  '@vanilla-extract/vite-plugin@5.2.4':
+    resolution: {integrity: sha512-KXm+Hghpr7/BNIPirsSVD7otMDCwjj9vfgc02CmtYoJ5t4shxQU0QbCRHc9YxlVvAeGvZfE2TmGkvhw2N/L/aw==}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2382,6 +2459,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -2395,6 +2475,10 @@ packages:
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -2442,6 +2526,14 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -2452,6 +2544,13 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deep-object-diff@1.1.9:
+    resolution: {integrity: sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -2637,6 +2736,10 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eval@0.1.8:
+    resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
+    engines: {node: '>= 0.8'}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
@@ -3037,6 +3140,9 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  javascript-stringify@2.1.0:
+    resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -3158,6 +3264,9 @@ packages:
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
+  media-query-parser@2.0.2:
+    resolution: {integrity: sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==}
+
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
@@ -3195,6 +3304,12 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  modern-ahocorasick@1.1.0:
+    resolution: {integrity: sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3335,6 +3450,9 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3492,6 +3610,12 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-like@0.1.2:
+    resolution: {integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3819,6 +3943,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -4229,6 +4356,29 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@base-ui/react@1.6.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.3.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@base-ui/utils@0.3.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@bramus/specificity@2.4.2':
@@ -4364,6 +4514,8 @@ snapshots:
       '@effect/platform': 0.95.0(effect@3.21.2)
       '@effect/rpc': 0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)
       effect: 3.21.2
+
+  '@emotion/hash@0.9.2': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -4576,6 +4728,12 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/fraunces@5.2.9': {}
+
+  '@fontsource/geist-mono@5.2.8': {}
+
+  '@fontsource/geist-sans@5.2.5': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -5885,6 +6043,81 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
+  '@vanilla-extract/babel-plugin-debug-ids@1.2.2':
+    dependencies:
+      '@babel/core': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vanilla-extract/compiler@0.7.1(@types/node@22.19.11)':
+    dependencies:
+      '@vanilla-extract/css': 1.21.1
+      '@vanilla-extract/integration': 8.0.10
+      vite: 5.4.21(@types/node@22.19.11)
+      vite-node: 3.2.4(@types/node@22.19.11)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  '@vanilla-extract/css@1.21.1':
+    dependencies:
+      '@emotion/hash': 0.9.2
+      '@vanilla-extract/private': 1.0.9
+      css-what: 6.2.2
+      csstype: 3.2.3
+      dedent: 1.7.2
+      deep-object-diff: 1.1.9
+      deepmerge: 4.3.1
+      lru-cache: 10.4.3
+      media-query-parser: 2.0.2
+      modern-ahocorasick: 1.1.0
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+
+  '@vanilla-extract/integration@8.0.10':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@vanilla-extract/babel-plugin-debug-ids': 1.2.2
+      '@vanilla-extract/css': 1.21.1
+      dedent: 1.7.2
+      esbuild: 0.28.0
+      eval: 0.1.8
+      find-up: 5.0.0
+      javascript-stringify: 2.1.0
+      mlly: 1.8.2
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  '@vanilla-extract/private@1.0.9': {}
+
+  '@vanilla-extract/vite-plugin@5.2.4(@types/node@22.19.11)(vite@5.4.21(@types/node@22.19.11))':
+    dependencies:
+      '@vanilla-extract/compiler': 0.7.1(@types/node@22.19.11)
+      '@vanilla-extract/integration': 8.0.10
+      vite: 5.4.21(@types/node@22.19.11)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.19.11))':
     dependencies:
       '@babel/core': 7.29.0
@@ -6226,6 +6459,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  confbox@0.1.8: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-es@2.0.0: {}
@@ -6240,6 +6475,8 @@ snapshots:
     dependencies:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
 
@@ -6289,11 +6526,17 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  dedent@1.7.2: {}
+
   deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
+
+  deep-object-diff@1.1.9: {}
+
+  deepmerge@4.3.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -6613,6 +6856,11 @@ snapshots:
       '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
+
+  eval@0.1.8:
+    dependencies:
+      '@types/node': 22.19.11
+      require-like: 0.1.2
 
   eventemitter3@5.0.4: {}
 
@@ -7006,6 +7254,8 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  javascript-stringify@2.1.0: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -7143,6 +7393,10 @@ snapshots:
 
   mdn-data@2.12.2: {}
 
+  media-query-parser@2.0.2:
+    dependencies:
+      '@babel/runtime': 7.29.2
+
   mime@3.0.0: {}
 
   mimic-function@5.0.1: {}
@@ -7168,6 +7422,15 @@ snapshots:
   minipass@7.1.3: {}
 
   mkdirp-classic@0.5.3: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  modern-ahocorasick@1.1.0: {}
 
   ms@2.1.3: {}
 
@@ -7314,6 +7577,12 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
 
   possible-typed-array-names@1.1.0: {}
 
@@ -7538,6 +7807,10 @@ snapshots:
       set-function-name: 2.0.2
 
   require-from-string@2.0.2: {}
+
+  require-like@0.1.2: {}
+
+  reselect@5.2.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -7939,6 +8212,8 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/src/components/app-theme.tsx
+++ b/src/components/app-theme.tsx
@@ -38,5 +38,13 @@ function useResolvedAppearance(): 'light' | 'dark' {
  */
 export function AppTheme({ children }: { children: ReactNode }): JSX.Element {
   const appearance = useResolvedAppearance();
+
+  // Bridge the resolved appearance to the Vanilla Extract tokens (ADR-0014):
+  // `data-theme` drives `src/design/theme.css.ts` so Base UI + VE surfaces stay
+  // in sync with Radix during the migration.
+  useEffect(() => {
+    document.documentElement.dataset.theme = appearance;
+  }, [appearance]);
+
   return <Theme appearance={appearance}>{children}</Theme>;
 }

--- a/src/components/app-theme.tsx
+++ b/src/components/app-theme.tsx
@@ -1,5 +1,5 @@
 import { Theme } from '@radix-ui/themes';
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useState, type ReactNode } from 'react';
 
 import { useAppStore } from '$/store/app-store';
 
@@ -41,8 +41,10 @@ export function AppTheme({ children }: { children: ReactNode }): JSX.Element {
 
   // Bridge the resolved appearance to the Vanilla Extract tokens (ADR-0014):
   // `data-theme` drives `src/design/theme.css.ts` so Base UI + VE surfaces stay
-  // in sync with Radix during the migration.
-  useEffect(() => {
+  // in sync with Radix during the migration. useLayoutEffect (not useEffect) so
+  // the attribute lands before first paint — no wrong-theme flash on launch when
+  // the chosen theme differs from the OS.
+  useLayoutEffect(() => {
     document.documentElement.dataset.theme = appearance;
   }, [appearance]);
 

--- a/src/components/individuals/person-editor-dialog.test.tsx
+++ b/src/components/individuals/person-editor-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState } from 'react';
@@ -148,9 +148,9 @@ describe('PersonEditorDialog', () => {
     await user.click(screen.getByRole('button', { name: 'Add event' }));
     await user.click(await screen.findByRole('button', { name: 'Baptism' }));
 
-    expect(screen.getByText('Baptism')).toBeInTheDocument();
-    const dateInputs = screen.getAllByPlaceholderText('e.g. 30 Jan 1960, abt 1960');
-    const newRowDateInput = dateInputs[dateInputs.length - 1];
+    // The new row's own date field (Death is always present as the last row).
+    const baptismRow = screen.getByText('Baptism').parentElement as HTMLElement;
+    const newRowDateInput = within(baptismRow).getByPlaceholderText('Date');
     await user.type(newRowDateInput, '1 Mar 1960');
     expect(newRowDateInput).toHaveValue('1 Mar 1960');
 
@@ -158,19 +158,24 @@ describe('PersonEditorDialog', () => {
     expect(screen.queryByText('Baptism')).not.toBeInTheDocument();
   });
 
-  it('reveals the death date field only when marked deceased', async () => {
+  it('keeps birth and death present, enabling the death date only when deceased', async () => {
     const user = userEvent.setup();
     renderDialog({ mode: 'create' });
 
-    // Living by default: only the birth event has a date field.
-    expect(screen.getAllByPlaceholderText('e.g. 30 Jan 1960, abt 1960')).toHaveLength(1);
+    // Birth and Death date fields are both always shown.
+    const dateInputs = screen.getAllByPlaceholderText('Date');
+    expect(dateInputs).toHaveLength(2);
+    const deathDate = dateInputs[1];
+
+    // Living by default: the death date is disabled.
+    expect(deathDate).toBeDisabled();
 
     await user.click(screen.getByRole('switch'));
-    expect(screen.getAllByPlaceholderText('e.g. 30 Jan 1960, abt 1960')).toHaveLength(2);
+    expect(deathDate).toBeEnabled();
 
-    // Marking living again hides the death date field.
+    // Marking living again disables the death date.
     await user.click(screen.getByRole('switch'));
-    expect(screen.getAllByPlaceholderText('e.g. 30 Jan 1960, abt 1960')).toHaveLength(1);
+    expect(deathDate).toBeDisabled();
   });
 
   it('picks an existing father via the relation picker, then removes him', async () => {
@@ -265,5 +270,19 @@ describe('PersonEditorDialog', () => {
     expect(screen.getAllByRole('button', { name: 'Add spouse' })).toHaveLength(1);
     await user.click(screen.getByRole('button', { name: 'Add another family' }));
     expect(screen.getAllByRole('button', { name: 'Add spouse' })).toHaveLength(2);
+  });
+
+  it('removes a family from the form', async () => {
+    const user = userEvent.setup();
+    renderDialog({ mode: 'create' });
+
+    await user.click(screen.getByRole('button', { name: 'Add another family' }));
+    expect(screen.getAllByRole('button', { name: 'Add spouse' })).toHaveLength(2);
+
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove this family' });
+    expect(removeButtons).toHaveLength(2);
+    await user.click(removeButtons[0]);
+
+    expect(screen.getAllByRole('button', { name: 'Add spouse' })).toHaveLength(1);
   });
 });

--- a/src/components/individuals/person-editor-dialog.test.tsx
+++ b/src/components/individuals/person-editor-dialog.test.tsx
@@ -285,4 +285,31 @@ describe('PersonEditorDialog', () => {
 
     expect(screen.getAllByRole('button', { name: 'Add spouse' })).toHaveLength(1);
   });
+
+  it('confirms before removing a family that has children', async () => {
+    const user = userEvent.setup();
+    renderDialog({ mode: 'create' });
+
+    // Give the family a child so removing it would detach someone.
+    await user.click(screen.getByRole('button', { name: 'Add child' }));
+    await user.type(screen.getByPlaceholderText('Search by name…'), 'New Kid');
+    await user.click(screen.getByRole('button', { name: 'Create "New Kid"' }));
+    expect(screen.getByText('New Kid')).toBeInTheDocument();
+
+    // Removing now asks for confirmation rather than dropping the family immediately.
+    await user.click(screen.getByRole('button', { name: 'Remove this family' }));
+    expect(screen.getByText('Remove this family?')).toBeInTheDocument();
+    expect(screen.getByText('New Kid')).toBeInTheDocument();
+
+    // Keeping the family dismisses the dialog and leaves the row intact.
+    await user.click(screen.getByRole('button', { name: 'Keep family' }));
+    expect(screen.queryByText('Remove this family?')).not.toBeInTheDocument();
+    expect(screen.getByText('New Kid')).toBeInTheDocument();
+
+    // Confirming removes the family for good.
+    await user.click(screen.getByRole('button', { name: 'Remove this family' }));
+    await user.click(screen.getByRole('button', { name: 'Remove family' }));
+    expect(screen.queryByText('Remove this family?')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add spouse' })).not.toBeInTheDocument();
+  });
 });

--- a/src/components/individuals/person-editor-dialog.tsx
+++ b/src/components/individuals/person-editor-dialog.tsx
@@ -1,24 +1,9 @@
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import {
-  AlertDialog,
-  Avatar,
-  Badge,
-  Button,
-  Callout,
-  Card,
-  Dialog,
-  Flex,
-  Grid,
-  IconButton,
-  SegmentedControl,
-  Select,
-  Switch,
-  Text,
-  TextArea,
-  TextField,
-} from '@radix-ui/themes';
+import { Dialog } from '@base-ui/react/dialog';
+import { Select } from '@base-ui/react/select';
+import { Switch } from '@base-ui/react/switch';
 
 import { Icon } from '$components/icon';
 import { useEventTypes } from '$hooks/useEvents';
@@ -44,6 +29,7 @@ import type {
 import type { PersonEventEntry } from '$db-tree/person-events';
 import { formatLifeYears, initialsFromDisplayName, personDisplayFields } from './person-display';
 import { PersonPicker, type PersonPickerSelection } from './person-picker';
+import * as s from './person-editor.css';
 
 const NAME_TYPES: NameType[] = [
   'birth',
@@ -54,6 +40,8 @@ const NAME_TYPES: NameType[] = [
   'religious',
   'other',
 ];
+
+const SEX_VALUES: Gender[] = ['F', 'M', 'U'];
 
 interface AltNameRow {
   /** Stable React key — the DB id for existing rows, a local id for new ones. */
@@ -328,8 +316,45 @@ function toRelationRef(selection: PersonPickerSelection): RelationPersonRef {
   };
 }
 
-/** Shared height for filled chips and empty "+ Add" triggers so a Parents row's two slots line up whatever their state. */
-const RELATION_SLOT_MIN_HEIGHT = '3.5rem';
+/** Localized-label Base UI select over the alternate-name types. */
+function NameTypeSelect({
+  value,
+  disabled,
+  onValueChange,
+}: {
+  value: NameType;
+  disabled: boolean;
+  onValueChange: (value: NameType) => void;
+}): JSX.Element {
+  const { t } = useTranslation('individuals');
+  return (
+    <Select.Root
+      value={value}
+      disabled={disabled}
+      onValueChange={(next) => {
+        if (next !== null) onValueChange(next as NameType);
+      }}
+    >
+      <Select.Trigger className={s.selbox}>
+        <Select.Value>{(v) => (v ? t(`overview.names.types.${v as NameType}`) : '')}</Select.Value>
+        <Select.Icon className={s.selboxCaret}>
+          <Icon name="chevron-down" size={12} />
+        </Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Positioner sideOffset={4}>
+          <Select.Popup className={s.selectPopup}>
+            {NAME_TYPES.map((nt) => (
+              <Select.Item key={nt} value={nt} className={s.selectItem}>
+                <Select.ItemText>{t(`overview.names.types.${nt}`)}</Select.ItemText>
+              </Select.Item>
+            ))}
+          </Select.Popup>
+        </Select.Positioner>
+      </Select.Portal>
+    </Select.Root>
+  );
+}
 
 interface RelationSlotProps {
   /** Label for the empty "+ Add …" trigger; unused once `person` is filled. */
@@ -359,57 +384,35 @@ function RelationSlot({
   if (person) {
     const dates = formatLifeYears(person.bornYear, person.deathYear);
     return (
-      <Card size="1" style={{ minHeight: RELATION_SLOT_MIN_HEIGHT }}>
-        <Flex align="center" justify="between" gap="3" height="100%">
-          <Flex align="center" gap="3" overflow="hidden">
-            <span aria-hidden="true">
-              <Avatar
-                size="2"
-                radius="full"
-                color="gray"
-                fallback={initialsFromDisplayName(person.displayName)}
-              />
-            </span>
-            <Flex direction="column" overflow="hidden">
-              <Text size="2" weight="medium" truncate>
-                {person.displayName}
-              </Text>
-              {dates && (
-                <Text size="1" color="gray">
-                  {dates}
-                </Text>
-              )}
-            </Flex>
-          </Flex>
-          <IconButton
-            type="button"
-            variant="ghost"
-            color="gray"
-            disabled={disabled}
-            aria-label={t('personEditor.relations.removeAria')}
-            onClick={onRemove}
-          >
-            <Icon name="x" />
-          </IconButton>
-        </Flex>
-      </Card>
+      <div className={s.pfield}>
+        <span className={s.pfieldAvatar} aria-hidden="true">
+          {initialsFromDisplayName(person.displayName)}
+        </span>
+        <span className={s.pfieldBody}>
+          <span className={s.pfieldName}>{person.displayName}</span>
+          {dates && <span className={s.pfieldDates}>{dates}</span>}
+        </span>
+        <button
+          type="button"
+          className={s.iconbtn}
+          disabled={disabled}
+          aria-label={t('personEditor.relations.removeAria')}
+          onClick={onRemove}
+        >
+          <Icon name="x" size={16} />
+        </button>
+      </div>
     );
   }
 
   return (
-    <PersonPicker onSelect={onPick!} excludeIds={excludeIds} newPersonGender={newPersonGender}>
-      <Button
-        type="button"
-        variant="outline"
-        color="gray"
-        size="2"
-        disabled={disabled}
-        style={{ width: '100%', minHeight: RELATION_SLOT_MIN_HEIGHT }}
-      >
-        <Icon name="plus" />
-        {label}
-      </Button>
-    </PersonPicker>
+    <PersonPicker
+      label={label}
+      onSelect={onPick!}
+      excludeIds={excludeIds}
+      newPersonGender={newPersonGender}
+      disabled={disabled}
+    />
   );
 }
 
@@ -423,7 +426,7 @@ interface EventDateRowProps {
   onRemove?: () => void;
 }
 
-/** One life-event row: label, free-text date field, a "place — soon" badge, and (for removable rows) a remove control. */
+/** One life-event row: type, free-text date field, a "place — soon" note, and (for removable rows) a remove control. */
 function EventDateRow({
   label,
   dateOriginal,
@@ -433,34 +436,30 @@ function EventDateRow({
 }: EventDateRowProps): JSX.Element {
   const { t } = useTranslation('individuals');
   return (
-    <Grid columns="110px 1fr 90px 32px" gap="2" align="center">
-      <Text size="2" weight="medium">
-        {label}
-      </Text>
-      <TextField.Root
+    <div className={s.eventrow}>
+      <span className={s.eventType}>{label}</span>
+      <input
+        className={`${s.input} ${s.tnum} ${s.wDate}`}
         placeholder={t('personEditor.lifeEvents.datePlaceholder')}
         value={dateOriginal}
         disabled={disabled}
         onChange={(e) => onChangeDate(e.target.value)}
       />
-      <Badge variant="outline" color="gray" size="1">
-        {t('personEditor.lifeEvents.placeSoon')}
-      </Badge>
+      <span className={s.eplace}>{t('personEditor.lifeEvents.placeSoon')}</span>
       {onRemove ? (
-        <IconButton
+        <button
           type="button"
-          variant="ghost"
-          color="gray"
+          className={s.iconbtn}
           disabled={disabled}
           aria-label={t('personEditor.lifeEvents.removeAria')}
           onClick={onRemove}
         >
-          <Icon name="x" />
-        </IconButton>
+          <Icon name="x" size={16} />
+        </button>
       ) : (
-        <div />
+        <span />
       )}
-    </Grid>
+    </div>
   );
 }
 
@@ -471,12 +470,13 @@ export type PersonEditorDialogProps = {
 } & ({ mode: 'create' } | { mode: 'edit'; individualId: string });
 
 /**
- * The shared create/edit form for a Person, as a Radix `Dialog` openable from
+ * The shared create/edit form for a Person, as a Base UI `Dialog` openable from
  * anywhere (the People list and the Person Overview). Covers identity
  * (primary + alternate names, sex, living status), a generic typed life-events
  * list (dates only — a place picker lands later, see the Person editor PRD),
  * notes, and relations (parents, spouse families, children) via the
- * search-or-create {@link PersonPicker}.
+ * search-or-create {@link PersonPicker}. Styled from the warm-earth tokens
+ * (ADR-0014).
  */
 export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element {
   const { open, onOpenChange, onSaved } = props;
@@ -495,14 +495,6 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
   const spouseFamiliesQuery = useSpouseFamilies(individualId ?? '', {
     enabled: mode === 'edit' && open,
   });
-
-  const givenNamesId = useId();
-  const surnameId = useId();
-  const prefixId = useId();
-  const suffixId = useId();
-  const nicknameId = useId();
-  const sexId = useId();
-  const notesId = useId();
 
   const [form, setForm] = useState<FormState>(() => emptyForm());
   const [hydrated, setHydrated] = useState(false);
@@ -617,6 +609,14 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
       return;
     }
     reallyClose();
+  }
+
+  function handleDialogOpenChange(nextOpen: boolean): void {
+    if (nextOpen) {
+      onOpenChange(true);
+      return;
+    }
+    attemptClose();
   }
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>): void {
@@ -737,430 +737,420 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
 
   const title = mode === 'create' ? t('personEditor.createTitle') : t('personEditor.editTitle');
   const showForm = mode === 'create' || hydrated;
+  const subtitle = `${form.givenNames} ${form.surname}`.trim();
+  const excludeSelf = individualId ? [individualId] : undefined;
 
   return (
     <>
-      <Dialog.Root
-        open={open}
-        onOpenChange={(next) => {
-          if (next) {
-            onOpenChange(true);
-            return;
-          }
-          attemptClose();
-        }}
-      >
-        {/* No Dialog.Description — the title alone is clear; this opts out of
-            Radix's a11y warning intentionally rather than adding filler copy. */}
-        <Dialog.Content width="95vw" maxWidth="1400px" aria-describedby={undefined}>
-          <Dialog.Title mb="4">{title}</Dialog.Title>
+      <Dialog.Root open={open} onOpenChange={handleDialogOpenChange}>
+        <Dialog.Portal>
+          <Dialog.Backdrop className={s.backdrop} />
+          <Dialog.Popup className={s.modal} aria-describedby={undefined}>
+            <div className={s.mhead}>
+              <div className={s.headAvatar} aria-hidden="true">
+                {initialsFromDisplayName(subtitle)}
+              </div>
+              <div>
+                <Dialog.Title className={s.headTitle}>{title}</Dialog.Title>
+                {subtitle && <div className={s.headSub}>{subtitle}</div>}
+              </div>
+              <span className={s.grow} />
+              <button
+                type="button"
+                className={s.iconbtn}
+                aria-label={t('personEditor.actions.close')}
+                disabled={mutation.isPending}
+                onClick={attemptClose}
+              >
+                <Icon name="x" size={16} />
+              </button>
+            </div>
 
-          {!showForm ? (
-            <Text size="2" color="gray">
-              {t('overview.loading')}
-            </Text>
-          ) : (
-            <form id="person-editor-form" onSubmit={handleSubmit}>
-              <Grid columns={{ initial: '1', md: '2' }} gap="4">
-                {/* Left column: names, sex, notes */}
-                <Flex direction="column" gap="4">
-                  <Card>
-                    <Flex direction="column" gap="3">
-                      <Text size="1" weight="bold" color="gray">
-                        {t('personEditor.sections.names')}
-                      </Text>
-                      <Grid columns="2" gap="3">
-                        <Flex direction="column" gap="1">
-                          <Text as="label" htmlFor={givenNamesId} size="1" weight="medium">
-                            {t('personEditor.fields.givenNames')}
-                          </Text>
-                          <TextField.Root
-                            id={givenNamesId}
-                            value={form.givenNames}
-                            disabled={mutation.isPending}
-                            onChange={(e) =>
-                              setForm((prev) => ({ ...prev, givenNames: e.target.value }))
-                            }
-                          />
-                        </Flex>
-                        <Flex direction="column" gap="1">
-                          <Text as="label" htmlFor={surnameId} size="1" weight="medium">
-                            {t('personEditor.fields.surname')}
-                          </Text>
-                          <TextField.Root
-                            id={surnameId}
-                            value={form.surname}
-                            disabled={mutation.isPending}
-                            onChange={(e) =>
-                              setForm((prev) => ({ ...prev, surname: e.target.value }))
-                            }
-                          />
-                        </Flex>
-                      </Grid>
-                      <Grid columns="3" gap="3">
-                        <Flex direction="column" gap="1">
-                          <Text as="label" htmlFor={prefixId} size="1" weight="medium">
-                            {t('personEditor.fields.prefix')}
-                          </Text>
-                          <TextField.Root
-                            id={prefixId}
-                            value={form.prefix}
-                            disabled={mutation.isPending}
-                            onChange={(e) =>
-                              setForm((prev) => ({ ...prev, prefix: e.target.value }))
-                            }
-                          />
-                        </Flex>
-                        <Flex direction="column" gap="1">
-                          <Text as="label" htmlFor={suffixId} size="1" weight="medium">
-                            {t('personEditor.fields.suffix')}
-                          </Text>
-                          <TextField.Root
-                            id={suffixId}
-                            value={form.suffix}
-                            disabled={mutation.isPending}
-                            onChange={(e) =>
-                              setForm((prev) => ({ ...prev, suffix: e.target.value }))
-                            }
-                          />
-                        </Flex>
-                        <Flex direction="column" gap="1">
-                          <Text as="label" htmlFor={nicknameId} size="1" weight="medium">
-                            {t('personEditor.fields.nickname')}
-                          </Text>
-                          <TextField.Root
-                            id={nicknameId}
-                            value={form.nickname}
-                            disabled={mutation.isPending}
-                            onChange={(e) =>
-                              setForm((prev) => ({ ...prev, nickname: e.target.value }))
-                            }
-                          />
-                        </Flex>
-                      </Grid>
-
-                      <Text size="1" weight="medium" color="gray" mt="2">
-                        {t('personEditor.sections.otherNames')}
-                      </Text>
-                      <Flex direction="column" gap="2">
-                        {form.alternateNames.map((row) => (
-                          <Grid key={row.key} columns="160px 1fr 1fr 32px" gap="2" align="center">
-                            <Select.Root
-                              value={row.type}
-                              disabled={mutation.isPending}
-                              onValueChange={(next) =>
-                                updateAltName(row.key, { type: next as NameType })
-                              }
-                            >
-                              <Select.Trigger />
-                              <Select.Content>
-                                {NAME_TYPES.map((nt) => (
-                                  <Select.Item key={nt} value={nt}>
-                                    {t(`overview.names.types.${nt}`)}
-                                  </Select.Item>
-                                ))}
-                              </Select.Content>
-                            </Select.Root>
-                            <TextField.Root
-                              placeholder={t('personEditor.fields.givenNames')}
-                              value={row.givenNames}
+            <div className={s.mbody}>
+              {!showForm ? (
+                <div className={s.loadingText}>{t('overview.loading')}</div>
+              ) : (
+                <form id="person-editor-form" onSubmit={handleSubmit}>
+                  <div className={s.cols}>
+                    {/* Left column: names, life events, notes */}
+                    <div className={s.col}>
+                      <div className={s.ecard}>
+                        <div className={s.sectitle}>{t('personEditor.sections.names')}</div>
+                        <div className={s.subhead}>{t('personEditor.sections.primaryName')}</div>
+                        <div className={s.fgridC2}>
+                          <label className={s.field}>
+                            <span className={s.fieldLabel}>
+                              {t('personEditor.fields.givenNames')}
+                            </span>
+                            <input
+                              className={s.input}
+                              value={form.givenNames}
                               disabled={mutation.isPending}
                               onChange={(e) =>
-                                updateAltName(row.key, { givenNames: e.target.value })
+                                setForm((prev) => ({ ...prev, givenNames: e.target.value }))
                               }
                             />
-                            <TextField.Root
-                              placeholder={t('personEditor.fields.surname')}
-                              value={row.surname}
+                          </label>
+                          <label className={s.field}>
+                            <span className={s.fieldLabel}>{t('personEditor.fields.surname')}</span>
+                            <input
+                              className={s.input}
+                              value={form.surname}
                               disabled={mutation.isPending}
-                              onChange={(e) => updateAltName(row.key, { surname: e.target.value })}
+                              onChange={(e) =>
+                                setForm((prev) => ({ ...prev, surname: e.target.value }))
+                              }
                             />
-                            <IconButton
-                              type="button"
-                              variant="ghost"
-                              color="gray"
+                          </label>
+                        </div>
+                        <div className={s.fgrid3Gap}>
+                          <label className={s.field}>
+                            <span className={s.fieldLabel}>{t('personEditor.fields.prefix')}</span>
+                            <input
+                              className={s.input}
+                              value={form.prefix}
                               disabled={mutation.isPending}
-                              aria-label={t('personEditor.otherNames.removeAria')}
-                              onClick={() => removeAltName(row.key)}
-                            >
-                              <Icon name="x" />
-                            </IconButton>
-                          </Grid>
-                        ))}
-                        <Flex justify="start">
-                          <Button
+                              onChange={(e) =>
+                                setForm((prev) => ({ ...prev, prefix: e.target.value }))
+                              }
+                            />
+                          </label>
+                          <label className={s.field}>
+                            <span className={s.fieldLabel}>{t('personEditor.fields.suffix')}</span>
+                            <input
+                              className={s.input}
+                              value={form.suffix}
+                              disabled={mutation.isPending}
+                              onChange={(e) =>
+                                setForm((prev) => ({ ...prev, suffix: e.target.value }))
+                              }
+                            />
+                          </label>
+                          <label className={s.field}>
+                            <span className={s.fieldLabel}>
+                              {t('personEditor.fields.nickname')}
+                            </span>
+                            <input
+                              className={s.input}
+                              value={form.nickname}
+                              disabled={mutation.isPending}
+                              onChange={(e) =>
+                                setForm((prev) => ({ ...prev, nickname: e.target.value }))
+                              }
+                            />
+                          </label>
+                        </div>
+
+                        <div className={`${s.subhead} ${s.subheadMt}`}>
+                          {t('personEditor.sections.otherNames')}
+                        </div>
+                        <div className={s.stack}>
+                          {form.alternateNames.map((row) => (
+                            <div key={row.key} className={s.altrow}>
+                              <input
+                                className={s.input}
+                                placeholder={t('personEditor.fields.givenNames')}
+                                value={row.givenNames}
+                                disabled={mutation.isPending}
+                                onChange={(e) =>
+                                  updateAltName(row.key, { givenNames: e.target.value })
+                                }
+                              />
+                              <input
+                                className={s.input}
+                                placeholder={t('personEditor.fields.surname')}
+                                value={row.surname}
+                                disabled={mutation.isPending}
+                                onChange={(e) =>
+                                  updateAltName(row.key, { surname: e.target.value })
+                                }
+                              />
+                              <NameTypeSelect
+                                value={row.type}
+                                disabled={mutation.isPending}
+                                onValueChange={(type) => updateAltName(row.key, { type })}
+                              />
+                              <button
+                                type="button"
+                                className={s.iconbtn}
+                                disabled={mutation.isPending}
+                                aria-label={t('personEditor.otherNames.removeAria')}
+                                onClick={() => removeAltName(row.key)}
+                              >
+                                <Icon name="x" size={16} />
+                              </button>
+                            </div>
+                          ))}
+                          <button
                             type="button"
-                            variant="soft"
-                            color="gray"
-                            size="1"
+                            className={s.addbtn}
                             disabled={mutation.isPending}
                             onClick={addAltName}
                           >
-                            <Icon name="plus" />
+                            <Icon name="plus" size={14} />
                             {t('personEditor.otherNames.addButton')}
-                          </Button>
-                        </Flex>
-                      </Flex>
-                    </Flex>
-                  </Card>
+                          </button>
+                        </div>
+                      </div>
 
-                  <Card>
-                    <Flex direction="column" gap="2">
-                      <Text id={sexId} size="1" weight="bold" color="gray">
-                        {t('personEditor.sex.label')}
-                      </Text>
-                      <SegmentedControl.Root
-                        aria-labelledby={sexId}
-                        value={form.gender}
-                        onValueChange={(next) =>
-                          setForm((prev) => ({ ...prev, gender: next as Gender }))
-                        }
-                      >
-                        <SegmentedControl.Item value="F">{t('table.sex.F')}</SegmentedControl.Item>
-                        <SegmentedControl.Item value="M">{t('table.sex.M')}</SegmentedControl.Item>
-                        <SegmentedControl.Item value="U">{t('table.sex.U')}</SegmentedControl.Item>
-                      </SegmentedControl.Root>
-                    </Flex>
-                  </Card>
+                      <div className={s.ecard}>
+                        <div className={s.sectitle}>{t('personEditor.sections.lifeEvents')}</div>
+                        <div className={s.hint}>{t('personEditor.sections.lifeEventsHint')}</div>
+                        <div className={s.eventlist}>
+                          {timelineEvents.map((row) => (
+                            <EventDateRow
+                              key={row.key}
+                              label={eventRowLabel(row.tag, eventTypesByTag, t)}
+                              dateOriginal={row.dateOriginal}
+                              disabled={mutation.isPending}
+                              onChangeDate={(value) => updateEventDate(row.key, value)}
+                              onRemove={row.removable ? () => removeEvent(row.key) : undefined}
+                            />
+                          ))}
+                        </div>
+                        <div className={s.hint}>{t('personEditor.lifeEvents.dateHint')}</div>
 
-                  <Card>
-                    <Flex direction="column" gap="2">
-                      <Text as="label" htmlFor={notesId} size="1" weight="bold" color="gray">
-                        {t('personEditor.sections.notes')}
-                      </Text>
-                      <TextArea
-                        id={notesId}
-                        value={form.notes}
-                        disabled={mutation.isPending}
-                        onChange={(e) => setForm((prev) => ({ ...prev, notes: e.target.value }))}
-                      />
-                    </Flex>
-                  </Card>
-                </Flex>
-
-                {/* Right column: life events, relations */}
-                <Flex direction="column" gap="4">
-                  <Card>
-                    <Flex direction="column" gap="3">
-                      <Flex align="center" justify="between">
-                        <Text size="1" weight="bold" color="gray">
-                          {t('personEditor.sections.lifeEvents')}
-                        </Text>
-                      </Flex>
-                      <Text size="1" color="gray">
-                        {t('personEditor.sections.lifeEventsHint')}
-                      </Text>
-                      <Flex direction="column" gap="2">
-                        {timelineEvents.map((row) => (
-                          <EventDateRow
-                            key={row.key}
-                            label={eventRowLabel(row.tag, eventTypesByTag, t)}
-                            dateOriginal={row.dateOriginal}
-                            disabled={mutation.isPending}
-                            onChangeDate={(value) => updateEventDate(row.key, value)}
-                            onRemove={row.removable ? () => removeEvent(row.key) : undefined}
-                          />
-                        ))}
-                      </Flex>
-                      <Text size="1" color="gray">
-                        {t('personEditor.lifeEvents.dateHint')}
-                      </Text>
-
-                      <Flex direction="column" gap="2">
-                        <Flex justify="start">
-                          <Button
+                        <div className={s.addWrap}>
+                          <button
                             type="button"
-                            variant="soft"
-                            color="gray"
-                            size="1"
+                            className={s.addbtn}
                             disabled={mutation.isPending}
                             onClick={() => setAddEventMenuOpen((v) => !v)}
                           >
-                            <Icon name="plus" />
+                            <Icon name="plus" size={14} />
                             {t('personEditor.lifeEvents.addButton')}
-                          </Button>
-                        </Flex>
-                        {addEventMenuOpen && (
-                          <Grid columns="2" gap="2">
-                            {pickableEventTypes.map((et) => (
-                              <Button
-                                key={et.id}
-                                type="button"
-                                variant="surface"
-                                color="gray"
-                                size="1"
-                                onClick={() => addEvent(et)}
-                              >
-                                {eventTypeLabel(et, t)}
-                              </Button>
-                            ))}
-                          </Grid>
-                        )}
-                      </Flex>
+                          </button>
+                          {addEventMenuOpen && (
+                            <div className={s.typegrid}>
+                              {pickableEventTypes.map((et) => (
+                                <button
+                                  key={et.id}
+                                  type="button"
+                                  className={s.typegridBtn}
+                                  onClick={() => addEvent(et)}
+                                >
+                                  {eventTypeLabel(et, t)}
+                                </button>
+                              ))}
+                            </div>
+                          )}
+                        </div>
 
-                      <Flex direction="column" gap="2" mt="2">
-                        <Text as="label" size="2" weight="medium">
-                          <Flex align="center" gap="2">
-                            <Switch
-                              checked={!form.isLiving}
-                              disabled={mutation.isPending}
-                              onCheckedChange={setDeceased}
-                            />
-                            {t('personEditor.status.deceased')}
-                          </Flex>
-                        </Text>
-                        {!form.isLiving && deathRow && (
-                          <EventDateRow
-                            label={eventRowLabel(deathRow.tag, eventTypesByTag, t)}
-                            dateOriginal={deathRow.dateOriginal}
+                        <div className={s.statusrow}>
+                          <Switch.Root
+                            className={s.switchRoot}
+                            checked={!form.isLiving}
                             disabled={mutation.isPending}
-                            onChangeDate={(value) => updateEventDate(deathRow.key, value)}
-                          />
+                            onCheckedChange={(checked) => setDeceased(checked)}
+                          >
+                            <Switch.Thumb className={s.switchThumb} />
+                          </Switch.Root>
+                          <span className={s.switchLabel}>{t('personEditor.status.deceased')}</span>
+                        </div>
+                        {!form.isLiving && deathRow && (
+                          <div className={s.deathField}>
+                            <EventDateRow
+                              label={eventRowLabel(deathRow.tag, eventTypesByTag, t)}
+                              dateOriginal={deathRow.dateOriginal}
+                              disabled={mutation.isPending}
+                              onChangeDate={(value) => updateEventDate(deathRow.key, value)}
+                            />
+                          </div>
                         )}
-                      </Flex>
-                    </Flex>
-                  </Card>
+                      </div>
 
-                  <Card>
-                    <Flex direction="column" gap="3">
-                      <Text size="1" weight="bold" color="gray">
-                        {t('personEditor.sections.relations')}
-                      </Text>
+                      <div className={s.ecard}>
+                        <div className={s.sectitle}>{t('personEditor.sections.notes')}</div>
+                        <textarea
+                          className={s.textarea}
+                          aria-label={t('personEditor.sections.notes')}
+                          value={form.notes}
+                          disabled={mutation.isPending}
+                          onChange={(e) => setForm((prev) => ({ ...prev, notes: e.target.value }))}
+                        />
+                      </div>
+                    </div>
 
-                      <Flex direction="column" gap="2">
-                        <Text size="1" weight="medium" color="gray">
-                          {t('overview.parents.title')}
-                        </Text>
-                        <Grid columns="2" gap="3">
+                    {/* Right column: sex, relations */}
+                    <div className={s.col}>
+                      <div className={s.ecard}>
+                        <div className={s.sectitle}>{t('personEditor.sex.label')}</div>
+                        <div className={s.rrow}>
+                          <span className={s.rl}>{t('personEditor.sex.label')}</span>
+                          <div
+                            className={s.seg}
+                            role="radiogroup"
+                            aria-label={t('personEditor.sex.label')}
+                          >
+                            {SEX_VALUES.map((value) => (
+                              <button
+                                key={value}
+                                type="button"
+                                role="radio"
+                                aria-checked={form.gender === value}
+                                className={`${s.segItem} ${form.gender === value ? s.segItemOn : ''}`}
+                                disabled={mutation.isPending}
+                                onClick={() => setForm((prev) => ({ ...prev, gender: value }))}
+                              >
+                                {t(`table.sex.${value}`)}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className={s.ecard}>
+                        <div className={s.sectitle}>{t('personEditor.sections.relations')}</div>
+
+                        <div className={s.subhead}>{t('overview.parents.title')}</div>
+                        <div className={s.relrow2}>
+                          <span className={s.relLabel}>
+                            {t('personEditor.relations.fatherLabel')}
+                          </span>
                           <RelationSlot
                             label={t('personEditor.relations.addFather')}
                             person={form.father}
                             disabled={mutation.isPending}
-                            excludeIds={individualId ? [individualId] : undefined}
+                            excludeIds={excludeSelf}
                             newPersonGender="M"
                             onPick={(selection) => setParentSlot('father', selection)}
                             onRemove={() => removeParentSlot('father')}
                           />
+                        </div>
+                        <div className={s.relrow2}>
+                          <span className={s.relLabel}>
+                            {t('personEditor.relations.motherLabel')}
+                          </span>
                           <RelationSlot
                             label={t('personEditor.relations.addMother')}
                             person={form.mother}
                             disabled={mutation.isPending}
-                            excludeIds={individualId ? [individualId] : undefined}
+                            excludeIds={excludeSelf}
                             newPersonGender="F"
                             onPick={(selection) => setParentSlot('mother', selection)}
                             onRemove={() => removeParentSlot('mother')}
                           />
-                        </Grid>
-                      </Flex>
+                        </div>
 
-                      {form.families.map((row) => (
-                        <Card key={row.key} variant="surface">
-                          <Flex direction="column" gap="3">
-                            <Flex direction="column" gap="2">
-                              <Text size="1" weight="medium" color="gray">
+                        {form.families.map((row) => (
+                          <div key={row.key} className={s.familyCard}>
+                            <div className={s.relrow2}>
+                              <span className={s.relLabel}>
                                 {t('personEditor.relations.spouse')}
-                              </Text>
+                              </span>
                               <RelationSlot
                                 label={t('personEditor.relations.addSpouse')}
                                 person={row.spouse}
                                 disabled={mutation.isPending}
-                                excludeIds={individualId ? [individualId] : undefined}
+                                excludeIds={excludeSelf}
                                 newPersonGender={spouseGenderGuess(form.gender)}
                                 onPick={(selection) => pickSpouse(row.key, selection)}
                                 onRemove={() => removeSpouse(row.key)}
                               />
-                            </Flex>
-                            <Flex direction="column" gap="2">
-                              <Text size="1" weight="medium" color="gray">
+                            </div>
+                            <div className={s.relrow2}>
+                              <span className={s.relLabel}>
                                 {t('personEditor.relations.children')}
-                              </Text>
-                              {row.children.map((child) => (
+                              </span>
+                              <div className={s.childstack}>
+                                {row.children.map((child) => (
+                                  <RelationSlot
+                                    key={child.key}
+                                    label=""
+                                    person={child}
+                                    disabled={mutation.isPending}
+                                    onRemove={() => removeChild(row.key, child.key)}
+                                  />
+                                ))}
                                 <RelationSlot
-                                  key={child.key}
-                                  label=""
-                                  person={child}
+                                  label={t('personEditor.relations.addChild')}
+                                  person={null}
                                   disabled={mutation.isPending}
-                                  onRemove={() => removeChild(row.key, child.key)}
+                                  excludeIds={excludeSelf}
+                                  onPick={(selection) => addChild(row.key, selection)}
                                 />
-                              ))}
-                              <RelationSlot
-                                label={t('personEditor.relations.addChild')}
-                                person={null}
-                                disabled={mutation.isPending}
-                                excludeIds={individualId ? [individualId] : undefined}
-                                onPick={(selection) => addChild(row.key, selection)}
-                              />
-                            </Flex>
-                          </Flex>
-                        </Card>
-                      ))}
+                              </div>
+                            </div>
+                          </div>
+                        ))}
 
-                      <Button
-                        type="button"
-                        variant="soft"
-                        color="gray"
-                        size="2"
-                        disabled={mutation.isPending}
-                        onClick={addFamily}
-                      >
-                        <Icon name="plus" />
-                        {t('personEditor.relations.addFamily')}
-                      </Button>
-                    </Flex>
-                  </Card>
-                </Flex>
-              </Grid>
+                        <div className={s.familyActions}>
+                          <button
+                            type="button"
+                            className={s.addbtn}
+                            disabled={mutation.isPending}
+                            onClick={addFamily}
+                          >
+                            <Icon name="plus" size={14} />
+                            {t('personEditor.relations.addFamily')}
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
 
-              {mutation.isError && (
-                <Callout.Root color="red" size="1" role="alert" mt="4">
-                  <Callout.Text>{t('personEditor.errorGeneric')}</Callout.Text>
-                </Callout.Root>
+                  {mutation.isError && (
+                    <div className={s.callout} role="alert">
+                      {t('personEditor.errorGeneric')}
+                    </div>
+                  )}
+                </form>
               )}
-            </form>
-          )}
+            </div>
 
-          <Flex gap="3" mt="4" justify="end">
-            <Button
-              variant="soft"
-              color="gray"
-              onClick={attemptClose}
-              disabled={mutation.isPending}
-            >
-              {t('personEditor.actions.cancel')}
-            </Button>
-            <Button
-              type="submit"
-              form="person-editor-form"
-              disabled={!showForm || mutation.isPending}
-            >
-              {mode === 'create'
-                ? t('personEditor.actions.saveNew')
-                : t('personEditor.actions.save')}
-            </Button>
-          </Flex>
-        </Dialog.Content>
+            <div className={s.mfoot}>
+              {isDirty && (
+                <span className={s.dirty}>{t('personEditor.unsavedChanges.indicator')}</span>
+              )}
+              <span className={s.grow} />
+              <button
+                type="button"
+                className={s.btnGhost}
+                onClick={attemptClose}
+                disabled={mutation.isPending}
+              >
+                {t('personEditor.actions.cancel')}
+              </button>
+              <button
+                type="submit"
+                form="person-editor-form"
+                className={s.btnSolid}
+                disabled={!showForm || mutation.isPending}
+              >
+                {mode === 'create'
+                  ? t('personEditor.actions.saveNew')
+                  : t('personEditor.actions.save')}
+              </button>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Portal>
       </Dialog.Root>
 
-      <AlertDialog.Root open={confirmDiscardOpen} onOpenChange={setConfirmDiscardOpen}>
-        <AlertDialog.Content maxWidth="440px">
-          <AlertDialog.Title>{t('personEditor.unsavedChanges.title')}</AlertDialog.Title>
-          <AlertDialog.Description size="2">
-            {t('personEditor.unsavedChanges.description')}
-          </AlertDialog.Description>
-          <Flex gap="3" mt="4" justify="end">
-            <AlertDialog.Cancel>
-              <Button variant="soft" color="gray">
+      <Dialog.Root open={confirmDiscardOpen} onOpenChange={setConfirmDiscardOpen}>
+        <Dialog.Portal>
+          <Dialog.Backdrop className={s.alertBackdrop} />
+          <Dialog.Popup className={s.alertPopup}>
+            <Dialog.Title className={s.alertTitle}>
+              {t('personEditor.unsavedChanges.title')}
+            </Dialog.Title>
+            <Dialog.Description className={s.alertDesc}>
+              {t('personEditor.unsavedChanges.description')}
+            </Dialog.Description>
+            <div className={s.alertActions}>
+              <button
+                type="button"
+                className={s.btnGhost}
+                onClick={() => setConfirmDiscardOpen(false)}
+              >
                 {t('personEditor.unsavedChanges.keepEditing')}
-              </Button>
-            </AlertDialog.Cancel>
-            <AlertDialog.Action>
-              <Button color="red" onClick={reallyClose}>
+              </button>
+              <button type="button" className={s.btnDanger} onClick={reallyClose}>
                 {t('personEditor.unsavedChanges.discard')}
-              </Button>
-            </AlertDialog.Action>
-          </Flex>
-        </AlertDialog.Content>
-      </AlertDialog.Root>
+              </button>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>
     </>
   );
 }

--- a/src/components/individuals/person-editor-dialog.tsx
+++ b/src/components/individuals/person-editor-dialog.tsx
@@ -499,6 +499,7 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
   const [hydrated, setHydrated] = useState(false);
   const [addEventMenuOpen, setAddEventMenuOpen] = useState(false);
   const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
+  const [confirmRemoveFamilyKey, setConfirmRemoveFamilyKey] = useState<string | null>(null);
   const initialSnapshotRef = useRef('');
 
   useEffect(() => {
@@ -716,6 +717,20 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
 
   function removeFamily(key: string): void {
     setForm((prev) => ({ ...prev, families: prev.families.filter((row) => row.key !== key) }));
+  }
+
+  // Removing a family with children detaches those children — confirm first.
+  function requestRemoveFamily(row: FamilyRelationRow): void {
+    if (row.children.length > 0) {
+      setConfirmRemoveFamilyKey(row.key);
+      return;
+    }
+    removeFamily(row.key);
+  }
+
+  function confirmRemoveFamily(): void {
+    if (confirmRemoveFamilyKey) removeFamily(confirmRemoveFamilyKey);
+    setConfirmRemoveFamilyKey(null);
   }
 
   const eventTypesByTag = new Map(
@@ -1056,7 +1071,7 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
                                 className={s.iconbtn}
                                 disabled={mutation.isPending}
                                 aria-label={t('personEditor.relations.removeFamilyAria')}
-                                onClick={() => removeFamily(row.key)}
+                                onClick={() => requestRemoveFamily(row)}
                               >
                                 <Icon name="x" size={16} />
                               </button>
@@ -1173,6 +1188,41 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
               </button>
               <button type="button" className={s.btnDanger} onClick={reallyClose}>
                 {t('personEditor.unsavedChanges.discard')}
+              </button>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      <Dialog.Root
+        open={confirmRemoveFamilyKey !== null}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setConfirmRemoveFamilyKey(null);
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Backdrop className={s.alertBackdrop} />
+          <Dialog.Popup className={s.alertPopup}>
+            <Dialog.Title className={s.alertTitle}>
+              {t('personEditor.removeFamilyConfirm.title')}
+            </Dialog.Title>
+            <Dialog.Description className={s.alertDesc}>
+              {t('personEditor.removeFamilyConfirm.description', {
+                count:
+                  form.families.find((row) => row.key === confirmRemoveFamilyKey)?.children
+                    .length ?? 0,
+              })}
+            </Dialog.Description>
+            <div className={s.alertActions}>
+              <button
+                type="button"
+                className={s.btnGhost}
+                onClick={() => setConfirmRemoveFamilyKey(null)}
+              >
+                {t('personEditor.removeFamilyConfirm.keepFamily')}
+              </button>
+              <button type="button" className={s.btnDanger} onClick={confirmRemoveFamily}>
+                {t('personEditor.removeFamilyConfirm.confirm')}
               </button>
             </div>
           </Dialog.Popup>

--- a/src/components/individuals/person-editor-dialog.tsx
+++ b/src/components/individuals/person-editor-dialog.tsx
@@ -342,7 +342,7 @@ function NameTypeSelect({
         </Select.Icon>
       </Select.Trigger>
       <Select.Portal>
-        <Select.Positioner sideOffset={4}>
+        <Select.Positioner sideOffset={4} positionMethod="fixed" className={s.positionerZ}>
           <Select.Popup className={s.selectPopup}>
             {NAME_TYPES.map((nt) => (
               <Select.Item key={nt} value={nt} className={s.selectItem}>

--- a/src/components/individuals/person-editor-dialog.tsx
+++ b/src/components/individuals/person-editor-dialog.tsx
@@ -506,6 +506,8 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
     if (!open) {
       setHydrated(false);
       setAddEventMenuOpen(false);
+      setConfirmDiscardOpen(false);
+      setConfirmRemoveFamilyKey(null);
       return;
     }
     if (mode === 'create') {

--- a/src/components/individuals/person-editor-dialog.tsx
+++ b/src/components/individuals/person-editor-dialog.tsx
@@ -426,7 +426,7 @@ interface EventDateRowProps {
   onRemove?: () => void;
 }
 
-/** One life-event row: type, free-text date field, a "place — soon" note, and (for removable rows) a remove control. */
+/** One life-event row: type, free-text date field, a (still disabled) place field, and (for removable rows) a remove control. */
 function EventDateRow({
   label,
   dateOriginal,
@@ -435,18 +435,19 @@ function EventDateRow({
   onRemove,
 }: EventDateRowProps): JSX.Element {
   const { t } = useTranslation('individuals');
+  const placeLabel = t('personEditor.lifeEvents.place');
   return (
-    <div className={s.eventrow}>
+    <div className={onRemove ? s.eventrowRemovable : s.eventrow}>
       <span className={s.eventType}>{label}</span>
       <input
-        className={`${s.input} ${s.tnum} ${s.wDate}`}
+        className={`${s.input} ${s.tnum}`}
         placeholder={t('personEditor.lifeEvents.datePlaceholder')}
         value={dateOriginal}
         disabled={disabled}
         onChange={(e) => onChangeDate(e.target.value)}
       />
-      <span className={s.eplace}>{t('personEditor.lifeEvents.placeSoon')}</span>
-      {onRemove ? (
+      <input className={s.input} placeholder={placeLabel} aria-label={placeLabel} disabled />
+      {onRemove && (
         <button
           type="button"
           className={s.iconbtn}
@@ -456,8 +457,6 @@ function EventDateRow({
         >
           <Icon name="x" size={16} />
         </button>
-      ) : (
-        <span />
       )}
     </div>
   );
@@ -715,6 +714,10 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
     setForm((prev) => ({ ...prev, families: [...prev.families, emptyFamilyRow()] }));
   }
 
+  function removeFamily(key: string): void {
+    setForm((prev) => ({ ...prev, families: prev.families.filter((row) => row.key !== key) }));
+  }
+
   const eventTypesByTag = new Map(
     (eventTypesQuery.data ?? []).map((et) => [et.tag ?? '', et] as const)
   );
@@ -750,9 +753,16 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
               <div className={s.headAvatar} aria-hidden="true">
                 {initialsFromDisplayName(subtitle)}
               </div>
-              <div>
+              <div className={s.headCrumb}>
                 <Dialog.Title className={s.headTitle}>{title}</Dialog.Title>
-                {subtitle && <div className={s.headSub}>{subtitle}</div>}
+                {subtitle && (
+                  <>
+                    <span className={s.headSep} aria-hidden="true">
+                      /
+                    </span>
+                    <span className={s.headSub}>{subtitle}</span>
+                  </>
+                )}
               </div>
               <span className={s.grow} />
               <button
@@ -776,7 +786,6 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
                     <div className={s.col}>
                       <div className={s.ecard}>
                         <div className={s.sectitle}>{t('personEditor.sections.names')}</div>
-                        <div className={s.subhead}>{t('personEditor.sections.primaryName')}</div>
                         <div className={s.fgridC2}>
                           <label className={s.field}>
                             <span className={s.fieldLabel}>
@@ -895,7 +904,6 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
 
                       <div className={s.ecard}>
                         <div className={s.sectitle}>{t('personEditor.sections.lifeEvents')}</div>
-                        <div className={s.hint}>{t('personEditor.sections.lifeEventsHint')}</div>
                         <div className={s.eventlist}>
                           {timelineEvents.map((row) => (
                             <EventDateRow
@@ -908,7 +916,6 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
                             />
                           ))}
                         </div>
-                        <div className={s.hint}>{t('personEditor.lifeEvents.dateHint')}</div>
 
                         <div className={s.addWrap}>
                           <button
@@ -936,23 +943,25 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
                           )}
                         </div>
 
-                        <div className={s.statusrow}>
-                          <Switch.Root
-                            className={s.switchRoot}
-                            checked={!form.isLiving}
-                            disabled={mutation.isPending}
-                            onCheckedChange={(checked) => setDeceased(checked)}
-                          >
-                            <Switch.Thumb className={s.switchThumb} />
-                          </Switch.Root>
-                          <span className={s.switchLabel}>{t('personEditor.status.deceased')}</span>
-                        </div>
-                        {!form.isLiving && deathRow && (
-                          <div className={s.deathField}>
+                        {deathRow && (
+                          <div className={s.deathGroup}>
+                            <div className={s.statusrow}>
+                              <Switch.Root
+                                className={s.switchRoot}
+                                checked={!form.isLiving}
+                                disabled={mutation.isPending}
+                                onCheckedChange={(checked) => setDeceased(checked)}
+                              >
+                                <Switch.Thumb className={s.switchThumb} />
+                              </Switch.Root>
+                              <span className={s.switchLabel}>
+                                {t('personEditor.status.deceased')}
+                              </span>
+                            </div>
                             <EventDateRow
                               label={eventRowLabel(deathRow.tag, eventTypesByTag, t)}
                               dateOriginal={deathRow.dateOriginal}
-                              disabled={mutation.isPending}
+                              disabled={mutation.isPending || form.isLiving}
                               onChangeDate={(value) => updateEventDate(deathRow.key, value)}
                             />
                           </div>
@@ -975,27 +984,24 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
                     <div className={s.col}>
                       <div className={s.ecard}>
                         <div className={s.sectitle}>{t('personEditor.sex.label')}</div>
-                        <div className={s.rrow}>
-                          <span className={s.rl}>{t('personEditor.sex.label')}</span>
-                          <div
-                            className={s.seg}
-                            role="radiogroup"
-                            aria-label={t('personEditor.sex.label')}
-                          >
-                            {SEX_VALUES.map((value) => (
-                              <button
-                                key={value}
-                                type="button"
-                                role="radio"
-                                aria-checked={form.gender === value}
-                                className={`${s.segItem} ${form.gender === value ? s.segItemOn : ''}`}
-                                disabled={mutation.isPending}
-                                onClick={() => setForm((prev) => ({ ...prev, gender: value }))}
-                              >
-                                {t(`table.sex.${value}`)}
-                              </button>
-                            ))}
-                          </div>
+                        <div
+                          className={s.seg}
+                          role="radiogroup"
+                          aria-label={t('personEditor.sex.label')}
+                        >
+                          {SEX_VALUES.map((value) => (
+                            <button
+                              key={value}
+                              type="button"
+                              role="radio"
+                              aria-checked={form.gender === value}
+                              className={`${s.segItem} ${form.gender === value ? s.segItemOn : ''}`}
+                              disabled={mutation.isPending}
+                              onClick={() => setForm((prev) => ({ ...prev, gender: value }))}
+                            >
+                              {t(`table.sex.${value}`)}
+                            </button>
+                          ))}
                         </div>
                       </div>
 
@@ -1032,8 +1038,28 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
                           />
                         </div>
 
-                        {form.families.map((row) => (
-                          <div key={row.key} className={s.familyCard}>
+                        {form.families.map((row, index) => (
+                          <div
+                            key={row.key}
+                            className={
+                              index === 0 ? `${s.familyCard} ${s.familyCardFirst}` : s.familyCard
+                            }
+                          >
+                            <div className={s.familyHead}>
+                              <span className={s.familyTitle}>
+                                {t('personEditor.relations.familyLabel')}
+                              </span>
+                              <span className={s.grow} />
+                              <button
+                                type="button"
+                                className={s.iconbtn}
+                                disabled={mutation.isPending}
+                                aria-label={t('personEditor.relations.removeFamilyAria')}
+                                onClick={() => removeFamily(row.key)}
+                              >
+                                <Icon name="x" size={16} />
+                              </button>
+                            </div>
                             <div className={s.relrow2}>
                               <span className={s.relLabel}>
                                 {t('personEditor.relations.spouse')}
@@ -1099,18 +1125,6 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
             </div>
 
             <div className={s.mfoot}>
-              {isDirty && (
-                <span className={s.dirty}>{t('personEditor.unsavedChanges.indicator')}</span>
-              )}
-              <span className={s.grow} />
-              <button
-                type="button"
-                className={s.btnGhost}
-                onClick={attemptClose}
-                disabled={mutation.isPending}
-              >
-                {t('personEditor.actions.cancel')}
-              </button>
               <button
                 type="submit"
                 form="person-editor-form"
@@ -1121,6 +1135,18 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
                   ? t('personEditor.actions.saveNew')
                   : t('personEditor.actions.save')}
               </button>
+              <button
+                type="button"
+                className={s.btnGhost}
+                onClick={attemptClose}
+                disabled={mutation.isPending}
+              >
+                {t('personEditor.actions.cancel')}
+              </button>
+              <span className={s.grow} />
+              {isDirty && (
+                <span className={s.dirty}>{t('personEditor.unsavedChanges.indicator')}</span>
+              )}
             </div>
           </Dialog.Popup>
         </Dialog.Portal>

--- a/src/components/individuals/person-editor-dialog.tsx
+++ b/src/components/individuals/person-editor-dialog.tsx
@@ -567,25 +567,21 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
       await FamilyManager.saveRelations(savedId, form.gender, buildRelationsPayload(form));
       return savedId;
     },
-    onSuccess: async (savedId) => {
-      const invalidations = [
-        queryClient.invalidateQueries({ queryKey: queryKeys.individuals }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.families }),
-      ];
-      if (mode === 'edit') {
-        invalidations.push(
-          queryClient.invalidateQueries({ queryKey: queryKeys.individual(savedId) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.personOverview(savedId) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.personEvents(savedId) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.personRelations(savedId) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.ancestors(savedId) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.parentFamily(savedId) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.spouseFamilies(savedId) })
-        );
-      }
-      await Promise.all(invalidations);
+    onSuccess: (savedId) => {
       onSaved?.(savedId);
       onOpenChange(false);
+
+      queryClient.invalidateQueries({ queryKey: queryKeys.individuals });
+      queryClient.invalidateQueries({ queryKey: queryKeys.families });
+      if (mode === 'edit') {
+        queryClient.invalidateQueries({ queryKey: queryKeys.individual(savedId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.personOverview(savedId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.personEvents(savedId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.personRelations(savedId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.ancestors(savedId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.parentFamily(savedId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.spouseFamilies(savedId) });
+      }
     },
     onError: (err) => {
       // Raw DB/Tauri errors are not translated — log them, surface a

--- a/src/components/individuals/person-editor-dialog.tsx
+++ b/src/components/individuals/person-editor-dialog.tsx
@@ -950,6 +950,7 @@ export function PersonEditorDialog(props: PersonEditorDialogProps): JSX.Element 
                                 className={s.switchRoot}
                                 checked={!form.isLiving}
                                 disabled={mutation.isPending}
+                                aria-label={t('personEditor.status.deceased')}
                                 onCheckedChange={(checked) => setDeceased(checked)}
                               >
                                 <Switch.Thumb className={s.switchThumb} />

--- a/src/components/individuals/person-editor.css.ts
+++ b/src/components/individuals/person-editor.css.ts
@@ -412,6 +412,16 @@ export const selbox = style({
   },
 });
 export const selboxCaret = style({ marginLeft: 'auto', fontSize: 9, color: vars.color.faint });
+/**
+ * Z-index for the Base UI positioner wrappers (Popover + Select). Floating UI
+ * sets `will-change: transform` inline on these, which creates a stacking
+ * context with `z-index: auto` — so any z-index on the popup inside is
+ * trapped and the dialog (z 101) wins. Giving the positioner itself a z-index
+ * above the dialog lifts the whole context. 105 sits below the discard
+ * AlertDialog (110/111) so the confirm prompt still covers the pickers.
+ */
+export const positionerZ = style({ zIndex: 105 });
+
 export const selectPopup = style({
   background: vars.color.panel2,
   border: `1px solid ${vars.color.borderStrong}`,
@@ -421,7 +431,6 @@ export const selectPopup = style({
   minWidth: 160,
   maxHeight: 260,
   overflow: 'auto',
-  zIndex: 200,
 });
 export const selectItem = style({
   display: 'flex',
@@ -573,7 +582,6 @@ export const pickerPopup = style({
   boxShadow: vars.shadow.lg,
   padding: 9,
   width: 288,
-  zIndex: 200,
 });
 export const pickerList = style({
   display: 'flex',

--- a/src/components/individuals/person-editor.css.ts
+++ b/src/components/individuals/person-editor.css.ts
@@ -31,7 +31,7 @@ export const modal = style({
   fontFamily: vars.font.sans,
   color: vars.color.text,
   width: 'calc(100vw - 44px)',
-  maxWidth: 1040,
+  maxWidth: 1180,
   background: vars.color.panel,
   border: `1px solid ${vars.color.borderStrong}`,
   borderRadius: 14,
@@ -54,8 +54,9 @@ export const headAvatar = style({
   width: 38,
   height: 38,
   borderRadius: 10,
-  background: vars.color.accentSoft,
-  color: vars.color.accent,
+  background: vars.color.subtle,
+  border: `1px solid ${vars.color.borderStrong}`,
+  color: vars.color.muted,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -63,16 +64,55 @@ export const headAvatar = style({
   fontSize: 13,
   flex: '0 0 auto',
 });
-export const headTitle = style({ fontSize: 15, fontWeight: 650 });
-/** The lineage signature: the person's name in Fraunces italic. */
+/** Title + person name on one line, read as a breadcrumb (`Add person / Jane Doe`). */
+export const headCrumb = style({
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: 8,
+  minWidth: 0,
+});
+export const headTitle = style({
+  fontSize: 15,
+  fontWeight: 650,
+  margin: 0,
+  whiteSpace: 'nowrap',
+  flex: '0 0 auto',
+});
+/** Breadcrumb separator between the title and the person name. */
+export const headSep = style({ fontSize: 14, color: vars.color.faint, flex: '0 0 auto' });
+/** The lineage signature: the person's name in Fraunces italic, truncated if long. */
 export const headSub = style({
   fontFamily: vars.font.serif,
   fontStyle: 'italic',
   fontSize: 15,
   color: vars.color.muted,
+  minWidth: 0,
+  flex: '0 1 auto',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 });
 export const grow = style({ flex: 1 });
-export const mbody = style({ flex: 1, minHeight: 0, overflow: 'auto', padding: '14px 18px 18px' });
+export const mbody = style({
+  flex: 1,
+  minHeight: 0,
+  overflow: 'auto',
+  padding: '14px 18px 18px',
+  // Local for now (first VE screen); promote to the design layer when a second
+  // VE screen needs a styled scroll container instead of copying this block.
+  selectors: {
+    '&::-webkit-scrollbar': { width: 14, height: 14 },
+    '&::-webkit-scrollbar-track': { background: 'transparent' },
+    // Warm, inset thumb (transparent border + padding-box clip) that sits on the theme.
+    '&::-webkit-scrollbar-thumb': {
+      background: vars.color.faint,
+      borderRadius: 999,
+      border: '4px solid transparent',
+      backgroundClip: 'padding-box',
+    },
+    '&::-webkit-scrollbar-thumb:hover': { background: vars.color.muted },
+  },
+});
 export const mfoot = style({
   display: 'flex',
   alignItems: 'center',
@@ -105,7 +145,7 @@ export const cols = style({
   display: 'grid',
   gap: 14,
   alignItems: 'start',
-  gridTemplateColumns: '1.5fr 1fr',
+  gridTemplateColumns: '1.35fr 1fr',
   '@media': { 'screen and (max-width: 900px)': { gridTemplateColumns: '1fr' } },
 });
 export const col = style({ display: 'flex', flexDirection: 'column', gap: 14, minWidth: 0 });
@@ -116,17 +156,18 @@ export const ecard = style({
   padding: '14px 15px',
 });
 export const familyCard = style({
-  background: vars.color.panel2,
   border: `1px solid ${vars.color.border}`,
   borderRadius: 10,
   padding: '12px 13px',
   marginTop: 4,
 });
+/** The first family sits below the Parents rows and wants a clearer break from them. */
+export const familyCardFirst = style({ marginTop: 16 });
 export const sectitle = style({
   fontSize: 11,
   letterSpacing: '.09em',
   textTransform: 'uppercase',
-  color: vars.color.faint,
+  color: vars.color.muted,
   fontWeight: 650,
   display: 'flex',
   alignItems: 'center',
@@ -136,16 +177,15 @@ export const sectitle = style({
 export const subhead = style({
   fontSize: 11.5,
   fontWeight: 650,
-  color: vars.color.muted,
+  color: vars.color.text,
   margin: '0 0 8px',
 });
 export const subheadMt = style({ marginTop: 14 });
-export const hint = style({ fontSize: 11.5, color: vars.color.faint, margin: '-2px 0 4px' });
 
 /* ---- controls ------------------------------------------------------- */
 
 export const field = style({ display: 'flex', flexDirection: 'column', gap: 5, minWidth: 0 });
-export const fieldLabel = style({ fontSize: 11.5, fontWeight: 600, color: vars.color.muted });
+export const fieldLabel = style({ fontSize: 11.5, fontWeight: 600, color: vars.color.text });
 export const input = style({
   height: 34,
   border: `1px solid ${vars.color.borderStrong}`,
@@ -161,6 +201,8 @@ export const input = style({
     '&:hover': { borderColor: vars.color.faint },
     '&::placeholder': { color: vars.color.faint },
     '&:focus-visible': { ...focusRing, outlineOffset: 1, borderColor: vars.color.accent },
+    '&:disabled': { opacity: 0.55, cursor: 'not-allowed' },
+    '&:disabled:hover': { borderColor: vars.color.borderStrong },
   },
 });
 export const textarea = style([
@@ -168,7 +210,6 @@ export const textarea = style([
   { height: 'auto', minHeight: 62, padding: '8px 10px', lineHeight: 1.45, resize: 'vertical' },
 ]);
 export const tnum = style({ fontVariantNumeric: 'tabular-nums' });
-export const wDate = style({ maxWidth: 150 });
 export const fgridC2 = style({ display: 'grid', gap: '10px 12px', gridTemplateColumns: '1fr 1fr' });
 export const fgridC3 = style({
   display: 'grid',
@@ -178,19 +219,25 @@ export const fgridC3 = style({
 export const stack = style({ display: 'flex', flexDirection: 'column', gap: 8 });
 /** The prefix/suffix/nickname grid, spaced below the given/surname grid. */
 export const fgrid3Gap = style([fgridC3, { marginTop: 10 }]);
-/** The death-date field revealed under the Deceased toggle. */
-export const deathField = style({ marginTop: 8 });
+/**
+ * The Deceased toggle and the always-present Death row. A top hairline sets them
+ * apart from the events above while keeping the rows flush-left with Birth (no
+ * indentation); the toggle sits directly over the Death row it gates.
+ */
+export const deathGroup = style({
+  marginTop: 12,
+  paddingTop: 12,
+  borderTop: `1px solid ${vars.color.border}`,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+});
 /** The "Add another family" action, spaced below the last family. */
 export const familyActions = style({ marginTop: 12 });
-
-export const rrow = style({
-  display: 'grid',
-  gridTemplateColumns: '88px minmax(0,1fr)',
-  gap: 10,
-  alignItems: 'center',
-  padding: '3px 0',
-});
-export const rl = style({ fontSize: 12, color: vars.color.muted });
+/** Header of a family card: a label and the remove control. */
+export const familyHead = style({ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 });
+/** Same type ramp as {@link subhead}; the flex header owns the spacing, so drop its margin. */
+export const familyTitle = style([subhead, { margin: 0 }]);
 
 export const seg = style({
   display: 'inline-flex',
@@ -249,7 +296,7 @@ export const switchThumb = style({
   transition: 'left .15s',
   selectors: { [`${switchRoot}[data-checked] &`]: { left: 18 } },
 });
-export const statusrow = style({ display: 'flex', alignItems: 'center', gap: 10, marginTop: 12 });
+export const statusrow = style({ display: 'flex', alignItems: 'center', gap: 10 });
 export const switchLabel = style({ fontSize: 13, fontWeight: 600 });
 
 export const iconbtn = style({
@@ -396,12 +443,13 @@ export const selectItem = style({
 /* ---- life events ---------------------------------------------------- */
 
 export const eventlist = style({ display: 'flex', flexDirection: 'column', gap: 8 });
-export const eventrow = style({
-  display: 'grid',
-  gridTemplateColumns: '148px 150px 1fr 30px',
-  gap: 8,
-  alignItems: 'center',
-  maxWidth: 560,
+const eventrowBase = { display: 'grid', gap: 8, alignItems: 'center' } as const;
+/** Dates are short, places are long — keep the date compact, let the place take the rest. */
+export const eventrow = style({ ...eventrowBase, gridTemplateColumns: '148px 190px 1fr' });
+/** Added events: same fields, plus a trailing column for the remove control. */
+export const eventrowRemovable = style({
+  ...eventrowBase,
+  gridTemplateColumns: '148px 190px 1fr 30px',
 });
 /** Read-only event-type cell (type is chosen when the event is added). */
 export const eventType = style({
@@ -414,16 +462,6 @@ export const eventType = style({
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-});
-export const eplace = style({
-  fontSize: 12,
-  color: vars.color.faint,
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 6,
-  justifySelf: 'start',
-  whiteSpace: 'nowrap',
-  opacity: 0.7,
 });
 export const addWrap = style({ marginTop: 10 });
 export const typegrid = style({
@@ -466,7 +504,7 @@ export const relrow2 = style({
   alignItems: 'start',
   padding: '4px 0',
 });
-export const relLabel = style({ fontSize: 12, color: vars.color.muted, paddingTop: 12 });
+export const relLabel = style({ fontSize: 12, color: vars.color.text, paddingTop: 12 });
 export const childstack = style({ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 0 });
 export const relslot = style({
   minHeight: 44,
@@ -481,7 +519,6 @@ export const relslot = style({
   fontSize: 12.5,
   fontWeight: 600,
   cursor: 'pointer',
-  maxWidth: 300,
   width: '100%',
   fontFamily: 'inherit',
   selectors: {
@@ -499,7 +536,7 @@ export const pfield = style({
   alignItems: 'center',
   gap: 9,
   padding: '4px 6px 4px 10px',
-  maxWidth: 300,
+  width: '100%',
 });
 export const pfieldAvatar = style({
   width: 26,

--- a/src/components/individuals/person-editor.css.ts
+++ b/src/components/individuals/person-editor.css.ts
@@ -1,0 +1,642 @@
+/**
+ * Vanilla Extract styles for the Person editor + Person picker (ADR-0014).
+ * Base UI supplies behavior; these styles supply the warm-earth look over the
+ * `src/design/theme.css.ts` token contract. Shared by `person-editor-dialog.tsx`
+ * and `person-picker.tsx`.
+ */
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '$/design/theme.css';
+
+const focusRing = {
+  outline: `2px solid ${vars.color.accent}`,
+  outlineOffset: 2,
+};
+
+/* ---- dialog chrome -------------------------------------------------- */
+
+export const backdrop = style({
+  position: 'fixed',
+  inset: 0,
+  zIndex: 100,
+  background: vars.color.scrim,
+});
+
+export const modal = style({
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  zIndex: 101,
+  fontFamily: vars.font.sans,
+  color: vars.color.text,
+  width: 'calc(100vw - 44px)',
+  maxWidth: 1040,
+  background: vars.color.panel,
+  border: `1px solid ${vars.color.borderStrong}`,
+  borderRadius: 14,
+  boxShadow: vars.shadow.lg,
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+  maxHeight: 'calc(100vh - 54px)',
+});
+
+export const mhead = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  padding: '14px 18px',
+  borderBottom: `1px solid ${vars.color.border}`,
+  flex: '0 0 auto',
+});
+export const headAvatar = style({
+  width: 38,
+  height: 38,
+  borderRadius: 10,
+  background: vars.color.accentSoft,
+  color: vars.color.accent,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontWeight: 700,
+  fontSize: 13,
+  flex: '0 0 auto',
+});
+export const headTitle = style({ fontSize: 15, fontWeight: 650 });
+/** The lineage signature: the person's name in Fraunces italic. */
+export const headSub = style({
+  fontFamily: vars.font.serif,
+  fontStyle: 'italic',
+  fontSize: 15,
+  color: vars.color.muted,
+});
+export const grow = style({ flex: 1 });
+export const mbody = style({ flex: 1, minHeight: 0, overflow: 'auto', padding: '14px 18px 18px' });
+export const mfoot = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  padding: '11px 18px',
+  borderTop: `1px solid ${vars.color.border}`,
+  flex: '0 0 auto',
+  background: `color-mix(in srgb, ${vars.color.panel} 92%, transparent)`,
+});
+export const dirty = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 8,
+  fontSize: 12.5,
+  color: vars.color.warn,
+  fontWeight: 600,
+  '::before': {
+    content: '""',
+    width: 7,
+    height: 7,
+    borderRadius: '50%',
+    background: vars.color.warn,
+  },
+});
+export const loadingText = style({ fontSize: 13.5, color: vars.color.muted, padding: '8px 0' });
+
+/* ---- layout + cards ------------------------------------------------- */
+
+export const cols = style({
+  display: 'grid',
+  gap: 14,
+  alignItems: 'start',
+  gridTemplateColumns: '1.5fr 1fr',
+  '@media': { 'screen and (max-width: 900px)': { gridTemplateColumns: '1fr' } },
+});
+export const col = style({ display: 'flex', flexDirection: 'column', gap: 14, minWidth: 0 });
+export const ecard = style({
+  background: vars.color.panel,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: 11,
+  padding: '14px 15px',
+});
+export const familyCard = style({
+  background: vars.color.panel2,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: 10,
+  padding: '12px 13px',
+  marginTop: 4,
+});
+export const sectitle = style({
+  fontSize: 11,
+  letterSpacing: '.09em',
+  textTransform: 'uppercase',
+  color: vars.color.faint,
+  fontWeight: 650,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  marginBottom: 12,
+});
+export const subhead = style({
+  fontSize: 11.5,
+  fontWeight: 650,
+  color: vars.color.muted,
+  margin: '0 0 8px',
+});
+export const subheadMt = style({ marginTop: 14 });
+export const hint = style({ fontSize: 11.5, color: vars.color.faint, margin: '-2px 0 4px' });
+
+/* ---- controls ------------------------------------------------------- */
+
+export const field = style({ display: 'flex', flexDirection: 'column', gap: 5, minWidth: 0 });
+export const fieldLabel = style({ fontSize: 11.5, fontWeight: 600, color: vars.color.muted });
+export const input = style({
+  height: 34,
+  border: `1px solid ${vars.color.borderStrong}`,
+  background: vars.color.panel,
+  color: vars.color.text,
+  borderRadius: vars.radius.sm,
+  padding: '0 10px',
+  fontSize: 13.5,
+  width: '100%',
+  boxShadow: 'inset 0 1px 1px rgba(0,0,0,.03)',
+  fontFamily: 'inherit',
+  selectors: {
+    '&:hover': { borderColor: vars.color.faint },
+    '&::placeholder': { color: vars.color.faint },
+    '&:focus-visible': { ...focusRing, outlineOffset: 1, borderColor: vars.color.accent },
+  },
+});
+export const textarea = style([
+  input,
+  { height: 'auto', minHeight: 62, padding: '8px 10px', lineHeight: 1.45, resize: 'vertical' },
+]);
+export const tnum = style({ fontVariantNumeric: 'tabular-nums' });
+export const wDate = style({ maxWidth: 150 });
+export const fgridC2 = style({ display: 'grid', gap: '10px 12px', gridTemplateColumns: '1fr 1fr' });
+export const fgridC3 = style({
+  display: 'grid',
+  gap: '10px 12px',
+  gridTemplateColumns: '1fr 1fr 1fr',
+});
+export const stack = style({ display: 'flex', flexDirection: 'column', gap: 8 });
+/** The prefix/suffix/nickname grid, spaced below the given/surname grid. */
+export const fgrid3Gap = style([fgridC3, { marginTop: 10 }]);
+/** The death-date field revealed under the Deceased toggle. */
+export const deathField = style({ marginTop: 8 });
+/** The "Add another family" action, spaced below the last family. */
+export const familyActions = style({ marginTop: 12 });
+
+export const rrow = style({
+  display: 'grid',
+  gridTemplateColumns: '88px minmax(0,1fr)',
+  gap: 10,
+  alignItems: 'center',
+  padding: '3px 0',
+});
+export const rl = style({ fontSize: 12, color: vars.color.muted });
+
+export const seg = style({
+  display: 'inline-flex',
+  background: vars.color.subtle,
+  borderRadius: 8,
+  padding: 3,
+  gap: 2,
+  width: 'max-content',
+});
+export const segItem = style({
+  padding: '6px 13px',
+  borderRadius: 6,
+  fontSize: 12.5,
+  fontWeight: 600,
+  color: vars.color.muted,
+  cursor: 'pointer',
+  border: 'none',
+  background: 'transparent',
+  fontFamily: 'inherit',
+  selectors: {
+    '&:disabled': { cursor: 'default', opacity: 0.6 },
+    '&:focus-visible': focusRing,
+  },
+});
+export const segItemOn = style({
+  background: vars.color.panel,
+  color: vars.color.text,
+  boxShadow: vars.shadow.sm,
+});
+
+export const switchRoot = style({
+  width: 38,
+  height: 22,
+  borderRadius: 99,
+  background: vars.color.borderStrong,
+  position: 'relative',
+  flex: '0 0 auto',
+  cursor: 'pointer',
+  border: 'none',
+  padding: 0,
+  selectors: {
+    '&[data-checked]': { background: vars.color.accent },
+    '&:focus-visible': focusRing,
+    '&:disabled': { cursor: 'default', opacity: 0.6 },
+  },
+});
+export const switchThumb = style({
+  position: 'absolute',
+  top: 2,
+  left: 2,
+  width: 18,
+  height: 18,
+  borderRadius: '50%',
+  background: '#fff',
+  boxShadow: vars.shadow.sm,
+  transition: 'left .15s',
+  selectors: { [`${switchRoot}[data-checked] &`]: { left: 18 } },
+});
+export const statusrow = style({ display: 'flex', alignItems: 'center', gap: 10, marginTop: 12 });
+export const switchLabel = style({ fontSize: 13, fontWeight: 600 });
+
+export const iconbtn = style({
+  width: 30,
+  height: 30,
+  borderRadius: 6,
+  border: '1px solid transparent',
+  background: 'transparent',
+  color: vars.color.faint,
+  cursor: 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flex: '0 0 auto',
+  selectors: {
+    '&:hover': { background: vars.color.subtle, color: vars.color.danger },
+    '&:focus-visible': focusRing,
+    '&:disabled': { cursor: 'default', opacity: 0.5 },
+  },
+});
+export const addbtn = style({
+  alignSelf: 'flex-start',
+  background: 'transparent',
+  border: `1px dashed ${vars.color.borderStrong}`,
+  color: vars.color.muted,
+  borderRadius: vars.radius.sm,
+  height: 32,
+  padding: '0 12px',
+  fontSize: 12.5,
+  fontWeight: 600,
+  cursor: 'pointer',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 7,
+  fontFamily: 'inherit',
+  selectors: {
+    '&:hover': { borderColor: vars.color.accent, color: vars.color.accent },
+    '&:focus-visible': focusRing,
+    '&:disabled': { cursor: 'default', opacity: 0.6 },
+  },
+});
+
+const btnBase = style({
+  height: 34,
+  borderRadius: vars.radius.sm,
+  padding: '0 16px',
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: 'pointer',
+  border: '1px solid transparent',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 8,
+  fontFamily: 'inherit',
+  selectors: {
+    '&:focus-visible': focusRing,
+    '&:disabled': { cursor: 'default', opacity: 0.6 },
+  },
+});
+export const btnSolid = style([
+  btnBase,
+  {
+    background: vars.color.accent,
+    color: vars.color.accentText,
+    selectors: { '&:hover:not(:disabled)': { background: vars.color.accentHover } },
+  },
+]);
+export const btnGhost = style([
+  btnBase,
+  {
+    background: 'transparent',
+    color: vars.color.muted,
+    selectors: { '&:hover:not(:disabled)': { color: vars.color.text } },
+  },
+]);
+export const btnDanger = style([
+  btnBase,
+  {
+    background: vars.color.danger,
+    color: vars.color.accentText,
+    selectors: { '&:hover:not(:disabled)': { filter: 'brightness(0.94)' } },
+  },
+]);
+
+export const altrow = style({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr) 128px 30px',
+  gap: 8,
+  alignItems: 'center',
+});
+
+/* ---- Base UI Select ------------------------------------------------- */
+
+export const selbox = style({
+  height: 34,
+  border: `1px solid ${vars.color.borderStrong}`,
+  background: vars.color.panel,
+  borderRadius: vars.radius.sm,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '0 10px',
+  fontSize: 12.5,
+  color: vars.color.text,
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+  fontFamily: 'inherit',
+  width: '100%',
+  selectors: {
+    '&:hover': { borderColor: vars.color.faint },
+    '&:focus-visible': focusRing,
+    '&:disabled': { cursor: 'default', opacity: 0.6 },
+  },
+});
+export const selboxCaret = style({ marginLeft: 'auto', fontSize: 9, color: vars.color.faint });
+export const selectPopup = style({
+  background: vars.color.panel2,
+  border: `1px solid ${vars.color.borderStrong}`,
+  borderRadius: 11,
+  boxShadow: vars.shadow.lg,
+  padding: 6,
+  minWidth: 160,
+  maxHeight: 260,
+  overflow: 'auto',
+  zIndex: 200,
+});
+export const selectItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '7px 9px',
+  borderRadius: 7,
+  fontSize: 13,
+  color: vars.color.text,
+  cursor: 'pointer',
+  userSelect: 'none',
+  outline: 'none',
+  selectors: {
+    '&[data-highlighted]': { background: vars.color.subtle },
+    '&[data-selected]': { color: vars.color.accent, fontWeight: 600 },
+  },
+});
+
+/* ---- life events ---------------------------------------------------- */
+
+export const eventlist = style({ display: 'flex', flexDirection: 'column', gap: 8 });
+export const eventrow = style({
+  display: 'grid',
+  gridTemplateColumns: '148px 150px 1fr 30px',
+  gap: 8,
+  alignItems: 'center',
+  maxWidth: 560,
+});
+/** Read-only event-type cell (type is chosen when the event is added). */
+export const eventType = style({
+  display: 'flex',
+  alignItems: 'center',
+  height: 34,
+  fontSize: 13,
+  fontWeight: 550,
+  color: vars.color.text,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+export const eplace = style({
+  fontSize: 12,
+  color: vars.color.faint,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  justifySelf: 'start',
+  whiteSpace: 'nowrap',
+  opacity: 0.7,
+});
+export const addWrap = style({ marginTop: 10 });
+export const typegrid = style({
+  marginTop: 9,
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr 1fr',
+  gap: 6,
+  maxWidth: 430,
+  border: `1px solid ${vars.color.border}`,
+  background: vars.color.panel2,
+  borderRadius: 10,
+  padding: 8,
+});
+export const typegridBtn = style({
+  border: `1px solid ${vars.color.border}`,
+  background: vars.color.panel,
+  borderRadius: 7,
+  padding: '8px 9px',
+  fontSize: 12.5,
+  cursor: 'pointer',
+  color: vars.color.text,
+  textAlign: 'left',
+  fontFamily: 'inherit',
+  selectors: {
+    '&:hover': {
+      borderColor: vars.color.accent,
+      color: vars.color.accent,
+      background: vars.color.accentSoft,
+    },
+    '&:focus-visible': focusRing,
+  },
+});
+
+/* ---- relations ------------------------------------------------------ */
+
+export const relrow2 = style({
+  display: 'grid',
+  gridTemplateColumns: '78px minmax(0,1fr)',
+  gap: 10,
+  alignItems: 'start',
+  padding: '4px 0',
+});
+export const relLabel = style({ fontSize: 12, color: vars.color.muted, paddingTop: 12 });
+export const childstack = style({ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 0 });
+export const relslot = style({
+  minHeight: 44,
+  border: `1px dashed ${vars.color.borderStrong}`,
+  background: 'transparent',
+  color: vars.color.faint,
+  borderRadius: vars.radius.sm,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '0 12px',
+  fontSize: 12.5,
+  fontWeight: 600,
+  cursor: 'pointer',
+  maxWidth: 300,
+  width: '100%',
+  fontFamily: 'inherit',
+  selectors: {
+    '&:hover': { borderColor: vars.color.accent, color: vars.color.accent },
+    '&:focus-visible': focusRing,
+    '&:disabled': { cursor: 'default', opacity: 0.6 },
+  },
+});
+export const pfield = style({
+  minHeight: 44,
+  border: `1px solid ${vars.color.borderStrong}`,
+  background: vars.color.panel,
+  borderRadius: vars.radius.sm,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 9,
+  padding: '4px 6px 4px 10px',
+  maxWidth: 300,
+});
+export const pfieldAvatar = style({
+  width: 26,
+  height: 26,
+  borderRadius: '50%',
+  background: vars.color.accentSoft,
+  color: vars.color.accent,
+  fontSize: 9,
+  fontWeight: 700,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flex: '0 0 auto',
+});
+export const pfieldBody = style({ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 });
+export const pfieldName = style({
+  fontSize: 13,
+  fontWeight: 550,
+  color: vars.color.text,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+export const pfieldDates = style({ fontSize: 11, color: vars.color.faint });
+
+/* ---- Person picker (Base UI Popover) -------------------------------- */
+
+export const pickerPopup = style({
+  background: vars.color.panel,
+  border: `1px solid ${vars.color.borderStrong}`,
+  borderRadius: 11,
+  boxShadow: vars.shadow.lg,
+  padding: 9,
+  width: 288,
+  zIndex: 200,
+});
+export const pickerList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+  marginTop: 8,
+  maxHeight: 260,
+  overflow: 'auto',
+});
+export const pickerItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 9,
+  width: '100%',
+  border: 0,
+  background: 'transparent',
+  textAlign: 'left',
+  padding: '7px 8px',
+  borderRadius: 7,
+  cursor: 'pointer',
+  color: vars.color.text,
+  fontFamily: 'inherit',
+  selectors: {
+    '&:hover': { background: vars.color.subtle },
+    '&:focus-visible': focusRing,
+  },
+});
+export const pickerMeta = style({ fontSize: 12, color: vars.color.faint, padding: '6px 8px' });
+export const pickerCreate = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  width: '100%',
+  marginTop: 6,
+  border: 0,
+  borderTop: `1px solid ${vars.color.border}`,
+  paddingTop: 9,
+  paddingBottom: 3,
+  paddingInline: 8,
+  background: 'transparent',
+  color: vars.color.accent,
+  fontWeight: 650,
+  fontSize: 12.5,
+  cursor: 'pointer',
+  textAlign: 'left',
+  fontFamily: 'inherit',
+  selectors: { '&:focus-visible': focusRing },
+});
+
+/* ---- error callout -------------------------------------------------- */
+
+export const callout = style({
+  marginTop: 16,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  fontSize: 12.5,
+  color: vars.color.danger,
+  background: `color-mix(in srgb, ${vars.color.danger} 12%, transparent)`,
+  border: `1px solid color-mix(in srgb, ${vars.color.danger} 30%, transparent)`,
+  borderRadius: 8,
+  padding: '9px 12px',
+});
+
+/* ---- discard AlertDialog ------------------------------------------- */
+
+export const alertBackdrop = style({
+  position: 'fixed',
+  inset: 0,
+  zIndex: 110,
+  background: vars.color.scrim,
+});
+export const alertPopup = style({
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  zIndex: 111,
+  fontFamily: vars.font.sans,
+  width: 'calc(100vw - 44px)',
+  maxWidth: 440,
+  background: vars.color.panel,
+  border: `1px solid ${vars.color.borderStrong}`,
+  borderRadius: 12,
+  boxShadow: vars.shadow.lg,
+  padding: 20,
+});
+export const alertTitle = style({
+  fontSize: 16,
+  fontWeight: 650,
+  color: vars.color.text,
+  margin: 0,
+});
+export const alertDesc = style({
+  fontSize: 13,
+  color: vars.color.muted,
+  margin: '8px 0 0',
+  lineHeight: 1.5,
+});
+export const alertActions = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: 10,
+  marginTop: 18,
+});

--- a/src/components/individuals/person-editor.css.ts
+++ b/src/components/individuals/person-editor.css.ts
@@ -525,6 +525,8 @@ export const relslot = style({
     '&:hover': { borderColor: vars.color.accent, color: vars.color.accent },
     '&:focus-visible': focusRing,
     '&:disabled': { cursor: 'default', opacity: 0.6 },
+    // Keep the resting look while disabled — no accent hover on a dead control.
+    '&:disabled:hover': { borderColor: vars.color.borderStrong, color: vars.color.faint },
   },
 });
 export const pfield = style({

--- a/src/components/individuals/person-picker.test.tsx
+++ b/src/components/individuals/person-picker.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Button } from '@radix-ui/themes';
 
 vi.mock('$managers/IndividualManager', () => ({
   IndividualManager: {
@@ -26,9 +25,7 @@ function renderPicker(props: Partial<Parameters<typeof PersonPicker>[0]> = {}) {
 
   render(
     <QueryClientProvider client={queryClient}>
-      <PersonPicker onSelect={onSelect} {...props}>
-        <Button type="button">Add father</Button>
-      </PersonPicker>
+      <PersonPicker label="Add father" onSelect={onSelect} {...props} />
     </QueryClientProvider>
   );
 

--- a/src/components/individuals/person-picker.tsx
+++ b/src/components/individuals/person-picker.tsx
@@ -103,7 +103,12 @@ export function PersonPicker({
         {label}
       </Popover.Trigger>
       <Popover.Portal>
-        <Popover.Positioner sideOffset={6} align="start">
+        <Popover.Positioner
+          sideOffset={6}
+          align="start"
+          positionMethod="fixed"
+          className={s.positionerZ}
+        >
           <Popover.Popup className={s.pickerPopup}>
             <input
               className={s.input}

--- a/src/components/individuals/person-picker.tsx
+++ b/src/components/individuals/person-picker.tsx
@@ -1,6 +1,6 @@
-import { type ReactNode, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Avatar, Box, Button, Flex, Popover, Text, TextField } from '@radix-ui/themes';
+import { Popover } from '@base-ui/react/popover';
 
 import { Icon } from '$components/icon';
 import { useDebouncedValue } from '$hooks/useDebouncedValue';
@@ -8,6 +8,7 @@ import { useIndividualSearch, useIndividuals } from '$hooks/useIndividuals';
 import { formatNameSimple } from '$db-tree/names';
 import { formatLifeYears, initialsFromDisplayName, personDisplayFields } from './person-display';
 import type { Gender, IndividualWithDetails } from '$types/database';
+import * as s from './person-editor.css';
 
 const MAX_RESULTS = 8;
 const SEARCH_DEBOUNCE_MS = 200;
@@ -30,27 +31,28 @@ function splitDisplayName(name: string): { givenNames?: string; surname?: string
 }
 
 export interface PersonPickerProps {
-  /** The trigger element wrapped by `Popover.Trigger` (typically a dashed "+ Add …" button). */
-  children: ReactNode;
+  /** Text for the dashed "+ Add …" trigger the picker renders when empty. */
+  label: string;
   onSelect: (selection: PersonPickerSelection) => void;
   /** Individual ids to hide from search results (e.g. the person being edited, or people already picked elsewhere in this form). */
   excludeIds?: string[];
   /** Gender to seed a newly-created person with (e.g. 'M' for a father slot); left unset defaults to unknown. */
   newPersonGender?: Gender;
+  disabled?: boolean;
 }
 
 /**
  * Search-existing-or-create-new person combobox, used by the Person editor's
- * Relations card to fill a father/mother/spouse/child slot. Composes
- * `Popover` + `TextField` + a plain button list (Radix Themes has no
- * combobox primitive) — see design-system-standards for why this stays a
- * composition rather than a new visual atom.
+ * Relations card to fill a father/mother/spouse/child slot. Base UI `Popover`
+ * over a plain search input and button list (no combobox atom needed), styled
+ * from the warm-earth tokens.
  */
 export function PersonPicker({
-  children,
+  label,
   onSelect,
   excludeIds,
   newPersonGender,
+  disabled,
 }: PersonPickerProps): JSX.Element {
   const { t } = useTranslation('individuals');
   const [open, setOpen] = useState(false);
@@ -96,65 +98,53 @@ export function PersonPicker({
 
   return (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
-      <Popover.Trigger>{children}</Popover.Trigger>
-      <Popover.Content width="280px">
-        <Flex direction="column" gap="2">
-          <TextField.Root
-            autoFocus
-            placeholder={t('personEditor.picker.searchPlaceholder')}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-          />
-          <Flex direction="column" gap="1">
-            {results.map((person) => {
-              const dates = formatLifeYears(person.bornYear, person.deathYear);
-              return (
-                <Button
-                  key={person.id}
-                  type="button"
-                  variant="ghost"
-                  color="gray"
-                  onClick={() => pick(person)}
-                >
-                  <Flex align="center" gap="2" width="100%">
-                    <span aria-hidden="true">
-                      <Avatar
-                        size="2"
-                        radius="full"
-                        fallback={initialsFromDisplayName(person.displayName)}
-                      />
+      <Popover.Trigger className={s.relslot} disabled={disabled}>
+        <Icon name="plus" size={14} />
+        {label}
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner sideOffset={6} align="start">
+          <Popover.Popup className={s.pickerPopup}>
+            <input
+              className={s.input}
+              autoFocus
+              placeholder={t('personEditor.picker.searchPlaceholder')}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            <div className={s.pickerList}>
+              {results.map((person) => {
+                const dates = formatLifeYears(person.bornYear, person.deathYear);
+                return (
+                  <button
+                    key={person.id}
+                    type="button"
+                    className={s.pickerItem}
+                    onClick={() => pick(person)}
+                  >
+                    <span className={s.pfieldAvatar} aria-hidden="true">
+                      {initialsFromDisplayName(person.displayName)}
                     </span>
-                    <Flex direction="column" align="start" overflow="hidden">
-                      <Text truncate>{person.displayName}</Text>
-                      {dates && (
-                        <Text size="1" color="gray">
-                          {dates}
-                        </Text>
-                      )}
-                    </Flex>
-                  </Flex>
-                </Button>
-              );
-            })}
-            {hiddenCount > 0 && (
-              <Box py="1">
-                <Text size="1" color="gray">
+                    <span className={s.pfieldBody}>
+                      <span className={s.pfieldName}>{person.displayName}</span>
+                      {dates && <span className={s.pfieldDates}>{dates}</span>}
+                    </span>
+                  </button>
+                );
+              })}
+              {hiddenCount > 0 && (
+                <div className={s.pickerMeta}>
                   {t('personEditor.picker.moreHidden', { count: hiddenCount })}
-                </Text>
-              </Box>
-            )}
-            {noMatches && (
-              <Box py="1">
-                <Text size="1" color="gray">
-                  {t('personEditor.picker.noMatches')}
-                </Text>
-              </Box>
-            )}
+                </div>
+              )}
+              {noMatches && (
+                <div className={s.pickerMeta}>{t('personEditor.picker.noMatches')}</div>
+              )}
+            </div>
             {isTyping && (
-              <Button
+              <button
                 type="button"
-                variant="soft"
-                color="gray"
+                className={s.pickerCreate}
                 onClick={() =>
                   pick({
                     createNew: { ...splitDisplayName(trimmedQuery), gender: newPersonGender },
@@ -162,15 +152,13 @@ export function PersonPicker({
                   })
                 }
               >
-                <Flex align="center" gap="2" width="100%">
-                  <Icon name="plus" />
-                  <Text truncate>{t('personEditor.picker.createNew', { name: trimmedQuery })}</Text>
-                </Flex>
-              </Button>
+                <Icon name="plus" size={14} />
+                {t('personEditor.picker.createNew', { name: trimmedQuery })}
+              </button>
             )}
-          </Flex>
-        </Flex>
-      </Popover.Content>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
     </Popover.Root>
   );
 }

--- a/src/design/fonts.ts
+++ b/src/design/fonts.ts
@@ -1,0 +1,22 @@
+/**
+ * Self-hosted brand fonts (ADR-0014), pulled from @fontsource. Import this once
+ * where the design tokens are consumed. Family names here must match the
+ * `font.*` token values in `theme.css.ts`.
+ *
+ * - Geist Sans: UI + body.
+ * - Geist Mono: data (dates, IDs).
+ * - Fraunces (italic only): the lineage signature — person names, hero, display
+ *   titles. Upright Fraunces is intentionally not loaded; the serif is only ever
+ *   used italic.
+ */
+import '@fontsource/geist-sans/400.css';
+import '@fontsource/geist-sans/500.css';
+import '@fontsource/geist-sans/600.css';
+import '@fontsource/geist-sans/700.css';
+
+import '@fontsource/geist-mono/400.css';
+import '@fontsource/geist-mono/500.css';
+
+import '@fontsource/fraunces/400-italic.css';
+import '@fontsource/fraunces/500-italic.css';
+import '@fontsource/fraunces/600-italic.css';

--- a/src/design/theme.css.ts
+++ b/src/design/theme.css.ts
@@ -103,7 +103,7 @@ const dark = {
     subtle: 'oklch(0.255 0.025 44)',
     border: 'oklch(1 0 0 / 0.08)',
     borderStrong: 'oklch(1 0 0 / 0.14)',
-    text: 'oklch(0.965 0.018 82)', // sand-100
+    text: 'oklch(0.90 0.022 80)', // sand-200 — softened off-white (pure white reads too harsh on the dark panels)
     muted: 'oklch(0.78 0.042 70)', // sand-400
     faint: 'oklch(0.62 0.035 60)',
     accent: 'oklch(0.62 0.125 34)', // clay-500

--- a/src/design/theme.css.ts
+++ b/src/design/theme.css.ts
@@ -1,0 +1,136 @@
+/**
+ * Vata design tokens — the single source of visual truth (ADR-0014).
+ *
+ * A typed, zero-runtime Vanilla Extract contract. Every styled component reads
+ * `vars.*`; raw color/size values live ONLY here. Warm-earth identity: terracotta
+ * (clay) accent over warm sand neutrals, all in oklch. Geist Sans for UI, Geist
+ * Mono for data, Fraunces (italic) reserved for lineage moments.
+ *
+ * Ported from the maintainer's design system. Lean by intent (ADR-0014): the
+ * contract holds what the product uses today and grows as screens demand it — no
+ * inherited shadcn/Radix semantic sprawl.
+ *
+ * Light is the default on `:root`; dark applies via `:root[data-theme="dark"]`
+ * (set from the resolved app appearance) and, as a fallback, via
+ * `prefers-color-scheme` when no attribute is present.
+ */
+import { assignVars, createGlobalThemeContract, globalStyle } from '@vanilla-extract/css';
+
+export const vars = createGlobalThemeContract(
+  {
+    color: {
+      /** App canvas. */
+      ground: null,
+      /** Raised surfaces: cards, modal, inputs. */
+      panel: null,
+      /** Secondary surface: popovers, nested panels. */
+      panel2: null,
+      /** Subtle fills: segmented track, hover wells. */
+      subtle: null,
+      /** Hairline separators. */
+      border: null,
+      /** Field / control borders. */
+      borderStrong: null,
+      /** Primary text. */
+      text: null,
+      /** Secondary text, labels. */
+      muted: null,
+      /** Tertiary text, placeholders, hints. */
+      faint: null,
+      /** Terracotta accent (primary). */
+      accent: null,
+      accentHover: null,
+      /** Tinted accent fill: avatars, hint bars. */
+      accentSoft: null,
+      accentBorder: null,
+      /** Text/glyphs on an accent fill. */
+      accentText: null,
+      success: null,
+      warn: null,
+      danger: null,
+      /** Modal backdrop. */
+      scrim: null,
+    },
+    radius: { base: null, sm: null },
+    shadow: { sm: null, lg: null },
+    font: { sans: null, serif: null, mono: null },
+  },
+  (_value, path) => `vata-${path.join('-')}`
+);
+
+const font = {
+  sans: '"Geist Sans", ui-sans-serif, system-ui, sans-serif',
+  serif: '"Fraunces", ui-serif, Georgia, serif',
+  mono: '"Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace',
+};
+
+const radius = { base: '0.625rem', sm: '0.4375rem' };
+
+const light = {
+  color: {
+    ground: 'oklch(0.985 0.012 85)', // sand-50
+    panel: 'oklch(1 0 0)',
+    panel2: 'oklch(0.965 0.018 82)', // sand-100
+    subtle: 'oklch(0.945 0.021 82)',
+    border: 'oklch(0.22 0.028 45 / 0.10)',
+    borderStrong: 'oklch(0.22 0.028 45 / 0.16)',
+    text: 'oklch(0.22 0.028 45)', // sand-900
+    muted: 'oklch(0.46 0.055 52)', // sand-700
+    faint: 'oklch(0.60 0.05 58)',
+    accent: 'oklch(0.54 0.13 32)', // clay-600
+    accentHover: 'oklch(0.45 0.115 30)', // clay-700
+    accentSoft: 'oklch(0.93 0.035 42)', // clay-100
+    accentBorder: 'oklch(0.87 0.055 40)', // clay-200
+    accentText: 'oklch(0.985 0.012 85)', // warm white
+    success: 'oklch(0.52 0.13 145)',
+    warn: 'oklch(0.64 0.15 70)',
+    danger: 'oklch(0.555 0.195 27)',
+    scrim: 'oklch(0.22 0.028 45 / 0.55)',
+  },
+  radius,
+  shadow: {
+    sm: '0 1px 3px oklch(0.2 0.02 50 / 0.08), 0 1px 2px oklch(0.2 0.02 50 / 0.06)',
+    lg: '0 12px 28px oklch(0.2 0.02 50 / 0.12), 0 4px 10px oklch(0.2 0.02 50 / 0.08)',
+  },
+  font,
+};
+
+const dark = {
+  color: {
+    ground: 'oklch(0.155 0.02 42)', // sand-950
+    panel: 'oklch(0.195 0.022 44)',
+    panel2: 'oklch(0.235 0.02 44)',
+    subtle: 'oklch(0.255 0.025 44)',
+    border: 'oklch(1 0 0 / 0.08)',
+    borderStrong: 'oklch(1 0 0 / 0.14)',
+    text: 'oklch(0.965 0.018 82)', // sand-100
+    muted: 'oklch(0.78 0.042 70)', // sand-400
+    faint: 'oklch(0.62 0.035 60)',
+    accent: 'oklch(0.62 0.125 34)', // clay-500
+    accentHover: 'oklch(0.70 0.105 36)', // clay-400
+    accentSoft: 'oklch(0.295 0.065 28)',
+    accentBorder: 'oklch(0.36 0.09 28)', // clay-800
+    accentText: 'oklch(0.985 0.012 85)',
+    success: 'oklch(0.64 0.115 145)',
+    warn: 'oklch(0.75 0.15 70)',
+    danger: 'oklch(0.635 0.18 27)',
+    scrim: 'oklch(0.12 0.01 45 / 0.70)',
+  },
+  radius,
+  shadow: {
+    sm: '0 1px 2px oklch(0 0 0 / 0.5)',
+    lg: '0 12px 28px oklch(0 0 0 / 0.55), 0 4px 10px oklch(0 0 0 / 0.4)',
+  },
+  font,
+};
+
+globalStyle(':root', { vars: assignVars(vars, light) });
+
+globalStyle(':root:not([data-theme])', {
+  '@media': {
+    '(prefers-color-scheme: dark)': { vars: assignVars(vars, dark) },
+  },
+});
+
+globalStyle(':root[data-theme="light"]', { vars: assignVars(vars, light) });
+globalStyle(':root[data-theme="dark"]', { vars: assignVars(vars, dark) });

--- a/src/i18n/locales/en/individuals.json
+++ b/src/i18n/locales/en/individuals.json
@@ -159,10 +159,8 @@
     "editButtonAria": "Edit person",
     "sections": {
       "names": "Names",
-      "primaryName": "Primary name",
       "otherNames": "Other names",
       "lifeEvents": "Life events",
-      "lifeEventsHint": "Dates only — places will be added once a place picker exists.",
       "relations": "Relations",
       "notes": "Notes"
     },
@@ -185,9 +183,8 @@
       "removeAria": "Remove this name"
     },
     "lifeEvents": {
-      "datePlaceholder": "e.g. 30 Jan 1960, abt 1960",
-      "dateHint": "Accepts approximate dates — “abt 1960”, “bef 1962”",
-      "placeSoon": "Place — soon",
+      "datePlaceholder": "Date",
+      "place": "Place",
       "addButton": "Add event",
       "removeAria": "Remove this event"
     },
@@ -198,9 +195,11 @@
       "addMother": "Add mother",
       "spouse": "Spouse",
       "children": "Children",
+      "familyLabel": "Family",
       "addSpouse": "Add spouse",
       "addChild": "Add child",
       "addFamily": "Add another family",
+      "removeFamilyAria": "Remove this family",
       "removeAria": "Remove this relation"
     },
     "picker": {

--- a/src/i18n/locales/en/individuals.json
+++ b/src/i18n/locales/en/individuals.json
@@ -159,6 +159,7 @@
     "editButtonAria": "Edit person",
     "sections": {
       "names": "Names",
+      "primaryName": "Primary name",
       "otherNames": "Other names",
       "lifeEvents": "Life events",
       "lifeEventsHint": "Dates only — places will be added once a place picker exists.",
@@ -191,6 +192,8 @@
       "removeAria": "Remove this event"
     },
     "relations": {
+      "fatherLabel": "Father",
+      "motherLabel": "Mother",
       "addFather": "Add father",
       "addMother": "Add mother",
       "spouse": "Spouse",
@@ -210,6 +213,7 @@
       "label": "Notes"
     },
     "actions": {
+      "close": "Close",
       "cancel": "Cancel",
       "save": "Save",
       "saveNew": "Save person"
@@ -219,7 +223,8 @@
       "title": "Discard unsaved changes?",
       "description": "You have unsaved changes. If you close now, they will be lost.",
       "discard": "Discard changes",
-      "keepEditing": "Keep editing"
+      "keepEditing": "Keep editing",
+      "indicator": "Unsaved changes"
     }
   }
 }

--- a/src/i18n/locales/en/individuals.json
+++ b/src/i18n/locales/en/individuals.json
@@ -224,6 +224,13 @@
       "discard": "Discard changes",
       "keepEditing": "Keep editing",
       "indicator": "Unsaved changes"
+    },
+    "removeFamilyConfirm": {
+      "title": "Remove this family?",
+      "description_one": "This family has {{count}} child. Removing the family will unlink them; the person stays in your tree.",
+      "description_other": "This family has {{count}} children. Removing the family will unlink them; the people stay in your tree.",
+      "confirm": "Remove family",
+      "keepFamily": "Keep family"
     }
   }
 }

--- a/src/i18n/locales/fr/individuals.json
+++ b/src/i18n/locales/fr/individuals.json
@@ -159,6 +159,7 @@
     "editButtonAria": "Modifier la personne",
     "sections": {
       "names": "Noms",
+      "primaryName": "Nom principal",
       "otherNames": "Autres noms",
       "lifeEvents": "Événements de vie",
       "lifeEventsHint": "Dates seulement — les lieux seront ajoutés une fois le sélecteur de lieu disponible.",
@@ -191,6 +192,8 @@
       "removeAria": "Retirer cet événement"
     },
     "relations": {
+      "fatherLabel": "Père",
+      "motherLabel": "Mère",
       "addFather": "Ajouter le père",
       "addMother": "Ajouter la mère",
       "spouse": "Conjoint",
@@ -210,6 +213,7 @@
       "label": "Notes"
     },
     "actions": {
+      "close": "Fermer",
       "cancel": "Annuler",
       "save": "Enregistrer",
       "saveNew": "Enregistrer la personne"
@@ -219,7 +223,8 @@
       "title": "Abandonner les modifications non enregistrées?",
       "description": "Des modifications n'ont pas été enregistrées. Si vous fermez maintenant, elles seront perdues.",
       "discard": "Abandonner les modifications",
-      "keepEditing": "Continuer l'édition"
+      "keepEditing": "Continuer l'édition",
+      "indicator": "Modifications non enregistrées"
     }
   }
 }

--- a/src/i18n/locales/fr/individuals.json
+++ b/src/i18n/locales/fr/individuals.json
@@ -224,6 +224,13 @@
       "discard": "Abandonner les modifications",
       "keepEditing": "Continuer l'édition",
       "indicator": "Modifications non enregistrées"
+    },
+    "removeFamilyConfirm": {
+      "title": "Retirer cette famille?",
+      "description_one": "Cette famille compte {{count}} enfant. Retirer la famille le dissociera; la personne demeure dans votre arbre.",
+      "description_other": "Cette famille compte {{count}} enfants. Retirer la famille les dissociera; les personnes demeurent dans votre arbre.",
+      "confirm": "Retirer la famille",
+      "keepFamily": "Conserver la famille"
     }
   }
 }

--- a/src/i18n/locales/fr/individuals.json
+++ b/src/i18n/locales/fr/individuals.json
@@ -159,10 +159,8 @@
     "editButtonAria": "Modifier la personne",
     "sections": {
       "names": "Noms",
-      "primaryName": "Nom principal",
       "otherNames": "Autres noms",
       "lifeEvents": "Événements de vie",
-      "lifeEventsHint": "Dates seulement — les lieux seront ajoutés une fois le sélecteur de lieu disponible.",
       "relations": "Relations",
       "notes": "Notes"
     },
@@ -185,9 +183,8 @@
       "removeAria": "Retirer ce nom"
     },
     "lifeEvents": {
-      "datePlaceholder": "ex. 30 janv. 1960, vers 1960",
-      "dateHint": "Accepte les dates approximatives — « vers 1960 », « avant 1962 »",
-      "placeSoon": "Lieu — bientôt",
+      "datePlaceholder": "Date",
+      "place": "Lieu",
       "addButton": "Ajouter un événement",
       "removeAria": "Retirer cet événement"
     },
@@ -198,9 +195,11 @@
       "addMother": "Ajouter la mère",
       "spouse": "Conjoint",
       "children": "Enfants",
+      "familyLabel": "Famille",
       "addSpouse": "Ajouter un conjoint",
       "addChild": "Ajouter un enfant",
       "addFamily": "Ajouter une autre famille",
+      "removeFamilyAria": "Retirer cette famille",
       "removeAria": "Retirer cette relation"
     },
     "picker": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,6 @@
 import './styles/app.css';
+import '$/design/theme.css';
+import '$/design/fonts';
 import './i18n/config';
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/src/managers/FamilyManager.test.ts
+++ b/src/managers/FamilyManager.test.ts
@@ -340,4 +340,35 @@ describe('FamilyManager.saveRelations', () => {
     const newChildId = childIds.find((id) => id !== keptChildId);
     expect((await getPrimaryName(newChildId ?? ''))?.givenNames).toBe('New');
   });
+
+  it('deletes spouse families dropped from the list while keeping listed and new ones', async () => {
+    const personId = await createNamedIndividual('Person', 'Doe', 'M');
+    const keptSpouseId = await createNamedIndividual('Kept', 'Doe', 'F');
+    const removedSpouseId = await createNamedIndividual('Removed', 'Doe', 'F');
+    const newSpouseId = await createNamedIndividual('New', 'Doe', 'F');
+
+    const keptFamilyId = await createFamily({});
+    await addFamilyMember({ familyId: keptFamilyId, individualId: personId, role: 'husband' });
+    await addFamilyMember({ familyId: keptFamilyId, individualId: keptSpouseId, role: 'wife' });
+    const removedFamilyId = await createFamily({});
+    await addFamilyMember({ familyId: removedFamilyId, individualId: personId, role: 'husband' });
+    await addFamilyMember({
+      familyId: removedFamilyId,
+      individualId: removedSpouseId,
+      role: 'wife',
+    });
+
+    // The editor lists the kept family and one newly added family; the second
+    // pre-existing family is absent because the user removed it.
+    await FamilyManager.saveRelations(personId, 'M', {
+      families: [
+        { id: keptFamilyId, spouse: { id: keptSpouseId }, children: [] },
+        { spouse: { id: newSpouseId }, children: [] },
+      ],
+    });
+
+    const families = await FamilyManager.getSpouseFamiliesWithMembers(personId);
+    expect(families.map((f) => f.wife?.id).sort()).toEqual([keptSpouseId, newSpouseId].sort());
+    expect(await FamilyManager.getById(removedFamilyId)).toBeNull();
+  });
 });

--- a/src/managers/FamilyManager.ts
+++ b/src/managers/FamilyManager.ts
@@ -377,8 +377,21 @@ export class FamilyManager {
     const individualRole: FamilyRole = individualGender === 'F' ? 'wife' : 'husband';
     const spouseRole: FamilyRole = individualRole === 'husband' ? 'wife' : 'husband';
 
+    // Snapshot pre-existing spouse families before the loop can create new ones,
+    // so removal reconciliation only targets unions the caller dropped.
+    const priorSpouseFamilyIds = (await getSpouseFamilies(individualId)).map((family) => family.id);
+    const keptFamilyIds = new Set(
+      input.families.map((family) => family.id).filter((id): id is string => id !== undefined)
+    );
+
     for (const familyInput of input.families) {
       await saveSpouseFamily(individualId, individualRole, spouseRole, familyInput);
+    }
+
+    // A pre-existing spouse family no longer listed was removed in the editor:
+    // delete the union (cascades to its member links; the individuals remain).
+    for (const familyId of priorSpouseFamilyIds) {
+      if (!keptFamilyIds.has(familyId)) await deleteFamily(familyId);
     }
   }
 }

--- a/src/managers/IndividualManager.test.ts
+++ b/src/managers/IndividualManager.test.ts
@@ -364,6 +364,24 @@ describe('IndividualManager.update', () => {
     expect(names.some((n) => n.type === 'married' && n.surname === 'Potter')).toBe(true);
   });
 
+  it('keeps an alternate name when only givenNames is cleared but surname remains', async () => {
+    const id = await IndividualManager.create({
+      gender: 'F',
+      name: { givenNames: 'Lily', surname: 'Potter' },
+      alternateNames: [{ type: 'birth', givenNames: 'Lily', surname: 'Evans' }],
+    });
+    const [alternate] = (await getNamesByIndividualId(id)).filter((n) => !n.isPrimary);
+
+    await IndividualManager.update(id, {
+      alternateNames: [{ id: alternate.id, type: 'birth', givenNames: '', surname: 'Evans' }],
+    });
+
+    const names = (await getNamesByIndividualId(id)).filter((n) => !n.isPrimary);
+    expect(names).toHaveLength(1);
+    expect(names[0]).toMatchObject({ type: 'birth', surname: 'Evans' });
+    expect(names[0].givenNames ?? '').toBe('');
+  });
+
   it('removes an alternate name whose id is kept but whose given and surname are cleared', async () => {
     const id = await IndividualManager.create({
       gender: 'F',

--- a/src/managers/IndividualManager.test.ts
+++ b/src/managers/IndividualManager.test.ts
@@ -257,6 +257,22 @@ describe('IndividualManager.create', () => {
     expect(alternate).toMatchObject({ type: 'birth', givenNames: 'Lily', surname: 'Evans' });
   });
 
+  it('skips alternate name rows where both given and surname are blank', async () => {
+    const id = await IndividualManager.create({
+      gender: 'F',
+      name: { givenNames: 'Lily', surname: 'Potter' },
+      alternateNames: [
+        { type: 'birth', givenNames: 'Lily', surname: 'Evans' },
+        { type: 'aka', givenNames: '', surname: '' },
+      ],
+    });
+
+    const names = await getNamesByIndividualId(id);
+    expect(names).toHaveLength(2);
+    const alternate = names.find((n) => !n.isPrimary);
+    expect(alternate).toMatchObject({ type: 'birth', givenNames: 'Lily', surname: 'Evans' });
+  });
+
   it('creates life events of arbitrary types with a date', async () => {
     const id = await IndividualManager.create({
       gender: 'F',
@@ -346,6 +362,22 @@ describe('IndividualManager.update', () => {
     expect(names.find((n) => n.id === toKeep.id)?.surname).toBe('Evans-updated');
     expect(names.some((n) => n.id === toRemove.id)).toBe(false);
     expect(names.some((n) => n.type === 'married' && n.surname === 'Potter')).toBe(true);
+  });
+
+  it('removes an alternate name whose id is kept but whose given and surname are cleared', async () => {
+    const id = await IndividualManager.create({
+      gender: 'F',
+      name: { givenNames: 'Lily', surname: 'Potter' },
+      alternateNames: [{ type: 'birth', givenNames: 'Lily', surname: 'Evans' }],
+    });
+    const [alternate] = (await getNamesByIndividualId(id)).filter((n) => !n.isPrimary);
+
+    await IndividualManager.update(id, {
+      alternateNames: [{ id: alternate.id, type: 'birth', givenNames: '', surname: '' }],
+    });
+
+    const names = await getNamesByIndividualId(id);
+    expect(names.filter((n) => !n.isPrimary)).toHaveLength(0);
   });
 
   it('adds, updates and removes life events in one call, leaving secondary participations untouched', async () => {

--- a/src/managers/IndividualManager.ts
+++ b/src/managers/IndividualManager.ts
@@ -83,13 +83,18 @@ function filterPrincipalEvents(
   );
 }
 
-/** Create or update the alternate names in `input` against `existing`, deleting any existing row not represented. */
+/** A row with neither given names nor surname is treated as absent: never created, never kept, never updated. This is how an alternate name is removed from the editor — clearing both fields. */
+function hasNameContent(name: AlternateNameInput): boolean {
+  return Boolean(name.givenNames?.trim() || name.surname?.trim());
+}
+
+/** Create or update the alternate names in `input` against `existing`, deleting any existing row not represented. Rows with neither given names nor surname are skipped entirely (never created, never used to keep an existing row alive). */
 async function saveAlternateNames(
   individualId: string,
   input: AlternateNameInput[],
   existing: Name[]
 ): Promise<void> {
-  const keptIds = new Set(input.filter((n) => n.id).map((n) => n.id));
+  const keptIds = new Set(input.filter((n) => n.id && hasNameContent(n)).map((n) => n.id));
   for (const name of existing) {
     if (!keptIds.has(name.id)) {
       await deleteName(name.id);
@@ -97,6 +102,7 @@ async function saveAlternateNames(
   }
 
   for (const name of input) {
+    if (!hasNameContent(name)) continue;
     const { type, prefix, givenNames, surname, suffix, nickname } = name;
     if (name.id) {
       await updateName(name.id, { type, prefix, givenNames, surname, suffix, nickname });

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,5 +1,18 @@
 @import '@radix-ui/themes/styles.css';
 
+/*
+ * Global box-sizing reset. Radix Themes scopes its own reset to `.radix-themes`,
+ * so Base UI surfaces portaled outside that scope (dialogs, popovers) fall back
+ * to the `content-box` default — their padded inputs then render wider than
+ * their grid tracks and overflow into neighbouring cells. A global reset keeps
+ * every surface on border-box, matching the Person editor prototype (ADR-0014).
+ */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 html,
 body,
 #root {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -19,6 +20,7 @@ export default defineConfig({
       routesDirectory: 'src/routes',
       generatedRouteTree: 'src/routeTree.gen.ts',
     }),
+    vanillaExtractPlugin(),
     react(),
   ],
   resolve: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -27,7 +28,7 @@ export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
-  plugins: [react()],
+  plugins: [vanillaExtractPlugin(), react()],
   resolve: { alias: aliases },
   test: {
     name: 'unit',


### PR DESCRIPTION
## Summary

First screen migrated off Radix Themes to the headless **Base UI + Vanilla Extract** stack (ADR-0014), rebuilding the **Person editor** (create/edit) on a typed, zero-runtime token contract with the warm-earth brand. Radix Themes and Base UI coexist; screens migrate one at a time, this being the first.

Two commits:
1. **Rebuild** the Person editor on Base UI (Dialog/Select/Switch/Popover) + Vanilla Extract over `src/design/theme.css.ts`. Form state, query hooks, mutations, and i18n preserved; only the render layer changed.
2. **Refinements** from design review (below).

## Refinements

- **Foundation fix:** global `box-sizing: border-box` reset — Base UI surfaces portal outside Radix's scoped reset and were overflowing their grid tracks.
- **Life events:** Birth and Death always shown; the Deceased switch is grouped with the Death row it gates; a (disabled) place field per event; event fields fill the row with a compact date column.
- **Relations:** remove a family; clearer separation between Parents and the first family; quieter family card (border only).
- **Contrast & consistency:** labels use `text`, section titles use `muted`, the dark `text` token softened off pure white, neutral header avatar.
- **Chrome:** breadcrumb header (`Add/Edit person / Name`), footer ordered primary → secondary → status, `"Date"` placeholder, theme-fitting scrollbar, wider modal.

## Testing

- `vitest` — 9/9 Person editor tests green (updated for the new behavior).
- Typecheck + lint clean.
- Verified live in the running app (light + dark) via the MCP bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vata-apps/vata-app/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

